### PR TITLE
model: handle default behavior for diffuser pipelines

### DIFF
--- a/src/optimum/rbln/configuration_utils.py
+++ b/src/optimum/rbln/configuration_utils.py
@@ -716,7 +716,6 @@ class RBLNModelConfig:
         Get default values for original class attributes from RBLNModelConfig.
 
         Args:
-            rbln_config (RBLNModelConfig): The RBLN model configuration.
             func_name (str): The name of the function to get the default values for.
             keys (List[str]): The keys of the attributes to get.
 

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_controlnet.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_controlnet.py
@@ -18,6 +18,8 @@ from ....configuration_utils import RBLNModelConfig
 
 
 class RBLNControlNetModelConfig(RBLNModelConfig):
+    subclass_non_save_attributes = ["_batch_size_is_specified"]
+
     def __init__(
         self,
         batch_size: Optional[int] = None,
@@ -44,6 +46,8 @@ class RBLNControlNetModelConfig(RBLNModelConfig):
             ValueError: If batch_size is not a positive integer.
         """
         super().__init__(**kwargs)
+        self._batch_size_is_specified = batch_size is not None
+
         self.batch_size = batch_size or 1
         if not isinstance(self.batch_size, int) or self.batch_size < 0:
             raise ValueError(f"batch_size must be a positive integer, got {self.batch_size}")
@@ -52,3 +56,7 @@ class RBLNControlNetModelConfig(RBLNModelConfig):
         self.unet_sample_size = unet_sample_size
         self.vae_sample_size = vae_sample_size
         self.text_model_hidden_size = text_model_hidden_size
+
+    @property
+    def batch_size_is_specified(self):
+        return self._batch_size_is_specified

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_prior_transformer.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_prior_transformer.py
@@ -18,6 +18,8 @@ from ....configuration_utils import RBLNModelConfig
 
 
 class RBLNPriorTransformerConfig(RBLNModelConfig):
+    subclass_non_save_attributes = ["_batch_size_is_specified"]
+
     def __init__(
         self,
         batch_size: Optional[int] = None,
@@ -36,9 +38,15 @@ class RBLNPriorTransformerConfig(RBLNModelConfig):
             ValueError: If batch_size is not a positive integer.
         """
         super().__init__(**kwargs)
+        self._batch_size_is_specified = batch_size is not None
+
         self.batch_size = batch_size or 1
         if not isinstance(self.batch_size, int) or self.batch_size < 0:
             raise ValueError(f"batch_size must be a positive integer, got {self.batch_size}")
 
         self.embedding_dim = embedding_dim
         self.num_embeddings = num_embeddings
+
+    @property
+    def batch_size_is_specified(self):
+        return self._batch_size_is_specified

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_transformer_sd3.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_transformer_sd3.py
@@ -18,6 +18,8 @@ from ....configuration_utils import RBLNModelConfig
 
 
 class RBLNSD3Transformer2DModelConfig(RBLNModelConfig):
+    subclass_non_save_attributes = ["_batch_size_is_specified"]
+
     def __init__(
         self,
         batch_size: Optional[int] = None,
@@ -38,6 +40,8 @@ class RBLNSD3Transformer2DModelConfig(RBLNModelConfig):
             ValueError: If batch_size is not a positive integer.
         """
         super().__init__(**kwargs)
+        self._batch_size_is_specified = batch_size is not None
+
         self.batch_size = batch_size or 1
         if not isinstance(self.batch_size, int) or self.batch_size < 0:
             raise ValueError(f"batch_size must be a positive integer, got {self.batch_size}")
@@ -46,3 +50,7 @@ class RBLNSD3Transformer2DModelConfig(RBLNModelConfig):
         self.sample_size = sample_size
         if isinstance(self.sample_size, int):
             self.sample_size = (self.sample_size, self.sample_size)
+
+    @property
+    def batch_size_is_specified(self):
+        return self._batch_size_is_specified

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_unet_2d_condition.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_unet_2d_condition.py
@@ -18,6 +18,8 @@ from ....configuration_utils import RBLNModelConfig
 
 
 class RBLNUNet2DConditionModelConfig(RBLNModelConfig):
+    subclass_non_save_attributes = ["_batch_size_is_specified"]
+
     def __init__(
         self,
         batch_size: Optional[int] = None,
@@ -49,6 +51,8 @@ class RBLNUNet2DConditionModelConfig(RBLNModelConfig):
             ValueError: If batch_size is not a positive integer.
         """
         super().__init__(**kwargs)
+        self._batch_size_is_specified = batch_size is not None
+
         self.batch_size = batch_size or 1
         if not isinstance(self.batch_size, int) or self.batch_size < 0:
             raise ValueError(f"batch_size must be a positive integer, got {self.batch_size}")
@@ -64,3 +68,7 @@ class RBLNUNet2DConditionModelConfig(RBLNModelConfig):
         self.sample_size = sample_size
         if isinstance(sample_size, int):
             self.sample_size = (sample_size, sample_size)
+
+    @property
+    def batch_size_is_specified(self):
+        return self._batch_size_is_specified

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_controlnet.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_controlnet.py
@@ -16,11 +16,7 @@ from typing import Optional, Tuple
 
 from ....configuration_utils import RBLNModelConfig
 from ....transformers import RBLNCLIPTextModelConfig, RBLNCLIPTextModelWithProjectionConfig
-from ....utils.logging import get_logger
 from ..models import RBLNAutoencoderKLConfig, RBLNControlNetModelConfig, RBLNUNet2DConditionModelConfig
-
-
-logger = get_logger(__name__)
 
 
 class _RBLNStableDiffusionControlNetPipelineBaseConfig(RBLNModelConfig):

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_kandinsky2_2.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_kandinsky2_2.py
@@ -16,12 +16,8 @@ from typing import Optional, Tuple
 
 from ....configuration_utils import RBLNModelConfig
 from ....transformers import RBLNCLIPTextModelWithProjectionConfig, RBLNCLIPVisionModelWithProjectionConfig
-from ....utils.logging import get_logger
 from ..models import RBLNUNet2DConditionModelConfig, RBLNVQModelConfig
 from ..models.configuration_prior_transformer import RBLNPriorTransformerConfig
-
-
-logger = get_logger(__name__)
 
 
 class _RBLNKandinskyV22PipelineBaseConfig(RBLNModelConfig):

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_kandinsky2_2.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_kandinsky2_2.py
@@ -48,7 +48,7 @@ class _RBLNKandinskyV22PipelineBaseConfig(RBLNModelConfig):
                 Initialized as RBLNVQModelConfig if not provided.
             sample_size (Optional[Tuple[int, int]]): Spatial dimensions for the UNet model.
             batch_size (Optional[int]): Batch size for inference, applied to all submodules.
-            guidance_scale (Optional[float]): Scale for classifier-free guidance. Deprecated parameter.
+            guidance_scale (Optional[float]): Scale for classifier-free guidance.
             image_size (Optional[Tuple[int, int]]): Dimensions for the generated images.
                 Cannot be used together with img_height/img_width.
             img_height (Optional[int]): Height of the generated images.
@@ -79,8 +79,13 @@ class _RBLNKandinskyV22PipelineBaseConfig(RBLNModelConfig):
             sample_size=image_size,  # image size is equal to sample size in vae
         )
 
-        if guidance_scale is not None:
-            logger.warning("Specifying `guidance_scale` is deprecated. It will be removed in a future version.")
+        # Get default guidance scale from original class to set UNet batch size
+        guidance_scale = (
+            guidance_scale
+            or self.get_default_values_for_original_cls("__call__", ["guidance_scale"])["guidance_scale"]
+        )
+
+        if not self.unet.batch_size_is_specified:
             do_classifier_free_guidance = guidance_scale > 1.0
             if do_classifier_free_guidance:
                 self.unet.batch_size = self.movq.batch_size * 2
@@ -134,7 +139,7 @@ class RBLNKandinskyV22PriorPipelineConfig(RBLNModelConfig):
             prior (Optional[RBLNPriorTransformerConfig]): Configuration for the prior transformer component.
                 Initialized as RBLNPriorTransformerConfig if not provided.
             batch_size (Optional[int]): Batch size for inference, applied to all submodules.
-            guidance_scale (Optional[float]): Scale for classifier-free guidance. Deprecated parameter.
+            guidance_scale (Optional[float]): Scale for classifier-free guidance.
             **kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Note:
@@ -151,8 +156,13 @@ class RBLNKandinskyV22PriorPipelineConfig(RBLNModelConfig):
 
         self.prior = self.init_submodule_config(RBLNPriorTransformerConfig, prior, batch_size=batch_size)
 
-        if guidance_scale is not None:
-            logger.warning("Specifying `guidance_scale` is deprecated. It will be removed in a future version.")
+        # Get default guidance scale from original class to set UNet batch size
+        guidance_scale = (
+            guidance_scale
+            or self.get_default_values_for_original_cls("__call__", ["guidance_scale"])["guidance_scale"]
+        )
+
+        if not self.prior.batch_size_is_specified:
             do_classifier_free_guidance = guidance_scale > 1.0
             if do_classifier_free_guidance:
                 self.prior.batch_size = self.text_encoder.batch_size * 2
@@ -205,7 +215,7 @@ class _RBLNKandinskyV22CombinedPipelineBaseConfig(RBLNModelConfig):
             batch_size (Optional[int]): Batch size for inference, applied to all submodules.
             img_height (Optional[int]): Height of the generated images.
             img_width (Optional[int]): Width of the generated images.
-            guidance_scale (Optional[float]): Scale for classifier-free guidance. Deprecated parameter.
+            guidance_scale (Optional[float]): Scale for classifier-free guidance.
             prior_prior (Optional[RBLNPriorTransformerConfig]): Direct configuration for the prior transformer.
                 Used if prior_pipe is not provided.
             prior_image_encoder (Optional[RBLNCLIPVisionModelWithProjectionConfig]): Direct configuration for the image encoder.

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion.py
@@ -55,7 +55,7 @@ class _RBLNStableDiffusionPipelineBaseConfig(RBLNModelConfig):
             sample_size (Optional[Tuple[int, int]]): Spatial dimensions for the UNet model.
             image_size (Optional[Tuple[int, int]]): Alternative way to specify image dimensions.
                 Cannot be used together with img_height/img_width.
-            guidance_scale (Optional[float]): Scale for classifier-free guidance. Deprecated parameter.
+            guidance_scale (Optional[float]): Scale for classifier-free guidance.
             **kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:
@@ -87,8 +87,13 @@ class _RBLNStableDiffusionPipelineBaseConfig(RBLNModelConfig):
             sample_size=image_size,  # image size is equal to sample size in vae
         )
 
-        if guidance_scale is not None:
-            logger.warning("Specifying `guidance_scale` is deprecated. It will be removed in a future version.")
+        # Get default guidance scale from original class to set UNet batch size
+        guidance_scale = (
+            guidance_scale
+            or self.get_default_values_for_original_cls("__call__", ["guidance_scale"])["guidance_scale"]
+        )
+
+        if not self.unet.batch_size_is_specified:
             do_classifier_free_guidance = guidance_scale > 1.0
             if do_classifier_free_guidance:
                 self.unet.batch_size = self.text_encoder.batch_size * 2

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion.py
@@ -72,7 +72,6 @@ class _RBLNStableDiffusionPipelineBaseConfig(RBLNModelConfig):
         self.unet = self.init_submodule_config(
             RBLNUNet2DConditionModelConfig,
             unet,
-            batch_size=batch_size,
             sample_size=sample_size,
         )
         self.vae = self.init_submodule_config(
@@ -84,15 +83,15 @@ class _RBLNStableDiffusionPipelineBaseConfig(RBLNModelConfig):
         )
 
         # Get default guidance scale from original class to set UNet batch size
-        guidance_scale = (
-            guidance_scale
-            or self.get_default_values_for_original_cls("__call__", ["guidance_scale"])["guidance_scale"]
-        )
+        if guidance_scale is None:
+            guidance_scale = self.get_default_values_for_original_cls("__call__", ["guidance_scale"])["guidance_scale"]
 
         if not self.unet.batch_size_is_specified:
             do_classifier_free_guidance = guidance_scale > 1.0
             if do_classifier_free_guidance:
                 self.unet.batch_size = self.text_encoder.batch_size * 2
+            else:
+                self.unet.batch_size = self.text_encoder.batch_size
 
     @property
     def batch_size(self):

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion.py
@@ -16,11 +16,7 @@ from typing import Optional, Tuple
 
 from ....configuration_utils import RBLNModelConfig
 from ....transformers import RBLNCLIPTextModelConfig
-from ....utils.logging import get_logger
 from ..models import RBLNAutoencoderKLConfig, RBLNUNet2DConditionModelConfig
-
-
-logger = get_logger(__name__)
 
 
 class _RBLNStableDiffusionPipelineBaseConfig(RBLNModelConfig):

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_3.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_3.py
@@ -63,7 +63,7 @@ class _RBLNStableDiffusion3PipelineBaseConfig(RBLNModelConfig):
             batch_size (Optional[int]): Batch size for inference, applied to all submodules.
             img_height (Optional[int]): Height of the generated images.
             img_width (Optional[int]): Width of the generated images.
-            guidance_scale (Optional[float]): Scale for classifier-free guidance. Deprecated parameter.
+            guidance_scale (Optional[float]): Scale for classifier-free guidance.
             **kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:
@@ -108,8 +108,13 @@ class _RBLNStableDiffusion3PipelineBaseConfig(RBLNModelConfig):
             sample_size=image_size,
         )
 
-        if guidance_scale is not None:
-            logger.warning("Specifying `guidance_scale` is deprecated. It will be removed in a future version.")
+        # Get default guidance scale from original class to set Transformer batch size
+        guidance_scale = (
+            guidance_scale
+            or self.get_default_values_for_original_cls("__call__", ["guidance_scale"])["guidance_scale"]
+        )
+
+        if not self.transformer.batch_size_is_specified:
             do_classifier_free_guidance = guidance_scale > 1.0
             if do_classifier_free_guidance:
                 self.transformer.batch_size = self.text_encoder.batch_size * 2

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_3.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_3.py
@@ -93,7 +93,6 @@ class _RBLNStableDiffusion3PipelineBaseConfig(RBLNModelConfig):
         self.transformer = self.init_submodule_config(
             RBLNSD3Transformer2DModelConfig,
             transformer,
-            batch_size=batch_size,
             sample_size=sample_size,
         )
         self.vae = self.init_submodule_config(
@@ -105,15 +104,15 @@ class _RBLNStableDiffusion3PipelineBaseConfig(RBLNModelConfig):
         )
 
         # Get default guidance scale from original class to set Transformer batch size
-        guidance_scale = (
-            guidance_scale
-            or self.get_default_values_for_original_cls("__call__", ["guidance_scale"])["guidance_scale"]
-        )
+        if guidance_scale is None:
+            guidance_scale = self.get_default_values_for_original_cls("__call__", ["guidance_scale"])["guidance_scale"]
 
         if not self.transformer.batch_size_is_specified:
             do_classifier_free_guidance = guidance_scale > 1.0
             if do_classifier_free_guidance:
                 self.transformer.batch_size = self.text_encoder.batch_size * 2
+            else:
+                self.transformer.batch_size = self.text_encoder.batch_size
 
     @property
     def max_seq_len(self):

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_3.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_3.py
@@ -16,11 +16,7 @@ from typing import Optional, Tuple
 
 from ....configuration_utils import RBLNModelConfig
 from ....transformers import RBLNCLIPTextModelWithProjectionConfig, RBLNT5EncoderModelConfig
-from ....utils.logging import get_logger
 from ..models import RBLNAutoencoderKLConfig, RBLNSD3Transformer2DModelConfig
-
-
-logger = get_logger(__name__)
 
 
 class _RBLNStableDiffusion3PipelineBaseConfig(RBLNModelConfig):

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_xl.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_xl.py
@@ -78,7 +78,6 @@ class _RBLNStableDiffusionXLPipelineBaseConfig(RBLNModelConfig):
         self.unet = self.init_submodule_config(
             RBLNUNet2DConditionModelConfig,
             unet,
-            batch_size=batch_size,
             sample_size=sample_size,
         )
         self.vae = self.init_submodule_config(
@@ -90,15 +89,15 @@ class _RBLNStableDiffusionXLPipelineBaseConfig(RBLNModelConfig):
         )
 
         # Get default guidance scale from original class to set UNet batch size
-        guidance_scale = (
-            guidance_scale
-            or self.get_default_values_for_original_cls("__call__", ["guidance_scale"])["guidance_scale"]
-        )
+        if guidance_scale is None:
+            guidance_scale = self.get_default_values_for_original_cls("__call__", ["guidance_scale"])["guidance_scale"]
 
         if not self.unet.batch_size_is_specified:
             do_classifier_free_guidance = guidance_scale > 1.0
             if do_classifier_free_guidance:
                 self.unet.batch_size = self.text_encoder.batch_size * 2
+            else:
+                self.unet.batch_size = self.text_encoder.batch_size
 
     @property
     def batch_size(self):

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_xl.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_xl.py
@@ -16,11 +16,7 @@ from typing import Optional, Tuple
 
 from ....configuration_utils import RBLNModelConfig
 from ....transformers import RBLNCLIPTextModelConfig, RBLNCLIPTextModelWithProjectionConfig
-from ....utils.logging import get_logger
 from ..models import RBLNAutoencoderKLConfig, RBLNUNet2DConditionModelConfig
-
-
-logger = get_logger(__name__)
 
 
 class _RBLNStableDiffusionXLPipelineBaseConfig(RBLNModelConfig):

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_xl.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_xl.py
@@ -58,7 +58,7 @@ class _RBLNStableDiffusionXLPipelineBaseConfig(RBLNModelConfig):
             sample_size (Optional[Tuple[int, int]]): Spatial dimensions for the UNet model.
             image_size (Optional[Tuple[int, int]]): Alternative way to specify image dimensions.
                 Cannot be used together with img_height/img_width.
-            guidance_scale (Optional[float]): Scale for classifier-free guidance. Deprecated parameter.
+            guidance_scale (Optional[float]): Scale for classifier-free guidance.
             **kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:
@@ -93,8 +93,13 @@ class _RBLNStableDiffusionXLPipelineBaseConfig(RBLNModelConfig):
             sample_size=image_size,  # image size is equal to sample size in vae
         )
 
-        if guidance_scale is not None:
-            logger.warning("Specifying `guidance_scale` is deprecated. It will be removed in a future version.")
+        # Get default guidance scale from original class to set UNet batch size
+        guidance_scale = (
+            guidance_scale
+            or self.get_default_values_for_original_cls("__call__", ["guidance_scale"])["guidance_scale"]
+        )
+
+        if not self.unet.batch_size_is_specified:
             do_classifier_free_guidance = guidance_scale > 1.0
             if do_classifier_free_guidance:
                 self.unet.batch_size = self.text_encoder.batch_size * 2

--- a/src/optimum/rbln/diffusers/modeling_diffusers.py
+++ b/src/optimum/rbln/diffusers/modeling_diffusers.py
@@ -76,6 +76,7 @@ class RBLNDiffusionMixin:
     _submodules = []
     _prefix = {}
     _rbln_config_class = None
+    _hf_class = None
 
     @classmethod
     def is_img2img_pipeline(cls):
@@ -138,6 +139,14 @@ class RBLNDiffusionMixin:
                     "Please report it to the developers."
                 )
         return cls._rbln_config_class
+
+    @classmethod
+    def get_hf_class(cls):
+        if cls._hf_class is None:
+            hf_cls_name = cls.__name__[4:]
+            library = importlib.import_module("diffusers")
+            cls._hf_class = getattr(library, hf_cls_name, None)
+        return cls._hf_class
 
     @classmethod
     def from_pretrained(

--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -69,10 +69,9 @@ class TestSDXLModel(BaseTest.TestModel):
     # Fix incorrect tiny-sd-pipe-xl's vae config.json sample_size
     RBLN_CLASS_KWARGS = {
         "rbln_config": {
-            "unet": {"batch_size": 2},
             "vae": {
                 "sample_size": (64, 64),
-            },
+            }
         }
     }
 
@@ -92,10 +91,7 @@ class TestSDImg2ImgModel(BaseTest.TestModel):
         "rbln_config": {
             "vae": {
                 "sample_size": (64, 64),
-            },
-            "unet": {
-                "batch_size": 2,
-            },
+            }
         },
         "rbln_img_width": 64,
         "rbln_img_height": 64,
@@ -114,14 +110,6 @@ class TestSDControlNetModel(BaseTest.TestModel):
     RBLN_CLASS_KWARGS = {
         "rbln_img_width": 64,
         "rbln_img_height": 64,
-        "rbln_config": {
-            "controlnet": {
-                "batch_size": 2,
-            },
-            "unet": {
-                "batch_size": 2,
-            },
-        },
     }
 
     @classmethod
@@ -144,14 +132,6 @@ class TestSDXLControlNetModel(BaseTest.TestModel):
     RBLN_CLASS_KWARGS = {
         "rbln_img_width": 64,
         "rbln_img_height": 64,
-        "rbln_config": {
-            "unet": {
-                "batch_size": 2,
-            },
-            "controlnet": {
-                "batch_size": 2,
-            },
-        },
     }
 
     @classmethod
@@ -171,10 +151,12 @@ class TestSD3Model(BaseTest.TestModel):
     }
     RBLN_CLASS_KWARGS = {
         "rbln_config": {
-            "transformer": {
-                "batch_size": 2,
-            }
-        }
+            "text_encoder": {"rbln_device": 0},
+            "text_encoder_2": {"rbln_device": 0},
+            "text_encoder_3": {"rbln_device": -1},
+            "transformer": {"rbln_device": 0},
+            "vae": {"rbln_device": 0},
+        },
     }
 
 
@@ -188,9 +170,14 @@ class TestSD3Img2ImgModel(BaseTest.TestModel):
         "image": torch.randn(1, 3, 64, 64, generator=torch.manual_seed(42)),
     }
     RBLN_CLASS_KWARGS = {
+        "rbln_img_width": 64,
+        "rbln_img_height": 64,
         "rbln_config": {
-            "image_size": (64, 64),
-            "transformer": {"batch_size": 2},
+            "text_encoder": {"rbln_device": 0},
+            "text_encoder_2": {"rbln_device": 0},
+            "text_encoder_3": {"rbln_device": -1},
+            "transformer": {"rbln_device": 0},
+            "vae": {"rbln_device": 0},
         },
     }
 
@@ -212,14 +199,6 @@ class TestSDMultiControlNetModel(BaseTest.TestModel):
     RBLN_CLASS_KWARGS = {
         "rbln_img_width": 64,
         "rbln_img_height": 64,
-        "rbln_config": {
-            "controlnet": {
-                "batch_size": 2,
-            },
-            "unet": {
-                "batch_size": 2,
-            },
-        },
     }
 
     @classmethod
@@ -242,10 +221,6 @@ class TestKandinskyV22Model(BaseTest.TestModel):
     RBLN_CLASS_KWARGS = {
         "rbln_img_width": 64,
         "rbln_img_height": 64,
-        "rbln_config": {
-            "prior_pipe": {"prior": {"batch_size": 2}},
-            "decoder_pipe": {"unet": {"batch_size": 2}},
-        },
     }
 
     def test_complicate_config(self):
@@ -262,19 +237,22 @@ class TestKandinskyV22Model(BaseTest.TestModel):
                 "batch_size": 2,
             },
             "batch_size": 1,
+            "prior_guidance_scale": 5.0,
+            "guidance_scale": 3.0,
         }
-        rbln_class_kwargs_copy = self.RBLN_CLASS_KWARGS.copy()
-        rbln_class_kwargs_copy["rbln_config"] = rbln_config
         with self.subTest():
             _ = self.RBLN_CLASS.from_pretrained(
                 model_id=self.HF_MODEL_ID,
                 export=True,
-                **rbln_class_kwargs_copy,
+                rbln_config=rbln_config,
+                **self.RBLN_CLASS_KWARGS,
             )
         with self.subTest():
-            self.assertEqual(_.prior_text_encoder.rbln_config.batch_size, 2)
-            self.assertEqual(_.prior_prior.rbln_config.batch_size, 4)
-            self.assertEqual(_.unet.rbln_config.batch_size, 2)
+            self.assertEqual(_.prior_text_encoder.rbln_config.model_cfg["batch_size"], 2)
+            self.assertEqual(_.prior_prior.rbln_config.model_cfg["batch_size"], 4)
+            self.assertEqual(_.prior_prior.rbln_config.model_cfg["guidance_scale"], 5.0)
+            self.assertEqual(_.unet.rbln_config.model_cfg["batch_size"], 2)
+            self.assertEqual(_.unet.rbln_config.model_cfg["guidance_scale"], 3.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -69,9 +69,10 @@ class TestSDXLModel(BaseTest.TestModel):
     # Fix incorrect tiny-sd-pipe-xl's vae config.json sample_size
     RBLN_CLASS_KWARGS = {
         "rbln_config": {
+            "unet": {"batch_size": 2},
             "vae": {
                 "sample_size": (64, 64),
-            }
+            },
         }
     }
 
@@ -91,7 +92,10 @@ class TestSDImg2ImgModel(BaseTest.TestModel):
         "rbln_config": {
             "vae": {
                 "sample_size": (64, 64),
-            }
+            },
+            "unet": {
+                "batch_size": 2,
+            },
         },
         "rbln_img_width": 64,
         "rbln_img_height": 64,
@@ -110,6 +114,14 @@ class TestSDControlNetModel(BaseTest.TestModel):
     RBLN_CLASS_KWARGS = {
         "rbln_img_width": 64,
         "rbln_img_height": 64,
+        "rbln_config": {
+            "controlnet": {
+                "batch_size": 2,
+            },
+            "unet": {
+                "batch_size": 2,
+            },
+        },
     }
 
     @classmethod
@@ -132,6 +144,14 @@ class TestSDXLControlNetModel(BaseTest.TestModel):
     RBLN_CLASS_KWARGS = {
         "rbln_img_width": 64,
         "rbln_img_height": 64,
+        "rbln_config": {
+            "unet": {
+                "batch_size": 2,
+            },
+            "controlnet": {
+                "batch_size": 2,
+            },
+        },
     }
 
     @classmethod
@@ -151,12 +171,10 @@ class TestSD3Model(BaseTest.TestModel):
     }
     RBLN_CLASS_KWARGS = {
         "rbln_config": {
-            "text_encoder": {"rbln_device": 0},
-            "text_encoder_2": {"rbln_device": 0},
-            "text_encoder_3": {"rbln_device": -1},
-            "transformer": {"rbln_device": 0},
-            "vae": {"rbln_device": 0},
-        },
+            "transformer": {
+                "batch_size": 2,
+            }
+        }
     }
 
 
@@ -170,14 +188,9 @@ class TestSD3Img2ImgModel(BaseTest.TestModel):
         "image": torch.randn(1, 3, 64, 64, generator=torch.manual_seed(42)),
     }
     RBLN_CLASS_KWARGS = {
-        "rbln_img_width": 64,
-        "rbln_img_height": 64,
         "rbln_config": {
-            "text_encoder": {"rbln_device": 0},
-            "text_encoder_2": {"rbln_device": 0},
-            "text_encoder_3": {"rbln_device": -1},
-            "transformer": {"rbln_device": 0},
-            "vae": {"rbln_device": 0},
+            "image_size": (64, 64),
+            "transformer": {"batch_size": 2},
         },
     }
 
@@ -199,6 +212,14 @@ class TestSDMultiControlNetModel(BaseTest.TestModel):
     RBLN_CLASS_KWARGS = {
         "rbln_img_width": 64,
         "rbln_img_height": 64,
+        "rbln_config": {
+            "controlnet": {
+                "batch_size": 2,
+            },
+            "unet": {
+                "batch_size": 2,
+            },
+        },
     }
 
     @classmethod
@@ -221,6 +242,10 @@ class TestKandinskyV22Model(BaseTest.TestModel):
     RBLN_CLASS_KWARGS = {
         "rbln_img_width": 64,
         "rbln_img_height": 64,
+        "rbln_config": {
+            "prior_pipe": {"prior": {"batch_size": 2}},
+            "decoder_pipe": {"unet": {"batch_size": 2}},
+        },
     }
 
     def test_complicate_config(self):
@@ -237,22 +262,19 @@ class TestKandinskyV22Model(BaseTest.TestModel):
                 "batch_size": 2,
             },
             "batch_size": 1,
-            "prior_guidance_scale": 5.0,
-            "guidance_scale": 3.0,
         }
+        rbln_class_kwargs_copy = self.RBLN_CLASS_KWARGS.copy()
+        rbln_class_kwargs_copy["rbln_config"] = rbln_config
         with self.subTest():
             _ = self.RBLN_CLASS.from_pretrained(
                 model_id=self.HF_MODEL_ID,
                 export=True,
-                rbln_config=rbln_config,
-                **self.RBLN_CLASS_KWARGS,
+                **rbln_class_kwargs_copy,
             )
         with self.subTest():
-            self.assertEqual(_.prior_text_encoder.rbln_config.model_cfg["batch_size"], 2)
-            self.assertEqual(_.prior_prior.rbln_config.model_cfg["batch_size"], 4)
-            self.assertEqual(_.prior_prior.rbln_config.model_cfg["guidance_scale"], 5.0)
-            self.assertEqual(_.unet.rbln_config.model_cfg["batch_size"], 2)
-            self.assertEqual(_.unet.rbln_config.model_cfg["guidance_scale"], 3.0)
+            self.assertEqual(_.prior_text_encoder.rbln_config.batch_size, 2)
+            self.assertEqual(_.prior_prior.rbln_config.batch_size, 4)
+            self.assertEqual(_.unet.rbln_config.batch_size, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_diffusers.py
+++ b/tests/test_diffusers.py
@@ -55,6 +55,7 @@ class TestSDModelBatch(BaseTest.TestModel):
                 "sample_size": (64, 64),
             },
         },
+        "rbln_guidance_scale": 0.0,
     }
 
 


### PR DESCRIPTION
# Pull Request Description

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] New Model Support
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

It is complicated from an API perspective for the user to specify the batch size for every submodule in the diffuser pipeline each time. Also, the current main implementation does not work with the example code specified in model_zoo or the user docs, which used to work. 

This PR changes it to compile by referencing the default value of the Huggingface library unless a batch size is otherwise specified.

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (If needed)

## Additional Information
<!-- Any additional information, configuration, or data that might be necessary to reproduce the issue or use the new feature -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only     
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update