### PR TITLE
model: integrate Cosmos World Foundation Model (#114)

### DIFF
--- a/examples/cosmos/run_cosmos_text2world.py
+++ b/examples/cosmos/run_cosmos_text2world.py
@@ -1,0 +1,69 @@
+import os
+from functools import partial
+from unittest.mock import patch
+
+import fire
+import torch
+from diffusers.pipelines.cosmos.cosmos_guardrail import CosmosSafetyChecker
+from diffusers.utils import export_to_video
+
+from optimum.rbln.diffusers.pipelines.cosmos import RBLNCosmosPipeline, RBLNCosmosSafetyChecker
+
+
+def main(
+    model_id: str = "nvidia/Cosmos-1.0-Diffusion-7B-Text2World",
+    from_diffusers: bool = False,
+    prompt: str = "an illustration of a cute white cat riding a black horse on mars",
+    steps: int = 36,
+):
+    model_id = "/mnt/shared_data/users/dkhong/nas_data/cosmos_examples/CosmosPredict1"  # FIXME: For test
+    if from_diffusers:
+        safety_checker_dir = "cosmos_safety_checker"
+        with patch("torch.load", partial(torch.load, weights_only=True, map_location=torch.device("cpu"))):
+            model = CosmosSafetyChecker()
+        checker = RBLNCosmosSafetyChecker.compile_submodules(
+            model=model,
+            model_save_dir=safety_checker_dir,
+            rbln_config={
+                "text_guardrail": {
+                    "device": [
+                        0,
+                        1,
+                        2,
+                        3,
+                    ]
+                },
+                "video_guardrail": {"device": 0},
+            },
+        )
+        pipe = RBLNCosmosPipeline.from_pretrained(model_id, safety_checker=checker, export=True)
+        pipe.save_pretrained(os.path.basename(model_id))
+    else:
+        safety_checker_dir = "cosmos_safety_checker"
+        with patch("torch.load", partial(torch.load, weights_only=True, map_location=torch.device("cpu"))):
+            model = CosmosSafetyChecker()
+        checker = RBLNCosmosSafetyChecker.load_submodules(
+            model=model,
+            model_save_dir=safety_checker_dir,
+            rbln_config={
+                "text_guardrail": {
+                    "device": [
+                        0,
+                        1,
+                        2,
+                        3,
+                    ]
+                },
+                "video_guardrail": {"device": 0},
+            },
+        )
+        pipe = RBLNCosmosPipeline.from_pretrained(model_id, safety_checker=checker, export=False)
+
+    prompt = "A sleek, humanoid robot stands in a vast warehouse filled with neatly stacked cardboard boxes on industrial shelves. The robot's metallic body gleams under the bright, even lighting, highlighting its futuristic design and intricate joints. A glowing blue light emanates from its chest, adding a touch of advanced technology. The background is dominated by rows of boxes, suggesting a highly organized storage system. The floor is lined with wooden pallets, enhancing the industrial setting. The camera remains static, capturing the robot's poised stance amidst the orderly environment, with a shallow depth of field that keeps the focus on the robot while subtly blurring the background for a cinematic effect."
+
+    output = pipe(prompt=prompt, num_inference_steps=steps).frames[0]
+    export_to_video(output, "output.mp4", fps=30)
+
+
+if __name__ == "__main__":
+    fire.Fire(main)

--- a/src/optimum/rbln/__init__.py
+++ b/src/optimum/rbln/__init__.py
@@ -120,8 +120,10 @@ _import_structure = {
     "diffusers": [
         "RBLNAutoencoderKL",
         "RBLNAutoencoderKLConfig",
+        "RBLNAutoencoderKLCosmosConfig",
         "RBLNControlNetModel",
         "RBLNControlNetModelConfig",
+        "RBLNCosmosTransformer3DModelConfig",
         "RBLNDiffusionMixin",
         "RBLNKandinskyV22CombinedPipeline",
         "RBLNKandinskyV22CombinedPipelineConfig",
@@ -172,6 +174,9 @@ _import_structure = {
         "RBLNUNet2DConditionModelConfig",
         "RBLNVQModel",
         "RBLNVQModelConfig",
+        "RBLNRetinaFaceConfig",
+        "RBLNSiglipVisionModelConfig",
+        "RBLNVideoSafetyModelConfig",
     ],
 }
 
@@ -183,8 +188,10 @@ if TYPE_CHECKING:
     from .diffusers import (
         RBLNAutoencoderKL,
         RBLNAutoencoderKLConfig,
+        RBLNAutoencoderKLCosmosConfig,
         RBLNControlNetModel,
         RBLNControlNetModelConfig,
+        RBLNCosmosTransformer3DModelConfig,
         RBLNDiffusionMixin,
         RBLNKandinskyV22CombinedPipeline,
         RBLNKandinskyV22CombinedPipelineConfig,
@@ -203,8 +210,10 @@ if TYPE_CHECKING:
         RBLNMultiControlNetModel,
         RBLNPriorTransformer,
         RBLNPriorTransformerConfig,
+        RBLNRetinaFaceConfig,
         RBLNSD3Transformer2DModel,
         RBLNSD3Transformer2DModelConfig,
+        RBLNSiglipVisionModelConfig,
         RBLNStableDiffusion3Img2ImgPipeline,
         RBLNStableDiffusion3Img2ImgPipelineConfig,
         RBLNStableDiffusion3InpaintPipeline,
@@ -233,6 +242,7 @@ if TYPE_CHECKING:
         RBLNStableDiffusionXLPipelineConfig,
         RBLNUNet2DConditionModel,
         RBLNUNet2DConditionModelConfig,
+        RBLNVideoSafetyModelConfig,
         RBLNVQModel,
         RBLNVQModelConfig,
     )

--- a/src/optimum/rbln/diffusers/__init__.py
+++ b/src/optimum/rbln/diffusers/__init__.py
@@ -25,7 +25,9 @@ ALL_IMPORTABLE_CLASSES.update(LOADABLE_CLASSES["optimum.rbln"])
 _import_structure = {
     "configurations": [
         "RBLNAutoencoderKLConfig",
+        "RBLNAutoencoderKLCosmosConfig",
         "RBLNControlNetModelConfig",
+        "RBLNCosmosTransformer3DModelConfig",
         "RBLNKandinskyV22CombinedPipelineConfig",
         "RBLNKandinskyV22Img2ImgCombinedPipelineConfig",
         "RBLNKandinskyV22Img2ImgPipelineConfig",
@@ -50,6 +52,9 @@ _import_structure = {
         "RBLNSD3Transformer2DModelConfig",
         "RBLNUNet2DConditionModelConfig",
         "RBLNVQModelConfig",
+        "RBLNRetinaFaceConfig",
+        "RBLNSiglipVisionModelConfig",
+        "RBLNVideoSafetyModelConfig",
     ],
     "pipelines": [
         "RBLNKandinskyV22CombinedPipeline",
@@ -90,7 +95,9 @@ _import_structure = {
 if TYPE_CHECKING:
     from .configurations import (
         RBLNAutoencoderKLConfig,
+        RBLNAutoencoderKLCosmosConfig,
         RBLNControlNetModelConfig,
+        RBLNCosmosTransformer3DModelConfig,
         RBLNKandinskyV22CombinedPipelineConfig,
         RBLNKandinskyV22Img2ImgCombinedPipelineConfig,
         RBLNKandinskyV22Img2ImgPipelineConfig,
@@ -99,7 +106,9 @@ if TYPE_CHECKING:
         RBLNKandinskyV22PipelineConfig,
         RBLNKandinskyV22PriorPipelineConfig,
         RBLNPriorTransformerConfig,
+        RBLNRetinaFaceConfig,
         RBLNSD3Transformer2DModelConfig,
+        RBLNSiglipVisionModelConfig,
         RBLNStableDiffusion3Img2ImgPipelineConfig,
         RBLNStableDiffusion3InpaintPipelineConfig,
         RBLNStableDiffusion3PipelineConfig,
@@ -114,6 +123,7 @@ if TYPE_CHECKING:
         RBLNStableDiffusionXLInpaintPipelineConfig,
         RBLNStableDiffusionXLPipelineConfig,
         RBLNUNet2DConditionModelConfig,
+        RBLNVideoSafetyModelConfig,
         RBLNVQModelConfig,
     )
     from .modeling_diffusers import RBLNDiffusionMixin

--- a/src/optimum/rbln/diffusers/configurations/__init__.py
+++ b/src/optimum/rbln/diffusers/configurations/__init__.py
@@ -1,9 +1,14 @@
 from .models import (
     RBLNAutoencoderKLConfig,
+    RBLNAutoencoderKLCosmosConfig,
     RBLNControlNetModelConfig,
+    RBLNCosmosTransformer3DModelConfig,
     RBLNPriorTransformerConfig,
+    RBLNRetinaFaceConfig,
     RBLNSD3Transformer2DModelConfig,
+    RBLNSiglipVisionModelConfig,
     RBLNUNet2DConditionModelConfig,
+    RBLNVideoSafetyModelConfig,
     RBLNVQModelConfig,
 )
 from .pipelines import (

--- a/src/optimum/rbln/diffusers/configurations/models/__init__.py
+++ b/src/optimum/rbln/diffusers/configurations/models/__init__.py
@@ -1,5 +1,12 @@
 from .configuration_autoencoder_kl import RBLNAutoencoderKLConfig
+from .configuration_autoencoder_kl_cosmos import RBLNAutoencoderKLCosmosConfig
 from .configuration_controlnet import RBLNControlNetModelConfig
+from .configuration_cosmos_guardrail import (
+    RBLNRetinaFaceConfig,
+    RBLNSiglipVisionModelConfig,
+    RBLNVideoSafetyModelConfig,
+)
+from .configuration_cosmos_transformer import RBLNCosmosTransformer3DModelConfig
 from .configuration_prior_transformer import RBLNPriorTransformerConfig
 from .configuration_transformer_sd3 import RBLNSD3Transformer2DModelConfig
 from .configuration_unet_2d_condition import RBLNUNet2DConditionModelConfig

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_autoencoder_kl_cosmos.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_autoencoder_kl_cosmos.py
@@ -1,0 +1,74 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+from ....configuration_utils import RBLNModelConfig
+from ....utils.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+class RBLNAutoencoderKLCosmosConfig(RBLNModelConfig):
+    def __init__(
+        self,
+        batch_size: Optional[int] = None,
+        uses_encoder: Optional[bool] = None,
+        num_frames: Optional[int] = None,
+        height: Optional[int] = None,
+        width: Optional[int] = None,
+        num_channel_latents: Optional[int] = None,
+        num_latent_frames: Optional[int] = None,
+        latent_height: Optional[int] = None,
+        latent_width: Optional[int] = None,
+        in_channels: Optional[int] = None,
+        **kwargs,
+    ):
+        """
+        Args:
+            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
+            uses_encoder (Optional[bool]): Whether to include the encoder part of the VAE in the model.
+                When False, only the decoder is used (for latent-to-image conversion).
+            **kwargs: Additional arguments passed to the parent RBLNModelConfig.
+
+        Raises:
+            ValueError: If batch_size is not a positive integer.
+        """
+        super().__init__(**kwargs)
+        # Since the Cosmos VAE Decoder already requires approximately 7.9 GiB of memory,
+        # Optimum-rbln cannot execute this model on RBLN-CA12 when the batch size > 1.
+        # However, the Cosmos VAE Decoder propose batch slicing when the batch size is greater than 1,
+        # Optimum-rbln utilize this method by compiling with batch_size=1 to enable batch slicing.
+        self.batch_size = batch_size or 1
+        if not isinstance(self.batch_size, int) or self.batch_size < 0:
+            raise ValueError(f"batch_size must be a positive integer, got {self.batch_size}")
+        elif self.batch_size > 1:
+            logger.warning("The batch size of Cosmos VAE Decoder will be explicitly 1 for memory efficiency.")
+            self.batch_size = 1
+
+        self.uses_encoder = uses_encoder
+        self.num_frames = num_frames or 121
+        self.height = height or 704
+        self.width = width or 1280
+
+        self.num_channel_latents = num_channel_latents
+        self.num_latent_frames = num_latent_frames
+        self.latent_height = self.latent_height
+        self.latent_width = latent_width
+        self.in_channels = in_channels
+
+    @property
+    def image_size(self):
+        return [self.height, self.width]

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_cosmos_guardrail.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_cosmos_guardrail.py
@@ -1,0 +1,86 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+from ....configuration_utils import RBLNModelConfig
+from ....utils.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+class RBLNRetinaFaceConfig(RBLNModelConfig):
+    def __init__(
+        self,
+        batch_size: Optional[int] = None,
+        height: Optional[int] = None,
+        width: Optional[int] = None,
+        **kwargs,
+    ):
+        """
+        Args:
+            height (Optional[int]): The width of input for inference. Defaults to 704.
+            width (Optional[int]): The width of input for inference. Defaults to 1280.
+            **kwargs: Additional arguments passed to the parent RBLNModelConfig.
+
+        Raises:
+            ValueError: If batch_size is not a positive integer.
+        """
+        super().__init__(**kwargs)
+        self.batch_size = 1  # hard coded
+        self.height = height or 704
+        self.width = width or 1280
+
+
+class RBLNVideoSafetyModelConfig(RBLNModelConfig):
+    def __init__(
+        self,
+        batch_size: Optional[int] = None,
+        input_size: Optional[int] = None,
+        **kwargs,
+    ):
+        """
+        Args:
+            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
+            **kwargs: Additional arguments passed to the parent RBLNModelConfig.
+
+        Raises:
+            ValueError: If batch_size is not a positive integer.
+        """
+        super().__init__(**kwargs)
+        self.batch_size = batch_size or 1
+        self.input_size = 1152  # hard coded
+
+
+class RBLNSiglipVisionModelConfig(RBLNModelConfig):
+    def __init__(
+        self,
+        batch_size: Optional[int] = None,
+        height: Optional[int] = None,
+        width: Optional[int] = None,
+        **kwargs,
+    ):
+        """
+        Args:
+            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
+            **kwargs: Additional arguments passed to the parent RBLNModelConfig.
+
+        Raises:
+            ValueError: If batch_size is not a positive integer.
+        """
+        super().__init__(**kwargs)
+        self.batch_size = batch_size or 1
+        self.height = 384  # hard coded
+        self.width = 384  # hard coded

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_cosmos_transformer.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_cosmos_transformer.py
@@ -1,0 +1,64 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+from ....configuration_utils import RBLNModelConfig
+
+
+class RBLNCosmosTransformer3DModelConfig(RBLNModelConfig):
+    def __init__(
+        self,
+        batch_size: Optional[int] = None,
+        max_sequence_length: Optional[int] = None,
+        num_frames: Optional[int] = None,
+        height: Optional[int] = None,
+        width: Optional[int] = None,
+        fps: Optional[int] = None,
+        num_channel_latents: Optional[int] = None,
+        num_latent_frames: Optional[int] = None,
+        latent_height: Optional[int] = None,
+        latent_width: Optional[int] = None,
+        hidden_size: Optional[int] = None,
+        embedding_dim: Optional[int] = None,
+        time_proj_num_channels: Optional[int] = None,
+        prompt_embed_length: Optional[int] = None,
+        **kwargs,
+    ):
+        """
+        Args:
+            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
+            **kwargs: Additional arguments passed to the parent RBLNModelConfig.
+
+        Raises:
+            ValueError: If batch_size is not a positive integer.
+        """
+        super().__init__(**kwargs)
+        self.batch_size = batch_size or 1
+        self.max_sequence_length = max_sequence_length or 512
+        self.num_frames = num_frames or 121
+        self.height = height or 704
+        self.width = width or 1280
+        self.fps = fps or 30
+
+        self.num_channel_latents = num_channel_latents
+        self.num_latent_frames = num_latent_frames
+        self.latent_height = latent_height
+        self.latent_width = latent_width
+        self.hidden_size = hidden_size
+        self.embedding_dim = embedding_dim
+        self.time_proj_num_channels = time_proj_num_channels
+
+        if not isinstance(self.batch_size, int) or self.batch_size < 0:
+            raise ValueError(f"batch_size must be a positive integer, got {self.batch_size}")

--- a/src/optimum/rbln/diffusers/modeling_diffusers.py
+++ b/src/optimum/rbln/diffusers/modeling_diffusers.py
@@ -76,6 +76,7 @@ class RBLNDiffusionMixin:
     _submodules = []
     _prefix = {}
     _rbln_config_class = None
+    _optional_components = []
 
     @classmethod
     def is_img2img_pipeline(cls):
@@ -267,8 +268,8 @@ class RBLNDiffusionMixin:
                     controlnet_rbln_config=getattr(rbln_config, submodule_name),
                     prefix=prefix,
                 )
-            elif isinstance(submodule, torch.nn.Module):
-                submodule_cls: RBLNModel = getattr(
+            elif isinstance(submodule, torch.nn.Module):  # for pretrainedmodel
+                submodule_cls: torch.nn.Module = getattr(
                     importlib.import_module("optimum.rbln"), f"RBLN{submodule.__class__.__name__}"
                 )
                 subfolder = prefix + submodule_name

--- a/src/optimum/rbln/diffusers/models/autoencoders/autoencoder_kl_cosmos.py
+++ b/src/optimum/rbln/diffusers/models/autoencoders/autoencoder_kl_cosmos.py
@@ -1,0 +1,215 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TYPE_CHECKING, Dict, List, Union
+
+import rebel
+import torch
+from diffusers.models.autoencoders.autoencoder_kl_cosmos import AutoencoderKLCosmos, CosmosCausalConv3d
+from diffusers.models.autoencoders.vae import DecoderOutput
+from diffusers.models.modeling_outputs import AutoencoderKLOutput
+from torch.nn import functional as F
+from transformers import PretrainedConfig
+
+from ....configuration_utils import RBLNCompileConfig
+from ....modeling import RBLNModel
+from ....utils.logging import get_logger
+from ...configurations import RBLNAutoencoderKLCosmosConfig
+from .vae import RBLNRuntimeVAEDecoder, _VAECosmosDecoder
+
+
+if TYPE_CHECKING:
+    import torch
+    from transformers import AutoFeatureExtractor, AutoProcessor, AutoTokenizer, PretrainedConfig, PreTrainedModel
+
+    from ...modeling_diffusers import RBLNDiffusionMixin, RBLNDiffusionMixinConfig
+
+logger = get_logger(__name__)
+
+
+def replaced_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    if self.temporal_pad != 0:
+        hidden_states_prev = hidden_states[:, :, :1, ...].repeat(1, 1, self.temporal_pad, 1, 1)
+        hidden_states = torch.cat([hidden_states_prev, hidden_states], dim=2)
+    hidden_states = F.pad(hidden_states, (*self.spatial_pad, 0, 0), mode=self.pad_mode, value=0.0)
+    return super(CosmosCausalConv3d, self).forward(hidden_states)
+
+
+class RBLNAutoencoderKLCosmos(RBLNModel):
+    auto_model_class = AutoencoderKLCosmos
+    hf_library_name = "diffusers"
+    _rbln_config_class = RBLNAutoencoderKLCosmosConfig
+
+    def __post_init__(self, **kwargs):
+        super().__post_init__(**kwargs)
+
+        if self.rbln_config.uses_encoder:
+            logger.warning("We currently support Text to World pipeline only.")
+            self.rbln_config.uses_encoder = False
+
+        self.encoder = None
+        self.decoder = RBLNRuntimeVAEDecoder(runtime=self.model[-1], main_input_name="z")
+        self.image_size = self.rbln_config.image_size
+
+    @classmethod
+    def wrap_model_if_needed(
+        cls, model: torch.nn.Module, rbln_config: RBLNAutoencoderKLCosmosConfig
+    ) -> torch.nn.Module:
+        def replace_forward_func(model):
+            for name, module in model.named_children():
+                if isinstance(module, CosmosCausalConv3d) and module.temporal_pad == 0:
+                    module.forward = replaced_forward.__get__(module, module.__class__)
+                else:
+                    replace_forward_func(module)
+
+        replace_forward_func(model)
+        if rbln_config.uses_encoder:
+            logger.warning("We currently support Text to World pipeline only.")
+            rbln_config.uses_encoder = False
+        decoder_model = _VAECosmosDecoder(model)
+        decoder_model.eval()
+        return decoder_model
+
+    @classmethod
+    def get_compiled_model(
+        cls, model, rbln_config: RBLNAutoencoderKLCosmosConfig
+    ) -> Dict[str, rebel.RBLNCompiledModel]:
+        def compile_encoder_decoder():
+            encoder_model, decoder_model = cls.wrap_model_if_needed(model, rbln_config)
+            enc_compiled_model = cls.compile(encoder_model, rbln_compile_config=rbln_config.compile_cfgs[0])
+            dec_compiled_model = cls.compile(decoder_model, rbln_compile_config=rbln_config.compile_cfgs[1])
+            return {"encoder": enc_compiled_model, "decoder": dec_compiled_model}
+
+        def compile_decoder_only():
+            decoder_model = cls.wrap_model_if_needed(model, rbln_config)
+            dec_compiled_model = cls.compile(decoder_model, rbln_compile_config=rbln_config.compile_cfgs[0])
+            return dec_compiled_model
+
+        return compile_decoder_only()
+
+    @classmethod
+    def update_rbln_config_using_pipe(
+        cls, pipe: RBLNDiffusionMixin, rbln_config: "RBLNDiffusionMixinConfig", submodule_name: str
+    ) -> "RBLNDiffusionMixinConfig":
+        num_channel_latents = pipe.transformer.config.in_channels
+        num_latent_frames = (rbln_config.num_frames - 1) // pipe.vae_scale_factor_temporal + 1
+        latent_height = rbln_config.height // pipe.vae_scale_factor_spatial
+        latent_width = rbln_config.width // pipe.vae_scale_factor_spatial
+
+        rbln_config.update(
+            {
+                "num_channel_latents": num_channel_latents,
+                "num_latent_frames": num_latent_frames,
+                "latent_height": latent_height,
+                "latent_width": latent_width,
+            }
+        )
+        return rbln_config
+
+    @classmethod
+    def _update_rbln_config(
+        cls,
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"],
+        model: "PreTrainedModel",
+        model_config: "PretrainedConfig",
+        rbln_config: RBLNAutoencoderKLCosmosConfig,
+    ) -> RBLNAutoencoderKLCosmosConfig:
+        compile_cfgs = []
+        if rbln_config.uses_encoder:
+            rbln_config.in_channels = model_config.in_channels if hasattr(model_config, "in_channels") else 3
+
+            vae_enc_input_info = [
+                (
+                    "x",
+                    [
+                        rbln_config.batch_size,
+                        rbln_config.in_channels,
+                        rbln_config.num_frames,
+                        rbln_config.height,
+                        rbln_config.width,
+                    ],
+                    "float32",
+                ),
+            ]
+            compile_cfgs.append(RBLNCompileConfig(compiled_model_name="encoder", input_info=vae_enc_input_info))
+
+        vae_dec_input_info = [
+            (
+                "z",
+                [
+                    rbln_config.batch_size,
+                    rbln_config.num_channel_latents,
+                    rbln_config.num_latent_frames,
+                    rbln_config.latent_height,
+                    rbln_config.latent_width,
+                ],
+                "float32",
+            ),
+        ]
+        compile_cfgs.append(RBLNCompileConfig(compiled_model_name="decoder", input_info=vae_dec_input_info))
+
+        rbln_config.set_compile_cfgs(compile_cfgs)
+        return rbln_config
+
+    @classmethod
+    def _create_runtimes(
+        cls,
+        compiled_models: List[rebel.RBLNCompiledModel],
+        rbln_config: RBLNAutoencoderKLCosmosConfig,
+    ) -> List[rebel.Runtime]:
+        if len(compiled_models) == 1:
+            # decoder
+            expected_models = ["decoder"]
+        else:
+            # encoder, decoder
+            expected_models = ["encoder", "decoder"]
+
+        if any(model_name not in rbln_config.device_map for model_name in expected_models):
+            cls._raise_missing_compiled_file_error(expected_models)
+
+        device_vals = [rbln_config.device_map[model_name] for model_name in expected_models]
+        return [
+            rebel.Runtime(
+                compiled_model,
+                tensor_type="pt",
+                device=device_val,
+                activate_profiler=rbln_config.activate_profiler,
+            )
+            for compiled_model, device_val in zip(compiled_models, device_vals)
+        ]
+
+    def encode(self, x: torch.FloatTensor, return_dict: bool = True, **kwargs) -> torch.FloatTensor:
+        posterior = self.encoder.encode(x)
+        if not return_dict:
+            return (posterior,)
+        return AutoencoderKLOutput(latent_dist=posterior)
+
+    def _decode(self, z: torch.FloatTensor, return_dict: bool = True) -> torch.FloatTensor:
+        dec = self.decoder(z)
+
+        if not return_dict:
+            return (dec,)
+        return DecoderOutput(sample=dec)
+
+    def decode(self, z: torch.FloatTensor, return_dict: bool = True) -> torch.FloatTensor:
+        if z.shape[0] > 1:
+            decoded_slices = [self._decode(z_slice).sample for z_slice in z.split(1)]
+            decoded = torch.cat(decoded_slices)
+        else:
+            decoded = self._decode(z).sample
+
+        if not return_dict:
+            return (decoded,)
+
+        return DecoderOutput(sample=decoded)

--- a/src/optimum/rbln/diffusers/models/autoencoders/vae.py
+++ b/src/optimum/rbln/diffusers/models/autoencoders/vae.py
@@ -50,6 +50,16 @@ class _VAEDecoder(torch.nn.Module):
         return vae_out
 
 
+class _VAECosmosDecoder(torch.nn.Module):
+    def __init__(self, vae: "AutoencoderKL"):
+        super().__init__()
+        self.vae = vae
+
+    def forward(self, z):
+        vae_out = self.vae._decode(z, return_dict=False)
+        return vae_out
+
+
 class _VAEEncoder(torch.nn.Module):
     def __init__(self, vae: "AutoencoderKL"):
         super().__init__()

--- a/src/optimum/rbln/diffusers/models/transformers/transformer_cosmos.py
+++ b/src/optimum/rbln/diffusers/models/transformers/transformer_cosmos.py
@@ -1,0 +1,374 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional, Tuple, Union
+
+import numpy as np
+import torch
+from diffusers import CosmosTransformer3DModel
+from diffusers.models.embeddings import Timesteps
+from diffusers.pipelines.cosmos.pipeline_cosmos import retrieve_timesteps
+
+from ....configuration_utils import RBLNCompileConfig, RBLNModelConfig
+from ....modeling import RBLNModel
+from ....utils.logging import get_logger
+from ...configurations import RBLNCosmosTransformer3DModelConfig
+
+
+if TYPE_CHECKING:
+    from transformers import AutoFeatureExtractor, AutoProcessor, AutoTokenizer, PretrainedConfig, PreTrainedModel
+
+    from ...modeling_diffusers import RBLNCosmosTransformer3DModelConfig, RBLNDiffusionMixin
+
+
+logger = get_logger(__name__)
+
+
+class CosmosTransformer3DModelWrapper(torch.nn.Module):
+    def __init__(
+        self,
+        model: CosmosTransformer3DModel,
+        num_latent_frames: int = 16,
+        latent_height: int = 88,
+        latent_width: int = 160,
+        hidden_size: int = 4096,
+        fps: int = 30,
+    ) -> None:
+        super().__init__()
+        self.model = model
+        self.set_rope(num_latent_frames, latent_height, latent_width, fps)
+        self.set_learnable_pos_emb(num_latent_frames, latent_height, latent_width, hidden_size)
+        self.set_time_embed()
+
+    def set_rope(self, num_latent_frames, latent_height, latent_width, fps):
+        self.model.rope = RBLNCosmosRotaryPosEmbed(
+            self.model.rope, num_latent_frames, latent_height, latent_width, fps
+        )
+
+    def set_learnable_pos_emb(self, num_latent_frames, latent_height, latent_width, hidden_size):
+        native_lpoe = self.model.learnable_pos_embed
+        patch_size = native_lpoe.patch_size
+        eps = native_lpoe.eps
+        batch_size = 1
+        pe_size = [num_latent_frames // patch_size[0], latent_height // patch_size[1], latent_width // patch_size[2]]
+        emb_t = native_lpoe.pos_emb_t[: pe_size[0]][None, :, None, None, :].repeat(
+            batch_size, 1, pe_size[1], pe_size[2], 1
+        )
+        emb_h = native_lpoe.pos_emb_h[: pe_size[1]][None, None, :, None, :].repeat(
+            batch_size, pe_size[0], 1, pe_size[2], 1
+        )
+        emb_w = native_lpoe.pos_emb_w[: pe_size[2]][None, None, None, :, :].repeat(
+            batch_size, pe_size[0], pe_size[1], 1, 1
+        )
+
+        self.model.learnable_pos_embed = RBLNCosmosLearnablePositionalEmbed(
+            emb_t.data, emb_h.data, emb_w.data, hidden_size, eps
+        ).train(self.model.training)
+
+    def set_time_embed(self):
+        self.model.time_embed = RBLNCosmosEmbedding(self.model.time_embed)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        padding_mask: Optional[torch.Tensor] = None,
+        fps: Optional[int] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        condition_mask: Optional[torch.Tensor] = None,
+        return_dict: bool = True,
+    ):
+        return self.model(
+            hidden_states=hidden_states,
+            timestep=timestep,
+            encoder_hidden_states=encoder_hidden_states,
+            fps=fps,
+            padding_mask=padding_mask,
+            return_dict=False,
+        )
+
+
+class RBLNCosmosRotaryPosEmbed(torch.nn.Module):
+    def __init__(
+        self,
+        rope,
+        num_latent_frames,
+        latent_height,
+        latent_width,
+        fps=None,
+    ) -> None:
+        super().__init__()
+
+        self.max_size = rope.max_size
+        self.patch_size = rope.patch_size
+        self.base_fps = rope.base_fps
+
+        self.dim_h = rope.dim_h
+        self.dim_w = rope.dim_w
+        self.dim_t = rope.dim_t
+
+        self.h_ntk_factor = rope.h_ntk_factor
+        self.w_ntk_factor = rope.w_ntk_factor
+        self.t_ntk_factor = rope.t_ntk_factor
+
+        seq = torch.arange(max(self.max_size), dtype=torch.float32)
+        pe_size = [
+            num_latent_frames // self.patch_size[0],
+            latent_height // self.patch_size[1],
+            latent_width // self.patch_size[2],
+        ]
+
+        h_theta = 10000.0 * self.h_ntk_factor
+        w_theta = 10000.0 * self.w_ntk_factor
+        t_theta = 10000.0 * self.t_ntk_factor
+
+        dim_h_range = torch.arange(0, self.dim_h, 2, dtype=torch.float32)[: (self.dim_h // 2)] / self.dim_h
+        dim_w_range = torch.arange(0, self.dim_w, 2, dtype=torch.float32)[: (self.dim_w // 2)] / self.dim_w
+        dim_t_range = torch.arange(0, self.dim_t, 2, dtype=torch.float32)[: (self.dim_t // 2)] / self.dim_t
+
+        h_spatial_freqs = 1.0 / (h_theta**dim_h_range)
+        w_spatial_freqs = 1.0 / (w_theta**dim_w_range)
+        temporal_freqs = 1.0 / (t_theta**dim_t_range)
+
+        emb_h = torch.outer(seq[: pe_size[1]], h_spatial_freqs)[None, :, None, :].repeat(pe_size[0], 1, pe_size[2], 1)
+        emb_w = torch.outer(seq[: pe_size[2]], w_spatial_freqs)[None, None, :, :].repeat(pe_size[0], pe_size[1], 1, 1)
+
+        if fps is None:
+            emb_t = torch.outer(seq[: pe_size[0]], temporal_freqs)
+        else:
+            emb_t = torch.outer(seq[: pe_size[0]] / fps * self.base_fps, temporal_freqs)
+
+        emb_t = emb_t[:, None, None, :].repeat(1, pe_size[1], pe_size[2], 1)
+        freqs = torch.cat([emb_t, emb_h, emb_w] * 2, dim=-1).flatten(0, 2).float()
+        self.cos = torch.cos(freqs)
+        self.sin = torch.sin(freqs)
+
+    def forward(self, hidden_states: torch.Tensor, fps: Optional[int] = None) -> Tuple[torch.Tensor, torch.Tensor]:
+        return self.cos.to(dtype=hidden_states.dtype), self.sin.to(dtype=hidden_states.dtype)
+
+
+class RBLNCosmosLearnablePositionalEmbed(torch.nn.Module):
+    def __init__(
+        self,
+        emb_t,
+        emb_h,
+        emb_w,
+        hidden_size,
+        eps,
+    ) -> None:
+        super().__init__()
+
+        self.emb_t = emb_t
+        self.emb_h = emb_h
+        self.emb_w = emb_w
+        self.eps = eps
+        self.alpha = np.sqrt(1 / hidden_size)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        emb = self.emb_t + self.emb_h + self.emb_w
+        emb = emb.flatten(1, 3)
+        norm = torch.linalg.vector_norm(emb, dim=-1, keepdim=True, dtype=torch.float32)
+        norm = torch.add(self.eps, norm, alpha=self.alpha)
+        return (emb / norm).type_as(hidden_states)
+
+
+class RBLNCosmosEmbedding(torch.nn.Module):
+    def __init__(self, time_embed):
+        super().__init__()
+        self.time_proj = time_embed.time_proj
+        self.t_embedder = time_embed.t_embedder
+        self.norm = time_embed.norm
+
+    def forward(self, hidden_states, timesteps):
+        timesteps_proj = timesteps.type_as(hidden_states)
+        temb = self.t_embedder(timesteps_proj)
+        embedded_timestep = self.norm(timesteps_proj)
+        return temb, embedded_timestep
+
+
+class RBLNCosmosTransformer3DModel(RBLNModel):
+    hf_library_name = "diffusers"
+    auto_model_class = CosmosTransformer3DModel
+
+    def __post_init__(self, **kwargs):
+        super().__post_init__(**kwargs)
+        artifacts = torch.load(self.model_save_dir / self.subfolder / "torch_artifacts.pth", weights_only=False)
+        num_channels = artifacts["num_channels"]
+        flip_sin_to_cos = artifacts["flip_sin_to_cos"]
+        downscale_freq_shift = artifacts["downscale_freq_shift"]
+        scale = artifacts["scale"]
+        self.time_proj = Timesteps(
+            num_channels=num_channels,
+            flip_sin_to_cos=flip_sin_to_cos,
+            downscale_freq_shift=downscale_freq_shift,
+            scale=scale,
+        )
+
+    def get_time_embed_table(self, scheduler, num_inference_steps):
+        timesteps = retrieve_timesteps(scheduler, num_inference_steps)[0]
+
+        embedding_dim = self.time_proj.num_channels
+        flip_sin_to_cos = self.time_proj.flip_sin_to_cos
+        downscale_freq_shift = self.time_proj.downscale_freq_shift
+        scale = self.time_proj.scale
+
+        half_dim = embedding_dim // 2
+        max_period = 10000
+        exponent = -math.log(max_period) * torch.arange(start=0, end=half_dim, dtype=torch.float32)
+        exponent = exponent / (half_dim - downscale_freq_shift)
+
+        emb = torch.exp(exponent)
+        emb = timesteps[:, None].float() * emb[None, :]
+
+        emb = scale * emb
+        emb = torch.cat([torch.sin(emb), torch.cos(emb)], dim=-1)
+
+        if flip_sin_to_cos:
+            emb = torch.cat([emb[:, half_dim:], emb[:, :half_dim]], dim=-1)
+
+        if embedding_dim % 2 == 1:
+            emb = torch.nn.functional.pad(emb, (0, 1, 0, 0))
+
+        emb_dict = {}
+        for timestep, e in zip(timesteps, emb):
+            emb_dict[timestep.item()] = e.reshape(1, -1)
+
+        self._emb_cached = emb_dict
+
+    def time_embed_table(self, timestep):
+        emb = self._emb_cached[timestep[0].item()]
+        emb = emb.repeat(timestep.shape[0], 1)
+        return emb
+
+    @classmethod
+    def wrap_model_if_needed(cls, model: torch.nn.Module, rbln_config: RBLNModelConfig) -> torch.nn.Module:
+        num_latent_frames = rbln_config.num_latent_frames
+        latent_height = rbln_config.latent_height
+        latent_width = rbln_config.latent_width
+        hidden_size = rbln_config.hidden_size
+        fps = rbln_config.fps
+        return CosmosTransformer3DModelWrapper(
+            model=model,
+            num_latent_frames=num_latent_frames,
+            latent_height=latent_height,
+            latent_width=latent_width,
+            hidden_size=hidden_size,
+            fps=fps,
+        ).eval()
+
+    @classmethod
+    def update_rbln_config_using_pipe(
+        cls, pipe: "RBLNDiffusionMixin", rbln_config: "RBLNCosmosTransformer3DModelConfig", submodule_name: str
+    ) -> RBLNCosmosTransformer3DModelConfig:
+        rbln_config.num_channel_latents = pipe.transformer.config.in_channels
+        rbln_config.num_latent_frames = (rbln_config.num_frames - 1) // pipe.vae_scale_factor_temporal + 1
+        rbln_config.latent_height = rbln_config.height // pipe.vae_scale_factor_temporal
+        rbln_config.latent_width = rbln_config.width // pipe.vae_scale_factor_temporal
+        rbln_config.hidden_size = (
+            pipe.transformer.config.num_attention_heads * pipe.transformer.config.attention_head_dim
+        )
+        rbln_config.embedding_dim = pipe.text_encoder.encoder.embed_tokens.embedding_dim
+        rbln_config.time_proj_num_channels = pipe.transformer.time_embed.time_proj.num_channels
+
+        return rbln_config
+
+    @classmethod
+    def save_torch_artifacts(
+        cls,
+        model: "PreTrainedModel",
+        save_dir_path: Path,
+        subfolder: str,
+        rbln_config: RBLNModelConfig,
+    ):
+        time_proj = model.time_embed.time_proj
+        save_dict = {}
+        save_dict["num_channels"] = time_proj.num_channels
+        save_dict["flip_sin_to_cos"] = time_proj.flip_sin_to_cos
+        save_dict["downscale_freq_shift"] = time_proj.downscale_freq_shift
+        save_dict["scale"] = time_proj.scale
+        torch.save(save_dict, save_dir_path / subfolder / "torch_artifacts.pth")
+
+    @classmethod
+    def _update_rbln_config(
+        cls,
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"],
+        model: "PreTrainedModel",
+        model_config: "PretrainedConfig",
+        rbln_config: "RBLNCosmosTransformer3DModelConfig",
+    ) -> RBLNCosmosTransformer3DModelConfig:
+        input_info = [
+            (
+                "hidden_states",
+                [
+                    rbln_config.batch_size,
+                    rbln_config.num_channel_latents,
+                    rbln_config.num_latent_frames,
+                    rbln_config.latent_height,
+                    rbln_config.latent_width,
+                ],
+                "float32",
+            ),
+            ("timestep", [rbln_config.batch_size, rbln_config.time_proj_num_channels], "float32"),
+            (
+                "encoder_hidden_states",
+                [
+                    rbln_config.batch_size,
+                    rbln_config.max_sequence_length,
+                    rbln_config.embedding_dim,
+                ],
+                "float32",
+            ),
+            (
+                "padding_mask",
+                [
+                    1,
+                    1,
+                    rbln_config.height,
+                    rbln_config.width,
+                ],
+                "float32",
+            ),
+        ]
+
+        compile_config = RBLNCompileConfig(input_info=input_info)
+        rbln_config.set_compile_cfgs([compile_config])
+        return rbln_config
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        fps: Optional[int] = None,
+        condition_mask: Optional[torch.Tensor] = None,
+        padding_mask: Optional[torch.Tensor] = None,
+        return_dict: bool = True,
+    ):
+        if not hasattr(self, "_emb_cached"):
+            raise RuntimeError(
+                "To run 'RBLNCosmosTransformer3DModel', the method 'get_time_embed_table' should be executed with the scheduler and 'num_inference_steps'."
+            )
+
+        timestep = self.time_embed_table(timestep)
+        output = self.model[0].forward(
+            hidden_states,
+            timestep,
+            encoder_hidden_states,
+            padding_mask,
+        )
+        return output

--- a/src/optimum/rbln/diffusers/pipelines/cosmos/__init__.py
+++ b/src/optimum/rbln/diffusers/pipelines/cosmos/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .cosmos_guardrail import RBLNCosmosSafetyChecker
+from .pipeline_cosmos import RBLNCosmosPipeline

--- a/src/optimum/rbln/diffusers/pipelines/cosmos/cosmos_guardrail.py
+++ b/src/optimum/rbln/diffusers/pipelines/cosmos/cosmos_guardrail.py
@@ -1,0 +1,492 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+from abc import abstractmethod
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import rebel
+import torch
+from diffusers.pipelines.cosmos.cosmos_guardrail import (
+    CosmosSafetyChecker,
+)
+
+from optimum.rbln import RBLNLlamaForCausalLM
+from optimum.rbln.diffusers.configurations.models.configuration_cosmos_guardrail import (
+    RBLNRetinaFaceConfig,
+    RBLNSiglipVisionModelConfig,
+    RBLNVideoSafetyModelConfig,
+)
+
+from ....configuration_utils import DEFAULT_COMPILED_MODEL_NAME, RBLNAutoConfig, RBLNCompileConfig, RBLNModelConfig
+from ....utils.hub import validate_files
+from ....utils.logging import get_logger
+from ....utils.runtime_utils import RBLNPytorchRuntime, UnavailableRuntime
+
+
+logger = get_logger(__name__)
+
+COSMOS_GUARDRAIL_CHECKPOINT = "nvidia/Cosmos-1.0-Guardrail"
+
+
+class RBLNSimpleModel:
+    """
+    An abstract class for compiling, loading, and saving PyTorch models to run on RBLN NPU devices.
+
+    This class supports compilation and loading models using the `compile_model` and `load_compiled_model` methods.
+
+    The `compile_model` method compiles a given model and save to 'model_save_dir/subfolder' directory.
+
+    The `load_compiled_model` method loads a pre-compiled model from given 'model_save_dir/subfolder' directory.
+
+    `rbln_config` contains various kwargs required for compilation and runtime. For example, `rbln_device`
+    specifies the device to be used at runtime. If not specified, defaults to device 0.
+
+    `RBLNModel`, `RBLNModelFor*`, etc. are all child classes of RBLNSimpleModel.
+
+    RBLNSimpleModel is a class for models consisting of an arbitrary number of `torch.nn.Module`s, and
+    therefore is an abstract class without explicit implementations of `forward` or `export` functions.
+    To inherit from this class, `forward`, `export`, etc. must be implemented.
+    """
+
+    def __init__(
+        self,
+        models: List[rebel.Runtime],
+        rbln_config: "RBLNModelConfig",
+        model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
+        rbln_compiled_models: Optional[rebel.RBLNCompiledModel] = None,
+        subfolder: str = "",
+    ):
+        self.model = models
+        self.rbln_config = rbln_config
+        self.compiled_models = rbln_compiled_models
+        self.model_save_dir = model_save_dir
+        self.subfolder = subfolder
+
+    @classmethod
+    def load_compiled_model(
+        cls, model_id: str, rbln_config: Optional[Union[Dict[str, Any], "RBLNModelConfig"]] = None, subfolder: str = ""
+    ):
+        return cls._load_compiled_model(model_id=model_id, subfolder=subfolder, rbln_config=rbln_config)
+
+    @classmethod
+    def _load_compiled_model(cls, model_id: str, subfolder: str, rbln_config, rbln_compiled_models=None):
+        model_path = Path(model_id)
+
+        model_save_dir = model_path / subfolder
+        rbln_files = list(model_save_dir.glob("*.rbln"))
+        rbln_config_filenames = list(model_save_dir.glob("rbln_config.json"))
+        validate_files(rbln_files, rbln_config_filenames, f"directory {model_save_dir}")
+
+        from_export_method = isinstance(rbln_config, RBLNModelConfig) and rbln_compiled_models is not None
+        if not from_export_method:
+            rbln_config_as_kwargs = {f"rbln_{key}": value for key, value in rbln_config.items()}
+            rbln_config, kwargs = RBLNAutoConfig.load(
+                model_save_dir, passed_rbln_config=None, kwargs=rbln_config_as_kwargs, return_unused_kwargs=True
+            )
+
+        compiled_models = Path(model_save_dir).glob("*.rbln")
+        rbln_compiled_models = {cm.stem: rebel.RBLNCompiledModel(cm) for cm in compiled_models}
+        return cls._from_compiled_models(rbln_compiled_models, rbln_config, model_path=model_path, subfolder=subfolder)
+
+    @classmethod
+    def _from_compiled_models(
+        cls,
+        rbln_compiled_models: Dict[str, rebel.RBLNCompiledModel],
+        rbln_config: "RBLNModelConfig",
+        model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
+        subfolder="",
+        **kwargs,
+    ):
+        compiled_model_names = [cfg.compiled_model_name for cfg in rbln_config.compile_cfgs]
+        rbln_compiled_models = [rbln_compiled_models[cm_name] for cm_name in compiled_model_names]
+
+        # create runtimes only if `rbln_create_runtimes` is enabled
+        try:
+            models = (
+                cls._create_runtimes(rbln_compiled_models, rbln_config)
+                if rbln_config.create_runtimes
+                else UnavailableRuntime()
+            )
+
+        except rebel.core.exception.RBLNRuntimeError as e:
+            logger.warning(
+                f"Failed to create the runtime for the model due to a runtime error: {e.__class__.__name__} - {e}"
+            )
+            models = UnavailableRuntime()
+
+        models = [cls.wrap_runtime_if_needed(model) for model in models]
+
+        return cls(
+            models,
+            rbln_config=rbln_config,
+            model_save_dir=model_save_dir,
+            rbln_compiled_models=rbln_compiled_models,
+            subfolder=subfolder,
+        )
+
+    @classmethod
+    def wrap_runtime_if_needed(cls, model):
+        return model
+
+    @classmethod
+    def wrap_model_if_needed(cls, model):
+        return model
+
+    @classmethod
+    def prepare_rbln_config(
+        cls, rbln_config: Optional[Union[Dict[str, Any], RBLNModelConfig]] = None, **kwargs
+    ) -> Tuple[RBLNModelConfig, Dict[str, Any]]:
+        """
+        Extract rbln-config from kwargs and convert it to RBLNModelConfig.
+        """
+        if not hasattr(cls, "_rbln_config_class"):
+            raise ValueError
+
+        rbln_config, kwargs = cls._rbln_config_class.initialize_from_kwargs(rbln_config, **kwargs)
+        return rbln_config, kwargs
+
+    @classmethod
+    def update_rbln_config(cls, **others) -> RBLNModelConfig:
+        rbln_config = cls._update_rbln_config(**others)
+        rbln_config.freeze()
+        if rbln_config.rbln_model_cls_name != cls.__name__:
+            raise NameError(
+                f"Cannot get the rbln config. {cls.__name__} is not the same as {rbln_config.rbln_model_cls_name}. "
+                "This is an internal error. Please report it to the developers."
+            )
+        return rbln_config
+
+    @classmethod
+    @abstractmethod
+    def _update_rbln_config(cls, **rbln_config_kwargs) -> RBLNModelConfig:
+        pass
+
+    @classmethod
+    def compile_model(cls, model, rbln_config, model_save_dir, subfolder="", **kwargs):
+        rbln_config, kwargs = cls.prepare_rbln_config(rbln_config=rbln_config, **kwargs)
+        rbln_config: RBLNModelConfig = cls.update_rbln_config(rbln_config=rbln_config)
+        compiled_model = cls._get_compiled_model(model, rbln_config)
+
+        # Save compiled models (.rbln)
+        (model_save_dir / subfolder).mkdir(exist_ok=True)
+        if not isinstance(compiled_model, dict):
+            compiled_models = {DEFAULT_COMPILED_MODEL_NAME: compiled_model}
+        else:
+            compiled_models = compiled_model
+        for compiled_model_name, cm in compiled_models.items():
+            cm.save(model_save_dir / subfolder / f"{compiled_model_name}.rbln")
+
+        rbln_config.save(model_save_dir / subfolder)
+        rbln_compiled_models = cls._load_compiled_model(
+            model_id=model_save_dir, subfolder=subfolder, rbln_config=rbln_config, rbln_compiled_models=compiled_models
+        )
+        return rbln_compiled_models
+
+    @classmethod
+    def _get_compiled_model(cls, model, rbln_config):
+        return cls._compile(cls.wrap_model_if_needed(model), rbln_compile_config=rbln_config.compile_cfgs[0])
+
+    @classmethod
+    def _compile(cls, model, rbln_compile_config: Optional[RBLNCompileConfig] = None, **kwargs):
+        compiled_model = rebel.compile_from_torch(
+            model,
+            input_info=rbln_compile_config.input_info,
+            fusion=rbln_compile_config.fusion,
+            npu=rbln_compile_config.npu,
+            tensor_parallel_size=rbln_compile_config.tensor_parallel_size,
+            **kwargs,
+        )
+        return compiled_model
+
+    @classmethod
+    def _create_runtimes(
+        cls,
+        compiled_models: List[rebel.RBLNCompiledModel],
+        rbln_config: RBLNModelConfig,
+    ) -> List[rebel.Runtime]:
+        if DEFAULT_COMPILED_MODEL_NAME not in rbln_config.device_map:
+            cls._raise_missing_compiled_file_error([DEFAULT_COMPILED_MODEL_NAME])
+
+        return [
+            compiled_model.create_runtime(
+                tensor_type="pt",
+                device=rbln_config.device_map[DEFAULT_COMPILED_MODEL_NAME],
+                activate_profiler=rbln_config.activate_profiler,
+            )
+            for compiled_model in compiled_models
+        ]
+
+    @staticmethod
+    def _raise_missing_compiled_file_error(missing_files: List[str]):
+        """Raises a KeyError with a message indicating missing compiled model files."""
+
+        if len(missing_files) == 1:
+            message = f"The rbln model folder is missing the required '{missing_files[0]}.rbln' file. "
+        else:
+            files_str = ", ".join([f"'{f}.rbln'" for f in missing_files])
+            message = (
+                "The rbln model folder is missing required files. "
+                f"Ensure that {files_str} files are present in the folder. "
+            )
+        message += (
+            "These files are necessary for loading the rbln model. "
+            "If these files are missing, please recompile the model using the latest optimum-rbln "
+            "and ensure the compilation completes successfully."
+        )
+        raise KeyError(message)
+
+    def parameters(self):
+        yield torch.tensor([1], dtype=torch.float32, device=torch.device("cpu"))
+
+    def to(self, device: Union[str, torch.device] = None, dtype: torch.dtype = None):
+        pass
+
+    def __call__(self, *args: List[torch.Tensor], **kwargs: Dict[str, torch.Tensor]):
+        output = self.model[0](*args, **kwargs)
+        return output
+
+
+class RBLNRetinaFace(RBLNSimpleModel):
+    _rbln_config_class = RBLNRetinaFaceConfig
+
+    @classmethod
+    def _update_rbln_config(cls, rbln_config: RBLNRetinaFaceConfig):
+        height = rbln_config.height
+        width = rbln_config.width
+        input_info = [("frames", [1, 3, height, width], "float32")]
+
+        postprocessor_config = RBLNCompileConfig(input_info=input_info)
+        rbln_config.set_compile_cfgs([postprocessor_config])
+        return rbln_config
+
+
+class RBLNVideoSafetyModel(RBLNSimpleModel):
+    _rbln_config_class = RBLNVideoSafetyModelConfig
+
+    @classmethod
+    def _update_rbln_config(cls, rbln_config: RBLNVideoSafetyModelConfig):
+        batch_size = rbln_config.batch_size
+        input_size = rbln_config.input_size
+        input_info_cls = [("data", [batch_size, input_size], "float32")]
+        cls_config = RBLNCompileConfig(input_info=input_info_cls)
+        rbln_config.set_compile_cfgs([cls_config])
+        return rbln_config
+
+    @classmethod
+    def wrap_model_if_needed(cls, model):
+        return model.network
+
+    def network(self, x):
+        return self(x)
+
+
+class RBLNRuntimeSiglipVisionModel(RBLNPytorchRuntime):
+    def __init__(self, runtime, **kwargs):
+        super().__init__(runtime=runtime, **kwargs)
+        self.model = runtime
+
+    def get_image_features(
+        self,
+        pixel_values: Optional[torch.FloatTensor] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        interpolate_pos_encoding: bool = False,
+    ) -> torch.FloatTensor:
+        # Use SiglipModel's config for some fields (if specified) instead of those of vision & text components.
+        vision_outputs = self.model(
+            pixel_values=pixel_values,
+        )
+        pooled_output = vision_outputs[1]
+        return pooled_output
+
+
+class _SiglipVisionModel(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, pixel_values):
+        return self.model(
+            pixel_values=pixel_values,
+            return_dict=False,
+        )
+
+
+class RBLNSiglipVisionModel(RBLNSimpleModel):
+    _rbln_config_class = RBLNSiglipVisionModelConfig
+
+    @classmethod
+    def _update_rbln_config(cls, rbln_config: RBLNSiglipVisionModelConfig):
+        batch_size = rbln_config.batch_size
+        height = rbln_config.height
+        width = rbln_config.width
+
+        input_info_enc = [("pixel_values", [batch_size, 3, height, width], "float32")]  # hard coded
+        enc_config = RBLNCompileConfig(input_info=input_info_enc)
+        rbln_config.set_compile_cfgs([enc_config])
+        return rbln_config
+
+    @classmethod
+    def wrap_model_if_needed(cls, model):
+        return _SiglipVisionModel(model)
+
+    @classmethod
+    def wrap_runtime_if_needed(cls, model):
+        return RBLNRuntimeSiglipVisionModel(model)
+
+
+class RBLNLlamaGuard:
+    _origin_class = RBLNLlamaForCausalLM
+
+    @classmethod
+    def load_compiled_model(cls, model_id, rbln_config, subfolder=""):
+        # FIXME: this is temp patch until fix main branch
+        rbln_config_as_kwargs = {f"rbln_{key}": value for key, value in rbln_config.items()}
+        rbln_config, kwargs = RBLNAutoConfig.load(
+            model_id, passed_rbln_config=None, kwargs=rbln_config_as_kwargs, return_unused_kwargs=True
+        )
+        model = cls._origin_class.from_pretrained(
+            model_id=model_id,
+            export=False,
+            rbln_config=rbln_config,
+        )
+        return model
+
+    @classmethod
+    def compile_model(cls, model, rbln_config, model_save_dir, subfolder=""):
+        batch_size = rbln_config.get("batch_size", 1)
+        max_seq_len = rbln_config.get("max_seq_len", 4096)
+        tensor_parallel_size = rbln_config.get("tensor_parallel_size", 4)
+        rbln_device = rbln_config.get("device", [0, 1, 2, 3])
+
+        model = model.merge_and_unload()
+        compiled_model = cls._origin_class.from_model(
+            model,
+            export=True,
+            rbln_batch_size=batch_size,
+            rbln_max_seq_len=max_seq_len,
+            rbln_tensor_parallel_size=tensor_parallel_size,
+            rbln_device=rbln_device,
+            model_save_dir=model_save_dir,
+            subfolder=subfolder,
+        )
+        return compiled_model
+
+
+def update_submodule_config(fn):
+    """
+    If the function uses rbln_config and kwargs,
+        then extract `rbln_` prefix from kwargs.
+
+    If rbln_config is already an instance of RBLNConfig, then pass.
+    """
+
+    def merged_rbln_config_fn(*args, **kwargs):
+        submodules = ["video_guardrail", "text_guardrail"]
+
+        rbln_kwargs = kwargs.pop("rbln_kwargs", None)
+        if rbln_kwargs is not None:
+            raise KeyError("`rbln_kwargs` cannot be specified when using `rbln_config`!")
+
+        rbln_config = kwargs.pop("rbln_config", None)
+
+        keys = list(kwargs.keys())
+        rbln_kwargs = {key[5:]: kwargs.pop(key) for key in keys if key.startswith("rbln_")}
+
+        if rbln_config is None:
+            rbln_config_dict = {}
+
+        else:
+            rbln_config_dict = rbln_config
+
+        for submodule in submodules:
+            submodule_dict = rbln_config_dict.get(submodule, None)
+            if submodule_dict is None:
+                rbln_config_dict[submodule] = {}
+
+            for key in rbln_config_dict[submodule]:
+                if key in rbln_kwargs:
+                    raise KeyError(f"Duplicated key in both `rbln_config` and rbln_{key}.")
+
+            rbln_config_dict[submodule].update(rbln_kwargs)
+
+        return fn(*args, **kwargs, rbln_config=rbln_config_dict)
+
+    return merged_rbln_config_fn
+
+
+class RBLNCosmosSafetyChecker:
+    original_class = CosmosSafetyChecker
+    _guardrails = ["video_guardrail", "video_guardrail", "video_guardrail", "text_guardrail"]
+    _submodules = ["postprocessors", "safety_models", "safety_models", "safety_models"]
+    _module_ids = [0, 0, 0, 1]
+    _additional_modules = [None, "encoder.model", None, None]
+    _target_model_names = ["net", "vision_model", "model", "model"]
+    _subfolders = ["", "encoder", "model", ""]
+    _rbln_modules = [RBLNRetinaFace, RBLNSiglipVisionModel, RBLNVideoSafetyModel, RBLNLlamaGuard]
+
+    @classmethod
+    @update_submodule_config
+    def compile_submodules(cls, model, rbln_config, model_save_dir: str = "safety_checker"):
+        save_dir_path = Path(model_save_dir)
+        save_dir_path.mkdir(exist_ok=True)
+        for i, target_model_name in enumerate(cls._target_model_names):
+            guardrail = cls._guardrails[i]
+            submodule = cls._submodules[i]
+            additional_module = cls._additional_modules[i]
+
+            save_dir_path = Path(model_save_dir + f"/{guardrail}/{submodule}")
+            os.makedirs(save_dir_path, exist_ok=True)
+            target_model = getattr(getattr(model, guardrail), submodule)[cls._module_ids[i]]
+            if additional_module is not None:
+                for m in additional_module.split("."):
+                    target_model = getattr(target_model, m)
+            compile_target = getattr(target_model, cls._target_model_names[i])
+            compiled_model = cls._rbln_modules[i].compile_model(
+                compile_target,
+                rbln_config=rbln_config.get(guardrail, {}),
+                model_save_dir=save_dir_path,
+                subfolder=cls._subfolders[i],
+            )
+            delattr(target_model, target_model_name)
+            setattr(target_model, target_model_name, compiled_model)
+        return model
+
+    @classmethod
+    @update_submodule_config
+    def load_submodules(cls, model, rbln_config, model_save_dir=""):
+        for i, target_model_name in enumerate(cls._target_model_names):
+            guardrail = cls._guardrails[i]
+            submodule = cls._submodules[i]
+            additional_module = cls._additional_modules[i]
+            rbln_module = cls._rbln_modules[i]
+
+            save_dir_path = Path(model_save_dir + f"/{guardrail}/{submodule}")
+
+            target_model = getattr(getattr(model, guardrail), submodule)[cls._module_ids[i]]
+            if additional_module is not None:
+                for m in additional_module.split("."):
+                    target_model = getattr(target_model, m)
+
+            compiled_model = rbln_module.load_compiled_model(
+                save_dir_path,
+                rbln_config=rbln_config.get(guardrail, {}),
+                subfolder=cls._subfolders[i],
+            )
+            delattr(target_model, target_model_name)
+            setattr(target_model, target_model_name, compiled_model)
+        return model

--- a/src/optimum/rbln/diffusers/pipelines/cosmos/pipeline_cosmos.py
+++ b/src/optimum/rbln/diffusers/pipelines/cosmos/pipeline_cosmos.py
@@ -1,0 +1,36 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from inspect import signature
+
+from diffusers import CosmosPipeline
+
+from ...modeling_diffusers import RBLNDiffusionMixin
+
+
+class RBLNCosmosPipeline(RBLNDiffusionMixin, CosmosPipeline):
+    original_class = CosmosPipeline
+    _submodules = ["text_encoder", "transformer", "vae"]
+    _optional_components = ["safety_checker"]
+
+    def forward(self, *args, **kwargs):
+        param_names = list(signature(super().forward).parameters.keys())
+        for i, value in enumerate(args):
+            kwargs[param_names[i]] = value
+
+        num_inference_steps = kwargs["num_inference_steps"]
+        if (not hasattr(self.transformer, "_emb_cached")) or len(self.transformer._emb_cached) != num_inference_steps:
+            self.transformer.get_time_embed_table(self.scheduler, num_inference_steps)
+        super().forward(**kwargs)


### PR DESCRIPTION
# Pull Request Description

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] New Model Support
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

- Support Cosmos World Foundation Model
- Implement submodules for CosmosPipeline

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

Please refer to the [PR in HuggingFace diffusers](https://github.com/huggingface/diffusers/pulls?q=cosmos)

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (If needed)

## Additional Information
<!-- Any additional information, configuration, or data that might be necessary to reproduce the issue or use the new feature -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only     
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update