### PR TITLE
other(runtime): Raise when failed to create runtime

### DIFF
--- a/src/optimum/rbln/modeling_base.py
+++ b/src/optimum/rbln/modeling_base.py
@@ -314,10 +314,15 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
             )
 
         except rebel.core.exception.RBLNRuntimeError as e:
-            logger.warning(
-                f"Failed to create the runtime for the model due to a runtime error: {e.__class__.__name__} - {e}"
+            error_msg = (
+                f"\nFailed to create RBLN runtime: {str(e)}\n\n"
+                f"If you only need to compile the model without loading it to NPU, you can use:\n"
+                f"  from_pretrained(..., rbln_create_runtimes=False) or\n"
+                f"  from_pretrained(..., rbln_config={{..., 'create_runtimes': False}})\n\n"
+                f"To check your NPU status, run the 'rbln-stat' command in your terminal.\n"
+                f"Make sure your NPU is properly installed and operational."
             )
-            models = UnavailableRuntime()
+            raise rebel.core.exception.RBLNRuntimeError(error_msg) from e
 
         return cls(
             models,

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -3,6 +3,7 @@ import shutil
 import unittest
 
 import torch
+from rebel.core.exception import RBLNRuntimeError
 from transformers import T5EncoderModel
 
 from optimum.rbln import (
@@ -77,7 +78,6 @@ class TestResNetModel(BaseTest.TestModel):
                     **self.HF_CONFIG_KWARGS,
                     **{
                         "torchscript": True,
-                        "return_dict": False,
                     },
                 )
                 _ = self.RBLN_CLASS.from_model(
@@ -86,6 +86,14 @@ class TestResNetModel(BaseTest.TestModel):
                     **self.HF_CONFIG_KWARGS,
                     preprocessors=preprocessors,  # For image_classification
                 )
+
+    def test_failed_to_create_runtime(self):
+        with self.assertRaises(RBLNRuntimeError):
+            _ = self.RBLN_CLASS.from_pretrained(
+                self.HF_MODEL_ID,
+                export=True,
+                rbln_device=[0, 1, 2, 3],
+            )
 
 
 class TestBertModel(BaseTest.TestModel):


### PR DESCRIPTION
# Pull Request Description

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] New Model Support
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

If the program does not die when the runtime fails to load, it will be discovered at a later inference point. This makes it difficult to spot and act on problems, so we update to raise an error immediately when runtime creation fails.

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (If needed)

## Additional Information
<!-- Any additional information, configuration, or data that might be necessary to reproduce the issue or use the new feature -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only     
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update