### PR TITLE
other: Check batch consistency

### DIFF
--- a/src/optimum/rbln/diffusers/modeling_diffusers.py
+++ b/src/optimum/rbln/diffusers/modeling_diffusers.py
@@ -428,6 +428,26 @@ class RBLNDiffusionMixin:
             compiled_image_size = None
         return compiled_image_size
 
+    def validate_model_runtime_consistency(self, *args, **kwargs):
+        if self.vae.compiled_batch_size == self.unet.compiled_batch_size:
+            do_classifier_free_guidance = False
+        elif self.vae.compiled_batch_size * 2 == self.unet.compiled_batch_size:
+            do_classifier_free_guidance = True
+        else:
+            raise ValueError(
+                "Inconsistent batch sizes between `unet` and `vae`. "
+                f"`unet` batch size: {self.unet.compiled_batch_size}, "
+                f"`vae` batch size: {self.vae.compiled_batch_size}. "
+                "The batch size of `unet` must be either equal to or twice the batch size of `vae`."
+            )
+        guidance_scale = kwargs.get("guidance_scale", 5.0)
+        if not ((guidance_scale <= 1.0) ^ do_classifier_free_guidance):
+            raise ValueError(
+                f"`guidance_scale` ({guidance_scale}) is incompetible with the compiled batch sizes of `unet` and `vae`. "
+                f"Those models are compiled assuming that classifier-free guidance is {'enabled' if do_classifier_free_guidance else 'disabled'}. "
+                "Please ensure `guidance_scale` is > 1.0 when classifier-free guidance is enabled, and <= 1.0 otherwise."
+            )
+
     def handle_additional_kwargs(self, **kwargs):
         """
         Function to handle additional compile-time parameters during inference.

--- a/src/optimum/rbln/diffusers/models/autoencoders/autoencoder_kl.py
+++ b/src/optimum/rbln/diffusers/models/autoencoders/autoencoder_kl.py
@@ -194,6 +194,10 @@ class RBLNAutoencoderKL(RBLNModel):
         )
         return rbln_config
 
+    @property
+    def compiled_batch_size(self):
+        return self.rbln_config.compile_cfgs[0].input_info[0][1][0]
+
     @classmethod
     def _create_runtimes(
         cls,

--- a/src/optimum/rbln/diffusers/models/autoencoders/vq_model.py
+++ b/src/optimum/rbln/diffusers/models/autoencoders/vq_model.py
@@ -137,6 +137,10 @@ class RBLNVQModel(RBLNModel):
         )
         return rbln_config
 
+    @property
+    def compiled_batch_size(self):
+        return self.rbln_config.compile_cfgs[0].input_info[0][1][0]
+
     @classmethod
     def _create_runtimes(
         cls,

--- a/src/optimum/rbln/diffusers/models/transformers/prior_transformer.py
+++ b/src/optimum/rbln/diffusers/models/transformers/prior_transformer.py
@@ -151,6 +151,10 @@ class RBLNPriorTransformer(RBLNModel):
         )
         return rbln_config
 
+    @property
+    def compiled_batch_size(self):
+        return self.rbln_config.compile_cfgs[0].input_info[0][1][0]
+
     def forward(
         self,
         hidden_states,

--- a/src/optimum/rbln/diffusers/pipelines/kandinsky2_2/pipeline_kandinsky2_2.py
+++ b/src/optimum/rbln/diffusers/pipelines/kandinsky2_2/pipeline_kandinsky2_2.py
@@ -23,3 +23,23 @@ class RBLNKandinskyV22Pipeline(RBLNDiffusionMixin, KandinskyV22Pipeline):
 
     def get_compiled_image_size(self):
         return self.movq.image_size
+
+    def validate_model_runtime_consistency(self, *args, **kwargs):
+        if self.movq.compiled_batch_size == self.unet.compiled_batch_size:
+            do_classifier_free_guidance = False
+        elif self.movq.compiled_batch_size * 2 == self.unet.compiled_batch_size:
+            do_classifier_free_guidance = True
+        else:
+            raise ValueError(
+                "Inconsistent batch sizes between `unet` and `movq`. "
+                f"`unet` batch size: {self.unet.compiled_batch_size}, "
+                f"`movq` batch size: {self.movq.compiled_batch_size}. "
+                "The batch size of `unet` must be either equal to or twice the batch size of `movq`."
+            )
+        guidance_scale = kwargs.get("guidance_scale", 5.0)
+        if not ((guidance_scale <= 1.0) ^ do_classifier_free_guidance):
+            raise ValueError(
+                f"`guidance_scale` ({guidance_scale}) is incompetible with the compiled batch sizes of `unet` and `movq`. "
+                f"Those models are compiled assuming that classifier-free guidance is {'enabled' if do_classifier_free_guidance else 'disabled'}. "
+                "Please ensure `guidance_scale` is > 1.0 when classifier-free guidance is enabled, and <= 1.0 otherwise."
+            )

--- a/src/optimum/rbln/diffusers/pipelines/kandinsky2_2/pipeline_kandinsky2_2_combined.py
+++ b/src/optimum/rbln/diffusers/pipelines/kandinsky2_2/pipeline_kandinsky2_2_combined.py
@@ -187,3 +187,7 @@ class RBLNKandinskyV22InpaintCombinedPipeline(RBLNDiffusionMixin, KandinskyV22In
 
     def get_compiled_image_size(self):
         return self.movq.image_size
+
+    def validate_model_runtime_consistency(self, *args, **kwargs):
+        # Consistency checks are handled by the individual connected pipelines (prior_pipe and decoder_pipe).
+        pass

--- a/src/optimum/rbln/diffusers/pipelines/kandinsky2_2/pipeline_kandinsky2_2_combined.py
+++ b/src/optimum/rbln/diffusers/pipelines/kandinsky2_2/pipeline_kandinsky2_2_combined.py
@@ -86,6 +86,10 @@ class RBLNKandinskyV22CombinedPipeline(RBLNDiffusionMixin, KandinskyV22CombinedP
     def get_compiled_image_size(self):
         return self.movq.image_size
 
+    def validate_model_runtime_consistency(self, *args, **kwargs):
+        # Consistency checks are handled by the individual connected pipelines (prior_pipe and decoder_pipe).
+        pass
+
 
 class RBLNKandinskyV22Img2ImgCombinedPipeline(RBLNDiffusionMixin, KandinskyV22Img2ImgCombinedPipeline):
     original_class = KandinskyV22Img2ImgCombinedPipeline
@@ -136,6 +140,10 @@ class RBLNKandinskyV22Img2ImgCombinedPipeline(RBLNDiffusionMixin, KandinskyV22Im
 
     def get_compiled_image_size(self):
         return self.movq.image_size
+
+    def validate_model_runtime_consistency(self, *args, **kwargs):
+        # Consistency checks are handled by the individual connected pipelines (prior_pipe and decoder_pipe).
+        pass
 
 
 class RBLNKandinskyV22InpaintCombinedPipeline(RBLNDiffusionMixin, KandinskyV22InpaintCombinedPipeline):

--- a/src/optimum/rbln/diffusers/pipelines/kandinsky2_2/pipeline_kandinsky2_2_img2img.py
+++ b/src/optimum/rbln/diffusers/pipelines/kandinsky2_2/pipeline_kandinsky2_2_img2img.py
@@ -23,3 +23,23 @@ class RBLNKandinskyV22Img2ImgPipeline(RBLNDiffusionMixin, KandinskyV22Img2ImgPip
 
     def get_compiled_image_size(self):
         return self.movq.image_size
+
+    def validate_model_runtime_consistency(self, *args, **kwargs):
+        if self.movq.compiled_batch_size == self.unet.compiled_batch_size:
+            do_classifier_free_guidance = False
+        elif self.movq.compiled_batch_size * 2 == self.unet.compiled_batch_size:
+            do_classifier_free_guidance = True
+        else:
+            raise ValueError(
+                "Inconsistent batch sizes between `unet` and `movq`. "
+                f"`unet` batch size: {self.unet.compiled_batch_size}, "
+                f"`movq` batch size: {self.movq.compiled_batch_size}. "
+                "The batch size of `unet` must be either equal to or twice the batch size of `movq`."
+            )
+        guidance_scale = kwargs.get("guidance_scale", 5.0)
+        if not ((guidance_scale <= 1.0) ^ do_classifier_free_guidance):
+            raise ValueError(
+                f"`guidance_scale` ({guidance_scale}) is incompetible with the compiled batch sizes of `unet` and `movq`. "
+                f"Those models are compiled assuming that classifier-free guidance is {'enabled' if do_classifier_free_guidance else 'disabled'}. "
+                "Please ensure `guidance_scale` is > 1.0 when classifier-free guidance is enabled, and <= 1.0 otherwise."
+            )

--- a/src/optimum/rbln/diffusers/pipelines/kandinsky2_2/pipeline_kandinsky2_2_inpaint.py
+++ b/src/optimum/rbln/diffusers/pipelines/kandinsky2_2/pipeline_kandinsky2_2_inpaint.py
@@ -23,3 +23,23 @@ class RBLNKandinskyV22InpaintPipeline(RBLNDiffusionMixin, KandinskyV22InpaintPip
 
     def get_compiled_image_size(self):
         return self.movq.image_size
+
+    def validate_model_runtime_consistency(self, *args, **kwargs):
+        if self.movq.compiled_batch_size == self.unet.compiled_batch_size:
+            do_classifier_free_guidance = False
+        elif self.movq.compiled_batch_size * 2 == self.unet.compiled_batch_size:
+            do_classifier_free_guidance = True
+        else:
+            raise ValueError(
+                "Inconsistent batch sizes between `unet` and `movq`. "
+                f"`unet` batch size: {self.unet.compiled_batch_size}, "
+                f"`movq` batch size: {self.movq.compiled_batch_size}. "
+                "The batch size of `unet` must be either equal to or twice the batch size of `movq`."
+            )
+        guidance_scale = kwargs.get("guidance_scale", 5.0)
+        if not ((guidance_scale <= 1.0) ^ do_classifier_free_guidance):
+            raise ValueError(
+                f"`guidance_scale` ({guidance_scale}) is incompetible with the compiled batch sizes of `unet` and `movq`. "
+                f"Those models are compiled assuming that classifier-free guidance is {'enabled' if do_classifier_free_guidance else 'disabled'}. "
+                "Please ensure `guidance_scale` is > 1.0 when classifier-free guidance is enabled, and <= 1.0 otherwise."
+            )

--- a/src/optimum/rbln/diffusers/pipelines/kandinsky2_2/pipeline_kandinsky2_2_prior.py
+++ b/src/optimum/rbln/diffusers/pipelines/kandinsky2_2/pipeline_kandinsky2_2_prior.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
+
 from diffusers import KandinskyV22PriorPipeline
 
 from ...modeling_diffusers import RBLNDiffusionMixin
@@ -20,3 +22,46 @@ from ...modeling_diffusers import RBLNDiffusionMixin
 class RBLNKandinskyV22PriorPipeline(RBLNDiffusionMixin, KandinskyV22PriorPipeline):
     original_class = KandinskyV22PriorPipeline
     _submodules = ["text_encoder", "image_encoder", "prior"]
+
+    def validate_model_runtime_consistency(self, *args, **kwargs):
+        param_names = list(inspect.signature(self.original_class.__call__).parameters.keys())[1:]
+        args_dict = dict(zip(param_names, args))
+        merged = {**args_dict, **kwargs}
+        prompt = merged.get("prompt")
+        negative_prompt = merged.get("negative_prompt", None)
+        guidance_scale = merged.get("guidance_scale", 5.0)
+        batch_size = len(prompt) if isinstance(prompt, list) else 1
+        if self.prior.compiled_batch_size == self.text_encoder.compiled_batch_size:
+            do_classifier_free_guidance = False
+        elif self.prior.compiled_batch_size == self.text_encoder.compiled_batch_size * 2:
+            do_classifier_free_guidance = True
+        else:
+            raise ValueError(
+                "Inconsistent batch sizes between `prior` and `text_encoder`. "
+                f"`prior` batch size: {self.prior.compiled_batch_size}, "
+                f"`text_encoder` batch size: {self.text_encoder.compiled_batch_size}. "
+                "The batch size of `prior` must be either equal to or twice the batch size of `text_encoder`."
+            )
+
+        if negative_prompt is not None:
+            if self.text_encoder.compiled_batch_size != batch_size * 2:
+                raise ValueError(
+                    "If `negative_prompt` is provided, the compiled batch size of `text_encoder` should be double compared to the batch size. "
+                    f"batch size: {batch_size}, "
+                    f"`text_encoder` batch size: {self.text_encoder.compiled_batch_size}. "
+                )
+        else:
+            if self.text_encoder.compiled_batch_size != batch_size:
+                raise ValueError(
+                    "If `negative_prompt` is not provided, the compiled batch size of `text_encoder` should be the same as the batch size. "
+                    f"batch size: {batch_size}, "
+                    f"`text_encoder` batch size: {self.text_encoder.compiled_batch_size}. "
+                )
+
+        if not ((guidance_scale <= 1.0) ^ do_classifier_free_guidance):
+            raise ValueError(
+                f"`guidance_scale` ({guidance_scale}) is incompetible with the compiled batch sizes of `prior` and `text_encoder`. "
+                f"Those models are compiled assuming that classifier-free guidance is {'enabled' if do_classifier_free_guidance else 'disabled'}. "
+                "Please ensure `guidance_scale` is > 1.0 when classifier-free guidance is enabled, and <= 1.0 otherwise. "
+                "If you are using a combined pipeline, please check `prior_guidance_scale` instead of `guidance_scale`."
+            )

--- a/src/optimum/rbln/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py
+++ b/src/optimum/rbln/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py
@@ -20,3 +20,23 @@ from ...modeling_diffusers import RBLNDiffusionMixin
 class RBLNStableDiffusion3Pipeline(RBLNDiffusionMixin, StableDiffusion3Pipeline):
     original_class = StableDiffusion3Pipeline
     _submodules = ["transformer", "text_encoder_3", "text_encoder", "text_encoder_2", "vae"]
+
+    def validate_model_runtime_consistency(self, *args, **kwargs):
+        if self.vae.compiled_batch_size == self.transformer.compiled_batch_size:
+            do_classifier_free_guidance = False
+        elif self.vae.compiled_batch_size * 2 == self.transformer.compiled_batch_size:
+            do_classifier_free_guidance = True
+        else:
+            raise ValueError(
+                "Inconsistent batch sizes between `transformer` and `vae`. "
+                f"`transformer` batch size: {self.transformer.compiled_batch_size}, "
+                f"`vae` batch size: {self.vae.compiled_batch_size}. "
+                "The batch size of `transformer` must be either equal to or twice the batch size of `vae`."
+            )
+        guidance_scale = kwargs.get("guidance_scale", 5.0)
+        if not ((guidance_scale <= 1.0) ^ do_classifier_free_guidance):
+            raise ValueError(
+                f"`guidance_scale` ({guidance_scale}) is incompetible with the compiled batch sizes of `transformer` and `vae`. "
+                f"Those models are compiled assuming that classifier-free guidance is {'enabled' if do_classifier_free_guidance else 'disabled'}. "
+                "Please ensure `guidance_scale` is > 1.0 when classifier-free guidance is enabled, and <= 1.0 otherwise."
+            )

--- a/src/optimum/rbln/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3_img2img.py
+++ b/src/optimum/rbln/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3_img2img.py
@@ -20,3 +20,23 @@ from ...modeling_diffusers import RBLNDiffusionMixin
 class RBLNStableDiffusion3Img2ImgPipeline(RBLNDiffusionMixin, StableDiffusion3Img2ImgPipeline):
     original_class = StableDiffusion3Img2ImgPipeline
     _submodules = ["transformer", "text_encoder_3", "text_encoder", "text_encoder_2", "vae"]
+
+    def validate_model_runtime_consistency(self, *args, **kwargs):
+        if self.vae.compiled_batch_size == self.transformer.compiled_batch_size:
+            do_classifier_free_guidance = False
+        elif self.vae.compiled_batch_size * 2 == self.transformer.compiled_batch_size:
+            do_classifier_free_guidance = True
+        else:
+            raise ValueError(
+                "Inconsistent batch sizes between `transformer` and `vae`. "
+                f"`transformer` batch size: {self.transformer.compiled_batch_size}, "
+                f"`vae` batch size: {self.vae.compiled_batch_size}. "
+                "The batch size of `transformer` must be either equal to or twice the batch size of `vae`."
+            )
+        guidance_scale = kwargs.get("guidance_scale", 5.0)
+        if not ((guidance_scale <= 1.0) ^ do_classifier_free_guidance):
+            raise ValueError(
+                f"`guidance_scale` ({guidance_scale}) is incompetible with the compiled batch sizes of `transformer` and `vae`. "
+                f"Those models are compiled assuming that classifier-free guidance is {'enabled' if do_classifier_free_guidance else 'disabled'}. "
+                "Please ensure `guidance_scale` is > 1.0 when classifier-free guidance is enabled, and <= 1.0 otherwise."
+            )

--- a/src/optimum/rbln/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3_inpaint.py
+++ b/src/optimum/rbln/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3_inpaint.py
@@ -20,3 +20,23 @@ from ...modeling_diffusers import RBLNDiffusionMixin
 class RBLNStableDiffusion3InpaintPipeline(RBLNDiffusionMixin, StableDiffusion3InpaintPipeline):
     original_class = StableDiffusion3InpaintPipeline
     _submodules = ["transformer", "text_encoder_3", "text_encoder", "text_encoder_2", "vae"]
+
+    def validate_model_runtime_consistency(self, *args, **kwargs):
+        if self.vae.compiled_batch_size == self.transformer.compiled_batch_size:
+            do_classifier_free_guidance = False
+        elif self.vae.compiled_batch_size * 2 == self.transformer.compiled_batch_size:
+            do_classifier_free_guidance = True
+        else:
+            raise ValueError(
+                "Inconsistent batch sizes between `transformer` and `vae`. "
+                f"`transformer` batch size: {self.transformer.compiled_batch_size}, "
+                f"`vae` batch size: {self.vae.compiled_batch_size}. "
+                "The batch size of `transformer` must be either equal to or twice the batch size of `vae`."
+            )
+        guidance_scale = kwargs.get("guidance_scale", 5.0)
+        if not ((guidance_scale <= 1.0) ^ do_classifier_free_guidance):
+            raise ValueError(
+                f"`guidance_scale` ({guidance_scale}) is incompetible with the compiled batch sizes of `transformer` and `vae`. "
+                f"Those models are compiled assuming that classifier-free guidance is {'enabled' if do_classifier_free_guidance else 'disabled'}. "
+                "Please ensure `guidance_scale` is > 1.0 when classifier-free guidance is enabled, and <= 1.0 otherwise."
+            )

--- a/src/optimum/rbln/transformers/models/clip/modeling_clip.py
+++ b/src/optimum/rbln/transformers/models/clip/modeling_clip.py
@@ -98,7 +98,9 @@ class RBLNCLIPTextModel(RBLNModel):
 
 
 class RBLNCLIPTextModelWithProjection(RBLNCLIPTextModel):
-    pass
+    @property
+    def compiled_batch_size(self):
+        return self.rbln_config.compile_cfgs[0].input_info[0][1][0]
 
 
 class _VisionEncoder(torch.nn.Module):
@@ -186,6 +188,10 @@ class RBLNCLIPVisionModel(RBLNModel):
 
 
 class RBLNCLIPVisionModelWithProjection(RBLNCLIPVisionModel):
+    @property
+    def compiled_batch_size(self):
+        return self.rbln_config.compile_cfgs[0].input_info[0][1][0]
+
     def forward(
         self,
         pixel_values: Optional[torch.FloatTensor] = None,

--- a/src/optimum/rbln/utils/decorator_utils.py
+++ b/src/optimum/rbln/utils/decorator_utils.py
@@ -83,6 +83,7 @@ def remove_compile_time_kwargs(func):
                     kwargs["cross_attention_kwargs"] = None
                 else:
                     kwargs["cross_attention_kwargs"].pop("scale")
+
         self.validate_model_runtime_consistency(**kwargs)
         return func(self, **kwargs)
 

--- a/src/optimum/rbln/utils/decorator_utils.py
+++ b/src/optimum/rbln/utils/decorator_utils.py
@@ -38,6 +38,9 @@ def remove_compile_time_kwargs(func):
     def wrapper(self, *args, **kwargs):
         check_params = {"height", "width"}
         params = inspect.signature(self.original_class.__call__).parameters
+        param_names = list(params.keys())[1:]
+        args_dict = dict(zip(param_names, args))
+        kwargs = {**args_dict, **kwargs}
 
         # If height and width exist in the base pipeline's __call__ method arguments
         # Otherwise, if there is no height or width of kwargs, it is filled based on the compiled size.
@@ -65,7 +68,7 @@ def remove_compile_time_kwargs(func):
         if "cross_attention_kwargs" in kwargs:
             cross_attention_kwargs = kwargs.get("cross_attention_kwargs")
             if not cross_attention_kwargs:
-                return func(self, *args, **kwargs)
+                return func(self, **kwargs)
 
             has_scale = "scale" in cross_attention_kwargs
             if has_scale:
@@ -80,7 +83,7 @@ def remove_compile_time_kwargs(func):
                     kwargs["cross_attention_kwargs"] = None
                 else:
                     kwargs["cross_attention_kwargs"].pop("scale")
-
-        return func(self, *args, **kwargs)
+        self.validate_model_runtime_consistency(**kwargs)
+        return func(self, **kwargs)
 
     return wrapper


### PR DESCRIPTION
# Pull Request Description

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] New Model Support
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

https://github.com/rebellions-sw/optimum-rbln/pull/54 에서 consistency check of compiled batch size 관련 내용을 삭제한 후, 새로 PR을 작성하였습니다.

- compiled batch size와 arguments의 정합성이 맞지 않는 경우 이에 대한 에러를 발생하도록 하였습니다.
    - e.g., `guidance_scale > 1`이지만 `vae`와 `unet`의 batch size가 동일한 경우
    - pipeline마다 동작이 다르기 때문에 하나의 함수로는 이에 대응할 수 없고, 각각에 맞는 적절한 함수를 구현해줘야 합니다.
    - 따라서, 현재 구조 상으로는 새 pipeline이 추가될 때, `diffusers`의 버전이 변경될 때 관련된 로직을 점검해야 합니다.
- `remove_compile_time_kwargs`의 `check_params`에 해당하는 runtime arguments들이 args를 통해 전달될 때 에러가 발생하는 문제를 해결하였습니다.

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (If needed)

## Additional Information
<!-- Any additional information, configuration, or data that might be necessary to reproduce the issue or use the new feature -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only     
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update