### PR TITLE
other: repr of the compiled model

### DIFF
--- a/src/optimum/rbln/modeling_base.py
+++ b/src/optimum/rbln/modeling_base.py
@@ -416,7 +416,20 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
         return self.forward(*args, **kwargs)
 
     def __repr__(self):
-        return repr(self.model) + repr(self.rbln_submodules)
+        has_submodule = len(self.rbln_submodules) > 0
+        repr_str: str = f"<{self.__class__.__name__}>\n"
+        repr_str += f"- Total {len(self.model)} Runtimes"
+        repr_str += f" and {len(self.rbln_submodules)} Submodules\n" if has_submodule else "\n"
+        repr_str += "[Runtimes]\n"
+        repr_str += "\n".join([repr(model) for model in self.model])
+        repr_str += "\n"
+
+        if has_submodule > 0:
+            for i, submodule in enumerate(self.rbln_submodules):
+                repr_str += f"[Submodules {i} : {self._rbln_submodules[i]['name']}]\n"
+                repr_str += repr(submodule) + "\n"
+
+        return repr_str
 
     def __post_init__(self, **kwargs):
         pass

--- a/src/optimum/rbln/modeling_base.py
+++ b/src/optimum/rbln/modeling_base.py
@@ -416,15 +416,15 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
         return self.forward(*args, **kwargs)
 
     def __repr__(self):
-        has_submodule = len(self.rbln_submodules) > 0
+        has_submodules = len(self.rbln_submodules) > 0
         repr_str: str = f"<{self.__class__.__name__}>\n"
         repr_str += f"- Total {len(self.model)} Runtimes"
-        repr_str += f" and {len(self.rbln_submodules)} Submodules\n" if has_submodule else "\n"
+        repr_str += f" and {len(self.rbln_submodules)} Submodules\n" if has_submodules else "\n"
         repr_str += "[Runtimes]\n"
         repr_str += "\n".join([repr(model) for model in self.model])
         repr_str += "\n"
 
-        if has_submodule > 0:
+        if has_submodules > 0:
             for i, submodule in enumerate(self.rbln_submodules):
                 repr_str += f"[Submodules {i} : {self._rbln_submodules[i]['name']}]\n"
                 repr_str += repr(submodule) + "\n"


### PR DESCRIPTION
# Pull Request Description

기존엔 list of runtimes와 submodule의 repr를 그대로 보여주고 있었어서..
특히 submodule이 없는 경우에도 empty list 의 repr이 같이 보여지고 있었습니다
한번 바꿔봤는데 다른 의견 있으시면 제안주세요

예) resnet

<기존>
```
[+------------------------------------------------------------+
|                 Compiled Model Description                 |
+----------+--------------+------------------+---------------+
| I/O Type | Key          | Shape            | Dtype         |
+----------+--------------+------------------+---------------+
| Input    | pixel_values | (1, 3, 224, 224) | torch.float32 |
+----------+--------------+------------------+---------------+
| Output   | 0            | (1, 1000)        | torch.float32 |
+----------+--------------+------------------+---------------+
+------------------+-----------------------------------------+
| Compiler version |          0.7.2.dev222+gef5d94a6         |
+------------------+-----------------------------------------+
|       NPU        |                RBLN-CA02                |
+------------------+-----------------------------------------+
|      Memory      |                 66.0MiB                 |
+------------------+-----------------------------------------+][]
```

<변경후>
```
<RBLNResNetForImageClassification>
- Total 1 Runtimes
[Runtimes]
+------------------------------------------------------------+
|                 Compiled Model Description                 |
+----------+--------------+------------------+---------------+
| I/O Type | Key          | Shape            | Dtype         |
+----------+--------------+------------------+---------------+
| Input    | pixel_values | (1, 3, 224, 224) | torch.float32 |
+----------+--------------+------------------+---------------+
| Output   | 0            | (1, 1000)        | torch.float32 |
+----------+--------------+------------------+---------------+
+------------------+-----------------------------------------+
| Compiler version |          0.7.2.dev222+gef5d94a6         |
+------------------+-----------------------------------------+
|       NPU        |                RBLN-CA02                |
+------------------+-----------------------------------------+
|      Memory      |                 66.0MiB                 |
+------------------+-----------------------------------------+

```




예2) LlavaNext
<기존>
```
[+------------------------------------------------------------+
|                 Compiled Model Description                 |
+----------+----------------+----------------+---------------+
| I/O Type | Key            | Shape          | Dtype         |
+----------+----------------+----------------+---------------+
| Input    | image_features | (1, 576, 1024) | torch.float32 |
+----------+----------------+----------------+---------------+
| Output   | 0              | (1, 576, 4096) | torch.float32 |
+----------+----------------+----------------+---------------+
+------------------+-----------------------------------------+
| Compiler version |          0.7.2.dev222+gef5d94a6         |
+------------------+-----------------------------------------+
|       NPU        |                RBLN-CA02                |
+------------------+-----------------------------------------+
|      Memory      |                 62.0MiB                 |
+------------------+-----------------------------------------+][[+------------------------------------------------------------+
|                 Compiled Model Description                 |
+----------+--------------+------------------+---------------+
| I/O Type | Key          | Shape            | Dtype         |
+----------+--------------+------------------+---------------+
| Input    | pixel_values | (1, 3, 336, 336) | torch.float32 |
+----------+--------------+------------------+---------------+
| Output   | 0            | (1, 577, 1024)   | torch.float32 |
| Output   | 1            | (1, 1024)        | torch.float32 |
| Output   | 2            | (1, 577, 1024)   | torch.float32 |
| Output   | 3            | (1, 577, 1024)   | torch.float32 |
| Output   | 4            | (1, 577, 1024)   | torch.float32 |
| Output   | 5            | (1, 577, 1024)   | torch.float32 |
| Output   | 6            | (1, 577, 1024)   | torch.float32 |
| Output   | 7            | (1, 577, 1024)   | torch.float32 |
| Output   | 8            | (1, 577, 1024)   | torch.float32 |
| Output   | 9            | (1, 577, 1024)   | torch.float32 |
| Output   | 10           | (1, 577, 1024)   | torch.float32 |
| Output   | 11           | (1, 577, 1024)   | torch.float32 |
| Output   | 12           | (1, 577, 1024)   | torch.float32 |
| Output   | 13           | (1, 577, 1024)   | torch.float32 |
| Output   | 14           | (1, 577, 1024)   | torch.float32 |
| Output   | 15           | (1, 577, 1024)   | torch.float32 |
| Output   | 16           | (1, 577, 1024)   | torch.float32 |
| Output   | 17           | (1, 577, 1024)   | torch.float32 |
| Output   | 18           | (1, 577, 1024)   | torch.float32 |
| Output   | 19           | (1, 577, 1024)   | torch.float32 |
| Output   | 20           | (1, 577, 1024)   | torch.float32 |
| Output   | 21           | (1, 577, 1024)   | torch.float32 |
| Output   | 22           | (1, 577, 1024)   | torch.float32 |
| Output   | 23           | (1, 577, 1024)   | torch.float32 |
| Output   | 24           | (1, 577, 1024)   | torch.float32 |
| Output   | 25           | (1, 577, 1024)   | torch.float32 |
| Output   | 26           | (1, 577, 1024)   | torch.float32 |
+----------+--------------+------------------+---------------+
+------------------+-----------------------------------------+
| Compiler version |          0.7.2.dev222+gef5d94a6         |
+------------------+-----------------------------------------+
|       NPU        |                RBLN-CA02                |
+------------------+-----------------------------------------+
|      Memory      |                 670.0MiB                |
+------------------+-----------------------------------------+][], [+----------------------------------------------------------------+
|                   Compiled Model Description                   |
+----------+----------------+--------------------+---------------+
| I/O Type | Key            | Shape              | Dtype         |
+----------+----------------+--------------------+---------------+
| Input    | inputs_embeds  | (1, 128, 4096)     | torch.float32 |
| Input    | attention_mask | (1, 1, 128, 32768) | torch.float32 |
| Input    | cache_position | (1, 128)           | torch.int32   |
| Input    | batch_position | ()                 | torch.int16   |
| Input    | query_position | ()                 | torch.int16   |
+----------+----------------+--------------------+---------------+
| Output   | 0              | (1, 1, 32064)      | torch.float32 |
+----------+----------------+--------------------+---------------+
+------------------+---------------------------------------------+
| Compiler version |            0.7.2.dev222+gef5d94a6           |
+------------------+---------------------------------------------+
|       NPU        |                  RBLN-CA02                  |
+------------------+---------------------------------------------+
| Memory[device=0] |                    5.4GiB                   |
| Memory[device=1] |                    5.4GiB                   |
| Memory[device=2] |                    5.4GiB                   |
| Memory[device=3] |                    5.4GiB                   |
+------------------+---------------------------------------------+, +--------------------------------------------------------------+
|                  Compiled Model Description                  |
+----------+----------------+------------------+---------------+
| I/O Type | Key            | Shape            | Dtype         |
+----------+----------------+------------------+---------------+
| Input    | inputs_embeds  | (2, 1, 4096)     | torch.float32 |
| Input    | attention_mask | (2, 1, 1, 32768) | torch.float32 |
| Input    | cache_position | (2, 1)           | torch.int32   |
+----------+----------------+------------------+---------------+
| Output   | 0              | (2, 1, 32064)    | torch.float32 |
+----------+----------------+------------------+---------------+
+------------------+-------------------------------------------+
| Compiler version |           0.7.2.dev222+gef5d94a6          |
+------------------+-------------------------------------------+
|       NPU        |                 RBLN-CA02                 |
+------------------+-------------------------------------------+
| Memory[device=0] |                  24.0MiB                  |
| Memory[device=1] |                  20.0MiB                  |
| Memory[device=2] |                  20.0MiB                  |
| Memory[device=3] |                  20.0MiB                  |
+------------------+-------------------------------------------+][]]
```


<변경후>
```
<RBLNLlavaNextForConditionalGeneration>
- Total 1 Runtimes and 2 Submodules
[Runtimes]
+------------------------------------------------------------+
|                 Compiled Model Description                 |
+----------+----------------+----------------+---------------+
| I/O Type | Key            | Shape          | Dtype         |
+----------+----------------+----------------+---------------+
| Input    | image_features | (1, 576, 1024) | torch.float32 |
+----------+----------------+----------------+---------------+
| Output   | 0              | (1, 576, 4096) | torch.float32 |
+----------+----------------+----------------+---------------+
+------------------+-----------------------------------------+
| Compiler version |          0.7.2.dev222+gef5d94a6         |
+------------------+-----------------------------------------+
|       NPU        |                RBLN-CA02                |
+------------------+-----------------------------------------+
|      Memory      |                 62.0MiB                 |
+------------------+-----------------------------------------+
[Submodules 0 : vision_tower]
<RBLNCLIPVisionModel>
- Total 1 Runtimes
[Runtimes]
+------------------------------------------------------------+
|                 Compiled Model Description                 |
+----------+--------------+------------------+---------------+
| I/O Type | Key          | Shape            | Dtype         |
+----------+--------------+------------------+---------------+
| Input    | pixel_values | (1, 3, 336, 336) | torch.float32 |
+----------+--------------+------------------+---------------+
| Output   | 0            | (1, 577, 1024)   | torch.float32 |
| Output   | 1            | (1, 1024)        | torch.float32 |
| Output   | 2            | (1, 577, 1024)   | torch.float32 |
| Output   | 3            | (1, 577, 1024)   | torch.float32 |
| Output   | 4            | (1, 577, 1024)   | torch.float32 |
| Output   | 5            | (1, 577, 1024)   | torch.float32 |
| Output   | 6            | (1, 577, 1024)   | torch.float32 |
| Output   | 7            | (1, 577, 1024)   | torch.float32 |
| Output   | 8            | (1, 577, 1024)   | torch.float32 |
| Output   | 9            | (1, 577, 1024)   | torch.float32 |
| Output   | 10           | (1, 577, 1024)   | torch.float32 |
| Output   | 11           | (1, 577, 1024)   | torch.float32 |
| Output   | 12           | (1, 577, 1024)   | torch.float32 |
| Output   | 13           | (1, 577, 1024)   | torch.float32 |
| Output   | 14           | (1, 577, 1024)   | torch.float32 |
| Output   | 15           | (1, 577, 1024)   | torch.float32 |
| Output   | 16           | (1, 577, 1024)   | torch.float32 |
| Output   | 17           | (1, 577, 1024)   | torch.float32 |
| Output   | 18           | (1, 577, 1024)   | torch.float32 |
| Output   | 19           | (1, 577, 1024)   | torch.float32 |
| Output   | 20           | (1, 577, 1024)   | torch.float32 |
| Output   | 21           | (1, 577, 1024)   | torch.float32 |
| Output   | 22           | (1, 577, 1024)   | torch.float32 |
| Output   | 23           | (1, 577, 1024)   | torch.float32 |
| Output   | 24           | (1, 577, 1024)   | torch.float32 |
| Output   | 25           | (1, 577, 1024)   | torch.float32 |
| Output   | 26           | (1, 577, 1024)   | torch.float32 |
+----------+--------------+------------------+---------------+
+------------------+-----------------------------------------+
| Compiler version |          0.7.2.dev222+gef5d94a6         |
+------------------+-----------------------------------------+
|       NPU        |                RBLN-CA02                |
+------------------+-----------------------------------------+
|      Memory      |                 670.0MiB                |
+------------------+-----------------------------------------+

[Submodules 1 : language_model]
<RBLNMistralForCausalLM>
- Total 2 Runtimes
[Runtimes]
+----------------------------------------------------------------+
|                   Compiled Model Description                   |
+----------+----------------+--------------------+---------------+
| I/O Type | Key            | Shape              | Dtype         |
+----------+----------------+--------------------+---------------+
| Input    | inputs_embeds  | (1, 128, 4096)     | torch.float32 |
| Input    | attention_mask | (1, 1, 128, 32768) | torch.float32 |
| Input    | cache_position | (1, 128)           | torch.int32   |
| Input    | batch_position | ()                 | torch.int16   |
| Input    | query_position | ()                 | torch.int16   |
+----------+----------------+--------------------+---------------+
| Output   | 0              | (1, 1, 32064)      | torch.float32 |
+----------+----------------+--------------------+---------------+
+------------------+---------------------------------------------+
| Compiler version |            0.7.2.dev222+gef5d94a6           |
+------------------+---------------------------------------------+
|       NPU        |                  RBLN-CA02                  |
+------------------+---------------------------------------------+
| Memory[device=0] |                    5.4GiB                   |
| Memory[device=1] |                    5.4GiB                   |
| Memory[device=2] |                    5.4GiB                   |
| Memory[device=3] |                    5.4GiB                   |
+------------------+---------------------------------------------+
+--------------------------------------------------------------+
|                  Compiled Model Description                  |
+----------+----------------+------------------+---------------+
| I/O Type | Key            | Shape            | Dtype         |
+----------+----------------+------------------+---------------+
| Input    | inputs_embeds  | (2, 1, 4096)     | torch.float32 |
| Input    | attention_mask | (2, 1, 1, 32768) | torch.float32 |
| Input    | cache_position | (2, 1)           | torch.int32   |
+----------+----------------+------------------+---------------+
| Output   | 0              | (2, 1, 32064)    | torch.float32 |
+----------+----------------+------------------+---------------+
+------------------+-------------------------------------------+
| Compiler version |           0.7.2.dev222+gef5d94a6          |
+------------------+-------------------------------------------+
|       NPU        |                 RBLN-CA02                 |
+------------------+-------------------------------------------+
| Memory[device=0] |                  24.0MiB                  |
| Memory[device=1] |                  20.0MiB                  |
| Memory[device=2] |                  20.0MiB                  |
| Memory[device=3] |                  20.0MiB                  |
+------------------+-------------------------------------------+

```




## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] New Model Support
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (If needed)

## Additional Information
<!-- Any additional information, configuration, or data that might be necessary to reproduce the issue or use the new feature -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only     
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update