### PR TITLE
model: Cosmos VAE Decoder

### DIFF
--- a/src/optimum/rbln/diffusers/modeling_diffusers.py
+++ b/src/optimum/rbln/diffusers/modeling_diffusers.py
@@ -79,8 +79,8 @@ class RBLNDiffusionMixin:
         return "Inpaint" in cls.__name__
 
     @classmethod
-    def is_video_pipeline(cls):
-        return "Video" in cls.__name__
+    def is_img2vid_pipeline(cls):
+        return "VideoToWorld" in cls.__name__
 
     @classmethod
     def get_submodule_rbln_config(
@@ -104,7 +104,7 @@ class RBLNDiffusionMixin:
                 {
                     "img2img_pipeline": cls.is_img2img_pipeline(),
                     "inpaint_pipeline": cls.is_inpaint_pipeline(),
-                    "video_pipeline": cls.is_video_pipeline(),
+                    "img2vid_pipeline": cls.is_img2vid_pipeline(),
                 }
             )
             submodule_config = submodule_cls.update_rbln_config_using_pipe(model, submodule_config)

--- a/src/optimum/rbln/diffusers/modeling_diffusers.py
+++ b/src/optimum/rbln/diffusers/modeling_diffusers.py
@@ -79,7 +79,7 @@ class RBLNDiffusionMixin:
         return "Inpaint" in cls.__name__
 
     @classmethod
-    def is_img2vid_pipeline(cls):
+    def is_vid2vid_pipeline(cls):
         return "VideoToWorld" in cls.__name__
 
     @classmethod
@@ -104,7 +104,7 @@ class RBLNDiffusionMixin:
                 {
                     "img2img_pipeline": cls.is_img2img_pipeline(),
                     "inpaint_pipeline": cls.is_inpaint_pipeline(),
-                    "img2vid_pipeline": cls.is_img2vid_pipeline(),
+                    "vid2vid_pipeline": cls.is_vid2vid_pipeline(),
                 }
             )
             submodule_config = submodule_cls.update_rbln_config_using_pipe(model, submodule_config)

--- a/src/optimum/rbln/diffusers/models/autoencoders/autoencoder_kl_cosmos.py
+++ b/src/optimum/rbln/diffusers/models/autoencoders/autoencoder_kl_cosmos.py
@@ -91,44 +91,7 @@ class RBLNAutoencoderKLCosmos(RBLNModel):
 
         def compile_decoder_only():
             decoder_model = cls.wrap_model_if_needed(model, rbln_config)
-
-            class TempDecoder(torch.nn.Module):
-                def __init__(self):
-                    super().__init__()
-                    self.layer = torch.nn.Linear(16, 3)
-
-                def forward(self, z):
-                    output = self._decode(z, return_dict=False)
-                    return output
-
-                def _decode(self, z: torch.Tensor, return_dict: bool = True):
-                    # shape = [
-                    #     rbln_batch_size, rbln_num_channel_latents, rbln_num_latent_frames, rbln_latent_height, rbln_latent_width,
-                    # ],
-                    output = z.permute(0, 2, 3, 4, 1)
-                    output = self.layer(output).permute(0, 4, 1, 2, 3)
-                    output = torch.nn.functional.interpolate(output, size=(128, 704, 1280))
-                    dec = output[:, :, :121, :, :]
-
-                    # output = torch.Size([1, 3, 121, 704, 1280])
-                    if not return_dict:
-                        return (dec,)
-                    return DecoderOutput(sample=dec)
-
-                def decode(self, z: torch.Tensor, return_dict: bool = True):
-                    if self.use_slicing and z.shape[0] > 1:
-                        decoded_slices = [self._decode(z_slice).sample for z_slice in z.split(1)]
-                        decoded = torch.cat(decoded_slices)
-                    else:
-                        decoded = self._decode(z).sample
-
-                    if not return_dict:
-                        return (decoded,)
-                    return DecoderOutput(sample=decoded)
-
-            decoder_model_test = _VAECosmosDecoder(TempDecoder())
-            dec_compiled_model = cls.compile(decoder_model_test, rbln_compile_config=rbln_config.compile_cfgs[0])
-            # dec_compiled_model = cls.compile(decoder_model, rbln_compile_config=rbln_config.compile_cfgs[0])
+            dec_compiled_model = cls.compile(decoder_model, rbln_compile_config=rbln_config.compile_cfgs[0])
             return dec_compiled_model
 
         if rbln_config.model_cfg.get("img2vid_pipeline"):
@@ -269,7 +232,7 @@ class RBLNAutoencoderKLCosmos(RBLNModel):
         return AutoencoderKLOutput(latent_dist=posterior)
 
     def _decode(self, z: torch.FloatTensor, return_dict: bool = True) -> torch.FloatTensor:
-        dec = self.decoder.forward(z)
+        dec = self.decoder(z)
 
         if not return_dict:
             return (dec,)

--- a/src/optimum/rbln/diffusers/models/autoencoders/autoencoder_kl_cosmos.py
+++ b/src/optimum/rbln/diffusers/models/autoencoders/autoencoder_kl_cosmos.py
@@ -128,8 +128,8 @@ class RBLNAutoencoderKLCosmos(RBLNModel):
     ) -> RBLNConfig:
         # Since the Cosmos VAE Decoder already requires approximately 7.9 GiB of memory,
         # Optimum-rbln cannot execute this model on RBLN-CA12 when the batch size > 1.
-        # However, the Cosmos VAE Decoder enforces batch slicing when the batch size is greater than 1,
-        # Optimum-rbln adheres to this rule by compiling with batch_size=1 to enable batch slicing.
+        # However, the Cosmos VAE Decoder propose batch slicing when the batch size is greater than 1,
+        # Optimum-rbln utilize this method by compiling with batch_size=1 to enable batch slicing.
         rbln_batch_size = 1
         rbln_kwargs.update({"batch_size": 1})
 

--- a/src/optimum/rbln/diffusers/models/autoencoders/autoencoder_kl_cosmos.py
+++ b/src/optimum/rbln/diffusers/models/autoencoders/autoencoder_kl_cosmos.py
@@ -230,7 +230,7 @@ class RBLNAutoencoderKLCosmos(RBLNModel):
             for compiled_model, device_val in zip(compiled_models, device_vals)
         ]
 
-    def encode(self, x: torch.FloatTensor, return_dict: bool = True) -> torch.FloatTensor:
+    def encode(self, x: torch.FloatTensor, **kwargs) -> torch.FloatTensor:
         posterior = self.encoder.encode(x)
         return AutoencoderKLOutput(latent_dist=posterior)
 

--- a/src/optimum/rbln/diffusers/models/autoencoders/vae.py
+++ b/src/optimum/rbln/diffusers/models/autoencoders/vae.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, List
 
 import torch  # noqa: I001
 from diffusers import AutoencoderKL, VQModel
-from diffusers.models.autoencoders.vae import DiagonalGaussianDistribution, DecoderOutput
+from diffusers.models.autoencoders.vae import DiagonalGaussianDistribution
 from diffusers.models.autoencoders.vq_model import VQEncoderOutput
 from diffusers.models.modeling_outputs import AutoencoderKLOutput
 
@@ -41,6 +41,7 @@ class RBLNRuntimeVAEDecoder(RBLNPytorchRuntime):
     def decode(self, z: torch.FloatTensor, **kwargs) -> torch.FloatTensor:
         return (self.forward(z),)
 
+
 class _VAEDecoder(torch.nn.Module):
     def __init__(self, vae: "AutoencoderKL"):
         super().__init__()
@@ -50,6 +51,7 @@ class _VAEDecoder(torch.nn.Module):
         vae_out = self.vae.decode(z, return_dict=False)
         return vae_out
 
+
 class _VAECosmosDecoder(torch.nn.Module):
     def __init__(self, vae: "AutoencoderKL"):
         super().__init__()
@@ -58,6 +60,7 @@ class _VAECosmosDecoder(torch.nn.Module):
     def forward(self, z):
         vae_out = self.vae._decode(z, return_dict=False)
         return vae_out
+
 
 class _VAEEncoder(torch.nn.Module):
     def __init__(self, vae: "AutoencoderKL"):

--- a/src/optimum/rbln/diffusers/models/autoencoders/vae.py
+++ b/src/optimum/rbln/diffusers/models/autoencoders/vae.py
@@ -41,26 +41,6 @@ class RBLNRuntimeVAEDecoder(RBLNPytorchRuntime):
     def decode(self, z: torch.FloatTensor, **kwargs) -> torch.FloatTensor:
         return (self.forward(z),)
 
-class RBLNRuntimeCosmosVAEDecoder(RBLNPytorchRuntime):
-    def _decode(self, z: torch.FloatTensor, return_dict: bool = True) -> torch.FloatTensor:
-        dec = self.forward(z),
-        
-        if not return_dict:
-            return (dec,)
-        return DecoderOutput(sample=dec)
-    
-    def decode(self, z: torch.FloatTensor, return_dict: bool = True) -> torch.FloatTensor:
-        if z.shape[0] > 1:
-            decoded_slices = [self._decode(z_slice).sample for z_slice in z.split(1)]
-            decoded = torch.cat(decoded_slices)
-        else :
-            decoded = self._decode(z).sample
-        
-        if not return_dict:
-            return (decoded,)
-        
-        return DecoderOutput(sample=decoded)
-
 class _VAEDecoder(torch.nn.Module):
     def __init__(self, vae: "AutoencoderKL"):
         super().__init__()
@@ -76,7 +56,6 @@ class _VAECosmosDecoder(torch.nn.Module):
         self.vae = vae
 
     def forward(self, z):
-        import pdb; pdb.set_trace()
         vae_out = self.vae._decode(z, return_dict=False)
         return vae_out
 

--- a/src/optimum/rbln/diffusers/pipelines/__init__.py
+++ b/src/optimum/rbln/diffusers/pipelines/__init__.py
@@ -54,15 +54,15 @@ _import_structure = {
     ],
 }
 if TYPE_CHECKING:
-    from .cosmos import (
-        RBLNCosmosPipeline,
-    )
     from .controlnet import (
         RBLNMultiControlNetModel,
         RBLNStableDiffusionControlNetImg2ImgPipeline,
         RBLNStableDiffusionControlNetPipeline,
         RBLNStableDiffusionXLControlNetImg2ImgPipeline,
         RBLNStableDiffusionXLControlNetPipeline,
+    )
+    from .cosmos import (
+        RBLNCosmosPipeline,
     )
     from .kandinsky2_2 import (
         RBLNKandinskyV22CombinedPipeline,


### PR DESCRIPTION
# Pull Request Description
- Bug fix and validate the VAE decoder implementation in `CosmosPipeline`
- Support batch-dim slice implementation for dram memory usage
- Unified with other video generation task code formats(SVD, CogvideoX...)

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [X] New Model Support
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [X] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Checklist
<!-- Mark completed items with an [x] -->
- [X] I have performed a self-review of my own code
- [X] I have added tests that prove my fix is effective or that my feature works (If needed)

## Additional Information
<!-- Any additional information, configuration, or data that might be necessary to reproduce the issue or use the new feature -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only     
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update