### PR TITLE
other(runtime)): change default behavior when no npu is available

### DIFF
--- a/src/optimum/rbln/configuration_utils.py
+++ b/src/optimum/rbln/configuration_utils.py
@@ -536,7 +536,7 @@ class RBLNModelConfig:
             optimize_host_memory (Optional[bool]): Whether to optimize host memory usage. Defaults to True.
             device (Optional[Union[int, List[int]]]): The device(s) to load the model onto. Can be a single device ID or a list.
             device_map (Optional[Dict[str, Union[int, List[int]]]]): Mapping from compiled model names to device IDs.
-            activate_profiler (Optional[bool]): Whether to activate the profiler for performance analysis Defaults to False.
+            activate_profiler (Optional[bool]): Whether to activate the profiler for performance analysis.
             npu (Optional[str]): The NPU device name to use for compilation.
             tensor_parallel_size (Optional[int]): Size for tensor parallelism to distribute the model across devices.
             optimum_rbln_version (Optional[str]): The optimum-rbln version used for this configuration.
@@ -767,6 +767,8 @@ class RBLNModelConfig:
         context = ContextRblnConfig.get_current_context()["optimize_host_memory"]
         if context is not None:
             return context
+        elif self._runtime_options["optimize_host_memory"] is None:
+            return True
         return self._runtime_options["optimize_host_memory"]
 
     @optimize_host_memory.setter

--- a/src/optimum/rbln/configuration_utils.py
+++ b/src/optimum/rbln/configuration_utils.py
@@ -767,8 +767,6 @@ class RBLNModelConfig:
         context = ContextRblnConfig.get_current_context()["optimize_host_memory"]
         if context is not None:
             return context
-        elif self._runtime_options["optimize_host_memory"] is None:
-            return True
         return self._runtime_options["optimize_host_memory"]
 
     @optimize_host_memory.setter
@@ -808,8 +806,6 @@ class RBLNModelConfig:
         context = ContextRblnConfig.get_current_context()["activate_profiler"]
         if context is not None:
             return context
-        elif self._runtime_options["activate_profiler"] is None:
-            return False
         return self._runtime_options["activate_profiler"]
 
     @activate_profiler.setter

--- a/src/optimum/rbln/configuration_utils.py
+++ b/src/optimum/rbln/configuration_utils.py
@@ -532,11 +532,11 @@ class RBLNModelConfig:
 
         Args:
             cls_name (Optional[str]): The class name of the configuration. Defaults to the current class name.
-            create_runtimes (Optional[bool]): Whether to create RBLN runtimes. Defaults to True if an NPU is available.
+            create_runtimes (Optional[bool]): Whether to create RBLN runtimes. Defaults to True.
             optimize_host_memory (Optional[bool]): Whether to optimize host memory usage. Defaults to True.
             device (Optional[Union[int, List[int]]]): The device(s) to load the model onto. Can be a single device ID or a list.
             device_map (Optional[Dict[str, Union[int, List[int]]]]): Mapping from compiled model names to device IDs.
-            activate_profiler (Optional[bool]): Whether to activate the profiler for performance analysis.
+            activate_profiler (Optional[bool]): Whether to activate the profiler for performance analysis Defaults to False.
             npu (Optional[str]): The NPU device name to use for compilation.
             tensor_parallel_size (Optional[int]): Size for tensor parallelism to distribute the model across devices.
             optimum_rbln_version (Optional[str]): The optimum-rbln version used for this configuration.
@@ -754,6 +754,8 @@ class RBLNModelConfig:
         context = ContextRblnConfig.get_current_context()["create_runtimes"]
         if context is not None:
             return context
+        elif self._runtime_options["create_runtimes"] is None:
+            return True
         return self._runtime_options["create_runtimes"]
 
     @create_runtimes.setter
@@ -806,6 +808,8 @@ class RBLNModelConfig:
         context = ContextRblnConfig.get_current_context()["activate_profiler"]
         if context is not None:
             return context
+        elif self._runtime_options["activate_profiler"] is None:
+            return False
         return self._runtime_options["activate_profiler"]
 
     @activate_profiler.setter

--- a/src/optimum/rbln/configuration_utils.py
+++ b/src/optimum/rbln/configuration_utils.py
@@ -19,7 +19,6 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
-import rebel
 import torch
 
 from .__version__ import __version__
@@ -755,8 +754,6 @@ class RBLNModelConfig:
         context = ContextRblnConfig.get_current_context()["create_runtimes"]
         if context is not None:
             return context
-        elif self._runtime_options["create_runtimes"] is None:
-            return rebel.npu_is_available()
         return self._runtime_options["create_runtimes"]
 
     @create_runtimes.setter


### PR DESCRIPTION
# Pull Request Description

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] New Model Support
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

if npu(0) is not available, 
AS-IS: create_runtimes automatically changes to False
TO-BE : create_runtimes not be changed.


## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Checklist
<!-- Mark completed items with an [x] -->
- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works (If needed)

## Additional Information
<!-- Any additional information, configuration, or data that might be necessary to reproduce the issue or use the new feature -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only     
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update