### PR TITLE
model(kandinsky): update not to use encoder

### DIFF
--- a/examples/kandinsky2_2/run_kandinsky2_2_img2img.py
+++ b/examples/kandinsky2_2/run_kandinsky2_2_img2img.py
@@ -20,6 +20,7 @@ def main(
         prior_pipe = RBLNKandinskyV22PriorPipeline.from_pretrained(
             model_id=prior_model_id,
             export=True,
+            rbln_config={"prior": {"batch_size": 2}},
         )
         prior_pipe.save_pretrained(os.path.basename(prior_model_id))
 
@@ -28,6 +29,7 @@ def main(
             export=True,
             rbln_img_height=768,
             rbln_img_width=768,
+            rbln_config={"unet": {"batch_size": 2}},
         )
         pipe.save_pretrained(os.path.basename(inpaint_model_id))
     else:

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_vq_model.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_vq_model.py
@@ -22,6 +22,7 @@ class RBLNVQModelConfig(RBLNModelConfig):
         self,
         batch_size: Optional[int] = None,
         sample_size: Optional[Tuple[int, int]] = None,
+        uses_encoder: Optional[bool] = None,
         vqmodel_scale_factor: Optional[float] = None,  # TODO: rename to scaling_factor
         in_channels: Optional[int] = None,
         latent_channels: Optional[int] = None,
@@ -32,6 +33,8 @@ class RBLNVQModelConfig(RBLNModelConfig):
             batch_size (Optional[int]): The batch size for inference. Defaults to 1.
             sample_size (Optional[Tuple[int, int]]): The spatial dimensions (height, width) of the input/output images.
                 If an integer is provided, it's used for both height and width.
+            uses_encoder (Optional[bool]): Whether to include the encoder part of the VAE in the model.
+                When False, only the decoder is used (for latent-to-image conversion).
             vqmodel_scale_factor (Optional[float]): The scaling factor between pixel space and latent space.
                 Determines the downsampling ratio between original images and latent representations.
             in_channels (Optional[int]): Number of input channels for the model.
@@ -46,6 +49,7 @@ class RBLNVQModelConfig(RBLNModelConfig):
         if not isinstance(self.batch_size, int) or self.batch_size < 0:
             raise ValueError(f"batch_size must be a positive integer, got {self.batch_size}")
 
+        self.uses_encoder = uses_encoder
         self.sample_size = sample_size
         if isinstance(self.sample_size, int):
             self.sample_size = (self.sample_size, self.sample_size)

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_kandinsky2_2.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_kandinsky2_2.py
@@ -26,6 +26,7 @@ logger = get_logger(__name__)
 
 class _RBLNKandinskyV22PipelineBaseConfig(RBLNModelConfig):
     submodules = ["unet", "movq"]
+    _movq_uses_encoder = False
 
     def __init__(
         self,
@@ -95,15 +96,15 @@ class _RBLNKandinskyV22PipelineBaseConfig(RBLNModelConfig):
 
 
 class RBLNKandinskyV22PipelineConfig(_RBLNKandinskyV22PipelineBaseConfig):
-    pass
+    _movq_uses_encoder = False
 
 
 class RBLNKandinskyV22Img2ImgPipelineConfig(_RBLNKandinskyV22PipelineBaseConfig):
-    pass
+    _movq_uses_encoder = True
 
 
 class RBLNKandinskyV22InpaintPipelineConfig(_RBLNKandinskyV22PipelineBaseConfig):
-    pass
+    _movq_uses_encoder = True
 
 
 class RBLNKandinskyV22PriorPipelineConfig(RBLNModelConfig):
@@ -168,6 +169,7 @@ class RBLNKandinskyV22PriorPipelineConfig(RBLNModelConfig):
 
 class _RBLNKandinskyV22CombinedPipelineBaseConfig(RBLNModelConfig):
     submodules = ["prior_pipe", "decoder_pipe"]
+    _decoder_pipe_cls = RBLNKandinskyV22PipelineConfig
 
     def __init__(
         self,
@@ -229,7 +231,7 @@ class _RBLNKandinskyV22CombinedPipelineBaseConfig(RBLNModelConfig):
             guidance_scale=guidance_scale,
         )
         self.decoder_pipe = self.init_submodule_config(
-            RBLNKandinskyV22PipelineConfig,
+            self._decoder_pipe_cls,
             decoder_pipe,
             unet=unet,
             movq=movq,
@@ -271,12 +273,12 @@ class _RBLNKandinskyV22CombinedPipelineBaseConfig(RBLNModelConfig):
 
 
 class RBLNKandinskyV22CombinedPipelineConfig(_RBLNKandinskyV22CombinedPipelineBaseConfig):
-    pass
+    _decoder_pipe_cls = RBLNKandinskyV22PipelineConfig
 
 
 class RBLNKandinskyV22InpaintCombinedPipelineConfig(_RBLNKandinskyV22CombinedPipelineBaseConfig):
-    pass
+    _decoder_pipe_cls = RBLNKandinskyV22InpaintPipelineConfig
 
 
 class RBLNKandinskyV22Img2ImgCombinedPipelineConfig(_RBLNKandinskyV22CombinedPipelineBaseConfig):
-    pass
+    _decoder_pipe_cls = RBLNKandinskyV22Img2ImgPipelineConfig

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_kandinsky2_2.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_kandinsky2_2.py
@@ -78,6 +78,7 @@ class _RBLNKandinskyV22PipelineBaseConfig(RBLNModelConfig):
             movq,
             batch_size=batch_size,
             sample_size=image_size,  # image size is equal to sample size in vae
+            uses_encoder=self._movq_uses_encoder,
         )
 
         if guidance_scale is not None:

--- a/src/optimum/rbln/diffusers/models/autoencoders/vq_model.py
+++ b/src/optimum/rbln/diffusers/models/autoencoders/vq_model.py
@@ -47,7 +47,7 @@ class RBLNVQModel(RBLNModel):
         else:
             self.encoder = None
 
-        self.decoder = RBLNRuntimeVQDecoder(runtime=self.model[1], main_input_name="z")
+        self.decoder = RBLNRuntimeVQDecoder(runtime=self.model[-1], main_input_name="z")
         self.decoder.lookup_from_codebook = self.config.lookup_from_codebook
         self.image_size = self.rbln_config.image_size
 

--- a/src/optimum/rbln/diffusers/models/autoencoders/vq_model.py
+++ b/src/optimum/rbln/diffusers/models/autoencoders/vq_model.py
@@ -20,7 +20,7 @@ from diffusers import VQModel
 from diffusers.models.autoencoders.vae import DecoderOutput
 from diffusers.models.autoencoders.vq_model import VQEncoderOutput
 
-from ....configuration_utils import DEFAULT_COMPILED_MODEL_NAME, RBLNCompileConfig, RBLNModelConfig
+from ....configuration_utils import RBLNCompileConfig, RBLNModelConfig
 from ....modeling import RBLNModel
 from ....utils.logging import get_logger
 from ...configurations.models.configuration_vq_model import RBLNVQModelConfig
@@ -42,22 +42,34 @@ class RBLNVQModel(RBLNModel):
     def __post_init__(self, **kwargs):
         super().__post_init__(**kwargs)
 
-        self.encoder = RBLNRuntimeVQEncoder(runtime=self.model[0], main_input_name="x")
+        if self.rbln_config.uses_encoder:
+            self.encoder = RBLNRuntimeVQEncoder(runtime=self.model[0], main_input_name="x")
+        else:
+            self.encoder = None
+
         self.decoder = RBLNRuntimeVQDecoder(runtime=self.model[1], main_input_name="z")
         self.decoder.lookup_from_codebook = self.config.lookup_from_codebook
         self.image_size = self.rbln_config.image_size
 
     @classmethod
     def get_compiled_model(cls, model, rbln_config: RBLNModelConfig):
-        encoder_model = _VQEncoder(model)
-        decoder_model = _VQDecoder(model)
-        encoder_model.eval()
-        decoder_model.eval()
+        if rbln_config.uses_encoder:
+            expected_models = ["encoder", "decoder"]
+        else:
+            expected_models = ["decoder"]
 
-        enc_compiled_model = cls.compile(encoder_model, rbln_compile_config=rbln_config.compile_cfgs[0])
-        dec_compiled_model = cls.compile(decoder_model, rbln_compile_config=rbln_config.compile_cfgs[1])
+        compiled_models = {}
+        for i, model_name in enumerate(expected_models):
+            if model_name == "encoder":
+                wrapped_model = _VQEncoder(model)
+            else:
+                wrapped_model = _VQDecoder(model)
 
-        return {"encoder": enc_compiled_model, "decoder": dec_compiled_model}
+            wrapped_model.eval()
+
+            compiled_models[model_name] = cls.compile(wrapped_model, rbln_compile_config=rbln_config.compile_cfgs[i])
+
+        return compiled_models
 
     @classmethod
     def update_rbln_config_using_pipe(
@@ -79,28 +91,38 @@ class RBLNVQModel(RBLNModel):
             # image processor default value 8 (int)
             rbln_config.vqmodel_scale_factor = 8
 
-        enc_shape = rbln_config.image_size
-        dec_shape = rbln_config.latent_sample_size
+        compile_cfgs = []
+        if rbln_config.uses_encoder:
+            enc_input_info = [
+                (
+                    "x",
+                    [
+                        rbln_config.batch_size,
+                        model_config.in_channels,
+                        rbln_config.sample_size[0],
+                        rbln_config.sample_size[1],
+                    ],
+                    "float32",
+                )
+            ]
+            enc_rbln_compile_config = RBLNCompileConfig(compiled_model_name="encoder", input_info=enc_input_info)
+            compile_cfgs.append(enc_rbln_compile_config)
 
-        enc_input_info = [
-            (
-                "x",
-                [rbln_config.batch_size, model_config.in_channels, enc_shape[0], enc_shape[1]],
-                "float32",
-            )
-        ]
         dec_input_info = [
             (
                 "h",
-                [rbln_config.batch_size, model_config.latent_channels, dec_shape[0], dec_shape[1]],
+                [
+                    rbln_config.batch_size,
+                    model_config.latent_channels,
+                    rbln_config.latent_sample_size[0],
+                    rbln_config.latent_sample_size[1],
+                ],
                 "float32",
             )
         ]
-
-        enc_rbln_compile_config = RBLNCompileConfig(compiled_model_name="encoder", input_info=enc_input_info)
         dec_rbln_compile_config = RBLNCompileConfig(compiled_model_name="decoder", input_info=dec_input_info)
+        compile_cfgs.append(dec_rbln_compile_config)
 
-        compile_cfgs = [enc_rbln_compile_config, dec_rbln_compile_config]
         rbln_config.set_compile_cfgs(compile_cfgs)
         return rbln_config
 
@@ -111,14 +133,16 @@ class RBLNVQModel(RBLNModel):
         rbln_config: RBLNVQModelConfig,
     ) -> List[rebel.Runtime]:
         if len(compiled_models) == 1:
-            device_val = rbln_config.device_map[DEFAULT_COMPILED_MODEL_NAME]
-            return [
-                compiled_models[0].create_runtime(
-                    tensor_type="pt", device=device_val, activate_profiler=rbln_config.activate_profiler
-                )
-            ]
+            # decoder
+            expected_models = ["decoder"]
+        else:
+            # encoder, decoder
+            expected_models = ["encoder", "decoder"]
 
-        device_vals = [rbln_config.device_map["encoder"], rbln_config.device_map["decoder"]]
+        if any(model_name not in rbln_config.device_map for model_name in expected_models):
+            cls._raise_missing_compiled_file_error(expected_models)
+
+        device_vals = [rbln_config.device_map[model_name] for model_name in expected_models]
         return [
             rebel.Runtime(
                 compiled_model,


### PR DESCRIPTION
# Pull Request Description

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] New Model Support
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

Encoder of vqvae is needed if and only if the pipeline requires image input.

This PR updates kandinsky pipeline compiles if the pipe requires movq encoder.

This reduces NPU's DRAM usage and total compile times.

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works (If needed)

## Additional Information
<!-- Any additional information, configuration, or data that might be necessary to reproduce the issue or use the new feature -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only     
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update