### PR TITLE
other: package metadata (license, metadata-version)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ authors = [
 ]
 requires-python = ">=3.9,<3.13"
 readme = "README.md"
-license = {text = "Apache"}
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 dynamic = ["version"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
@@ -76,7 +77,6 @@ version-file = "src/optimum/rbln/__version__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/optimum"]
-core-metadata-version = "2.3"
 
 [tool.uv]
 environments = [


### PR DESCRIPTION
# Pull Request Description

This PR fixes `license` metadata to comply with [PEP639](https://peps.python.org/pep-0639/), which guides to use valid SPDX License expression syntax. See https://spdx.org/licenses/ for the list of available licenses.
It also suggests using `license-files` to include license-related files, so build tools can validate these files appropriately.

In addition, the temporary workaround of pinning `core-metadata-version` seems not necessary anymore (verified by uploading to testpypi using twine 6.1.0), hence removed it.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] New Model Support
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Other (please describe): metadata, packaging


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (If needed)

## Additional Information
<!-- Any additional information, configuration, or data that might be necessary to reproduce the issue or use the new feature -->
Need to consider changing classifier `"Development Status :: 2 - Pre-Alpha"` to more appropriate one at the current status.

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->
