### PR TITLE
model(whisper): fix generation config handling

### DIFF
--- a/src/optimum/rbln/modeling.py
+++ b/src/optimum/rbln/modeling.py
@@ -136,11 +136,10 @@ class RBLNModel(RBLNBaseModel):
                 config_path = save_dir_path / subfolder / "generation_config.json"
                 config_path.write_text(
                     json.dumps(
-                        {**json.loads(config_path.read_text(encoding="utf-8")),
-                        "transformers_version": "4.36.0.dev0"},
-                        indent=2
+                        {**json.loads(config_path.read_text(encoding="utf-8")), "transformers_version": "4.36.0.dev0"},
+                        indent=2,
                     ),
-                    encoding="utf-8"
+                    encoding="utf-8",
                 )
 
         if not isinstance(config, PretrainedConfig):  # diffusers config

--- a/src/optimum/rbln/modeling.py
+++ b/src/optimum/rbln/modeling.py
@@ -131,8 +131,17 @@ class RBLNModel(RBLNBaseModel):
             # Reference: https://github.com/huggingface/transformers/blob/v4.50.3/src/transformers/generation/utils.py#L1595
             # TODO: Evaluate if version management can be automated instead of hardcoding the transformers version.
             if model.__class__.__name__ == "WhisperForConditionalGeneration":
-                generation_config.transformers_version = "4.36.0.dev0"
-                generation_config.save_pretrained(save_dir_path / subfolder)
+                import json
+
+                config_path = save_dir_path / subfolder / "generation_config.json"
+                config_path.write_text(
+                    json.dumps(
+                        {**json.loads(config_path.read_text(encoding="utf-8")),
+                        "transformers_version": "4.36.0.dev0"},
+                        indent=2
+                    ),
+                    encoding="utf-8"
+                )
 
         if not isinstance(config, PretrainedConfig):  # diffusers config
             config = PretrainedConfig(**config)

--- a/src/optimum/rbln/modeling.py
+++ b/src/optimum/rbln/modeling.py
@@ -129,9 +129,9 @@ class RBLNModel(RBLNBaseModel):
             config_path = save_dir_path / subfolder / "generation_config.json"
 
             generation_config.save_pretrained(config_path.parent)
-            config = json.loads(config_path.read_text(encoding="utf-8"))
-            config["transformers_version"] = generation_config.transformers_version
-            config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+            config_local = json.loads(config_path.read_text(encoding="utf-8"))
+            config_local["transformers_version"] = generation_config.transformers_version
+            config_path.write_text(json.dumps(config_local, indent=2) + "\n", encoding="utf-8")
 
         if not isinstance(config, PretrainedConfig):  # diffusers config
             config = PretrainedConfig(**config)

--- a/src/optimum/rbln/modeling.py
+++ b/src/optimum/rbln/modeling.py
@@ -126,12 +126,12 @@ class RBLNModel(RBLNBaseModel):
             import json
 
             generation_config = model.generation_config
-            config_path = save_dir_path / subfolder / "generation_config.json"
+            generation_config_path = save_dir_path / subfolder / "generation_config.json"
 
-            generation_config.save_pretrained(config_path.parent)
-            config_local = json.loads(config_path.read_text(encoding="utf-8"))
-            config_local["transformers_version"] = generation_config.transformers_version
-            config_path.write_text(json.dumps(config_local, indent=2) + "\n", encoding="utf-8")
+            generation_config.save_pretrained(generation_config_path.parent)
+            local_config = json.loads(generation_config_path.read_text(encoding="utf-8"))
+            local_config["transformers_version"] = generation_config.transformers_version
+            generation_config_path.write_text(json.dumps(local_config, indent=2) + "\n", encoding="utf-8")
 
         if not isinstance(config, PretrainedConfig):  # diffusers config
             config = PretrainedConfig(**config)

--- a/src/optimum/rbln/modeling.py
+++ b/src/optimum/rbln/modeling.py
@@ -126,6 +126,14 @@ class RBLNModel(RBLNBaseModel):
             generation_config = model.generation_config
             generation_config.save_pretrained(save_dir_path / subfolder)
 
+            # Check if the model is a WhisperForConditionalGeneration instance without importing the class.
+            # This block adds the transformers version to the generation_config, ensuring consistency during saving.
+            # Reference: https://github.com/huggingface/transformers/blob/v4.50.3/src/transformers/generation/utils.py#L1595
+            # TODO: Evaluate if version management can be automated instead of hardcoding the transformers version.
+            if model.__class__.__name__ == "WhisperForConditionalGeneration":
+                generation_config.transformers_version = "4.36.0.dev0"
+                generation_config.save_pretrained(save_dir_path / subfolder)
+
         if not isinstance(config, PretrainedConfig):  # diffusers config
             config = PretrainedConfig(**config)
         config.save_pretrained(save_dir_path / subfolder)

--- a/src/optimum/rbln/transformers/models/whisper/modeling_whisper.py
+++ b/src/optimum/rbln/transformers/models/whisper/modeling_whisper.py
@@ -140,7 +140,6 @@ class RBLNWhisperForConditionalGeneration(RBLNModel, RBLNWhisperGenerationMixin)
         #     input_stride = self.model.encoder.conv1.stride[0] * self.model.encoder.conv2.stride[0]
         self.model = WhisperModel(self.config)
         self.pad_token_id = self.config.pad_token_id
-        self.generation_config.forced_decoder_ids = None
 
     def can_generate(self):
         return True


### PR DESCRIPTION
# Pull Request Description
- Update the logic in from_model() to properly save the generation configuration by writing to a dedicated directory and including the transformers_version.
- Remove the redundant assignment of forced_decoder_ids in the Whisper model initialization (#75 ).
- This bugfix resolves configuration issues for generation in Whisper models (#79 ).

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] New Model Support
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (If needed)

## Additional Information
<!-- Any additional information, configuration, or data that might be necessary to reproduce the issue or use the new feature -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only     
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update