### PR TITLE
model(llm): update logic for estimating max num blocks

### DIFF
--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -580,6 +580,19 @@ class RBLNDecoderOnlyModelForCausalLM(RBLNModel):
     ) -> int:
         """
         We are finding max_n_blocks(x) that satisfies the following equation:
+
+        available_dram - kernel_size - buffer
+            - num_layers * 2 * tensor_parallel_size
+            * align_2MB(
+                n_blocks
+                * block_size
+                * align_64(head_dim)
+                * math.ceil(num_key_value_heads / tensor_parallel_size)
+                * 2
+            ) > 0
+
+        This inequality can be rewritten as follows:
+
         a / c > align_2MB(b * x)
         where
            a = available_dram

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -578,11 +578,28 @@ class RBLNDecoderOnlyModelForCausalLM(RBLNModel):
         nbits_per_param: int,
         n_model_params: int,
     ) -> int:
+        """
+        We are finding max_n_blocks(x) that satisfies the following equation:
+        a / c > align_2MB(b * x)
+        where
+           a = available_dram
+           b = block_size * align_64(head_dim) * math.ceil(num_key_value_heads / tensor_parallel_size) * 2
+           c = num_layers * 2 * tensor_parallel_size
+
+        We can rewrite the inequality as follows:
+        k > align_2MB(b*x)
+        where
+           k = a / c
+
+        After that, we can derive the following equation:
+        x = floor(2**21 / b * floor((k - 1) / 2**21))
+        """
+
         def align(x: int, nbytes: int) -> int:
             return int(math.ceil(x / nbytes) * nbytes)
 
         def align_2MB(x: int) -> int:
-            return align(x, 2 * 1024 * 1024)
+            return align(x, 2**21)
 
         num_attention_heads = getattr(config, "n_head", None) or getattr(config, "num_attention_heads")
         num_layers = getattr(config, "n_layer", None) or getattr(config, "num_hidden_layers")
@@ -612,27 +629,16 @@ class RBLNDecoderOnlyModelForCausalLM(RBLNModel):
         available_dram -= kernel_size
 
         # TODO: Accurate buffer estimation
-        buffer = 2**30  # 1GB Buffer
-        if tensor_parallel_size <= 4:
-            buffer /= 4
-
+        buffer_per_core = 2**29  # 500MB per npu
+        buffer = buffer_per_core * tensor_parallel_size
         available_dram -= buffer
 
-        # Estimate nbytes per a single kvcache block
-        nbytes_per_block = (
-            align_2MB(
-                kvcache_block_size
-                * head_dim
-                * math.ceil(num_key_value_heads / tensor_parallel_size)  # Shard
-                * 2  # (fp16)
-            )
-            * num_layers
-            * 2  # (k, v)
-            * tensor_parallel_size
-        )
-        n_blocks = available_dram // nbytes_per_block
+        b = kvcache_block_size * align(head_dim, 64) * math.ceil(num_key_value_heads / tensor_parallel_size) * 2
+        c = num_layers * 2 * tensor_parallel_size
+        k = available_dram / c
+        max_n_blocks = math.floor(2**21 / b * math.floor((k - 1) / 2**21))
 
-        return n_blocks, nbytes_per_block
+        return max_n_blocks
 
     @classmethod
     def _get_rbln_config(
@@ -689,7 +695,7 @@ class RBLNDecoderOnlyModelForCausalLM(RBLNModel):
 
         rbln_kvcache_num_blocks = (rbln_max_seq_len // rbln_kvcache_block_size) * rbln_batch_size
         if rbln_attn_impl == "flash_attn":
-            max_num_blocks, _ = cls.get_maximum_num_blocks(
+            max_num_blocks = cls.get_maximum_num_blocks(
                 config=model_config,
                 tensor_parallel_size=rbln_kwargs.get("tensor_parallel_size", 1),
                 kvcache_block_size=rbln_kvcache_block_size,

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -584,7 +584,7 @@ class RBLNDecoderOnlyModelForCausalLM(RBLNModel):
         available_dram - kernel_size - buffer
             - num_layers * 2 * tensor_parallel_size
             * align_2MB(
-                n_blocks
+                x
                 * block_size
                 * align_64(head_dim)
                 * math.ceil(num_key_value_heads / tensor_parallel_size)
@@ -593,9 +593,9 @@ class RBLNDecoderOnlyModelForCausalLM(RBLNModel):
 
         This inequality can be rewritten as follows:
 
-        a / c > align_2MB(b * x)
+        a - c * align_2MB(b * x) > 0
         where
-           a = available_dram
+           a = available_dram - kernel_size - buffer
            b = block_size * align_64(head_dim) * math.ceil(num_key_value_heads / tensor_parallel_size) * 2
            c = num_layers * 2 * tensor_parallel_size
 


### PR DESCRIPTION
# Pull Request Description

The original expression is incorrect because the units of align_2MB are in units of available num blocks, not 1 num block.

We cannot calculate kvcache memory by calculating kvcache per block and then multiplying by the number of blocks, we need to solve an inequality equation

To do this, we have the function find the maximum num_blocks that satisfy the inequality below.

(16GB - Kernel - Buffer) - n_layer * tp * 2 * align_2MB(block_size * head_dim * ceil(num_kv_heads / tp) * 2 * num_blocks) > 0 

To simplify this inequality, we can enclose it as follows:

available_dram = (16GB - Kernel - Buffer) * tp
b = kvcache_block_size * align(head_dim, 64) * math. ceil(num_key_value_heads / tensor_parallel_size) * 2
c = num_layers * 2 * tensor_parallel_size
k = available_dram / c

The expression is organized as follows

k - align_2MB(b*x) > 0 

We need to find the largest natural number x that satisfies the above inequality

and solving it gives us

x_max = floor(2MB / b * floor((k-1) / 2MB))

.

This solves the problem that some existing models inferred the kv cache size to be twice the actual size @rebel-myeongbo 

However, we previously estimated the size of the buffers (init, cs, etc.) to be 1GB in total, but in this patch we estimate it to be 500MB per tp, which is larger than before. 
(If we leave the buffer estimation as it is, we get models that blow up.)

This makes the existing max num blocks smaller, so it seems we need to estimate the buffer size more precisely @rebel-yhboo








## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] New Model Support
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (If needed)

## Additional Information
<!-- Any additional information, configuration, or data that might be necessary to reproduce the issue or use the new feature -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only     
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update