### PR TITLE
model: change parameters of RBLNDecoderOnlyModel's get_input_info method.

### DIFF
--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -838,6 +838,16 @@ class RBLNDecoderOnlyModelForCausalLM(RBLNModel):
         rbln_config: RBLNDecoderOnlyModelForCausalLMConfig,
         model_config: PretrainedConfig,
     ):
+        """
+        Returns the input information for the RBLNDecoderOnlyModel.
+
+        Args:
+            batch_size (int): The batch size.
+            query_length (int): The length of the query.
+            rbln_config (RBLNDecoderOnlyModelForCausalLMConfig): The RBLN model configuration.
+            model_config (PretrainedConfig): The HuggingFace model configuration.
+        """
+        
         num_attention_heads = getattr(model_config, "n_head", None) or getattr(model_config, "num_attention_heads")
         num_key_value_heads = getattr(model_config, "num_key_value_heads", None) or num_attention_heads
         num_hidden_layers = getattr(model_config, "n_layer", None) or getattr(model_config, "num_hidden_layers")

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -838,16 +838,6 @@ class RBLNDecoderOnlyModelForCausalLM(RBLNModel):
         rbln_config: RBLNDecoderOnlyModelForCausalLMConfig,
         model_config: PretrainedConfig,
     ):
-        """
-        Returns the input information for the RBLNDecoderOnlyModel.
-
-        Args:
-            batch_size (int): The batch size.
-            query_length (int): The length of the query.
-            rbln_config (RBLNDecoderOnlyModelForCausalLMConfig): The RBLN model configuration.
-            model_config (PretrainedConfig): The HuggingFace model configuration.
-        """
-
         num_attention_heads = getattr(model_config, "n_head", None) or getattr(model_config, "num_attention_heads")
         num_key_value_heads = getattr(model_config, "num_key_value_heads", None) or num_attention_heads
         num_hidden_layers = getattr(model_config, "n_layer", None) or getattr(model_config, "num_hidden_layers")

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -847,7 +847,7 @@ class RBLNDecoderOnlyModelForCausalLM(RBLNModel):
             rbln_config (RBLNDecoderOnlyModelForCausalLMConfig): The RBLN model configuration.
             model_config (PretrainedConfig): The HuggingFace model configuration.
         """
-        
+
         num_attention_heads = getattr(model_config, "n_head", None) or getattr(model_config, "num_attention_heads")
         num_key_value_heads = getattr(model_config, "num_key_value_heads", None) or num_attention_heads
         num_hidden_layers = getattr(model_config, "n_layer", None) or getattr(model_config, "num_hidden_layers")

--- a/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
@@ -776,7 +776,9 @@ class RBLNGemma3ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             main_input,
             (
                 "attention_mask",
-                [batch_size, 1, query_length, rbln_config.max_seq_len] if not rbln_config.use_position_ids else [batch_size, rbln_config.max_seq_len],
+                [batch_size, 1, query_length, rbln_config.max_seq_len]
+                if not rbln_config.use_position_ids
+                else [batch_size, rbln_config.max_seq_len],
                 "float32",
             ),
             (
@@ -818,7 +820,12 @@ class RBLNGemma3ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             return bool((layer_idx + 1) % sliding_window_pattern)
 
         local_kvcache_shape = [dec_batch_size, num_key_value_heads, sliding_window, head_dim]
-        global_kvcache_shape = [rbln_config.kvcache_num_blocks, num_key_value_heads, rbln_config.kvcache_block_size, head_dim]
+        global_kvcache_shape = [
+            rbln_config.kvcache_num_blocks,
+            num_key_value_heads,
+            rbln_config.kvcache_block_size,
+            head_dim,
+        ]
         input_info.extend(
             [
                 (

--- a/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
@@ -767,7 +767,7 @@ class RBLNGemma3ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             rbln_config (RBLNGemma3ForCausalLMConfig): The RBLN model configuration.
             model_config (PretrainedConfig): The HuggingFace model configuration.
         """
-        
+
         num_attention_heads = getattr(model_config, "n_head", None) or getattr(model_config, "num_attention_heads")
         num_key_value_heads = getattr(model_config, "num_key_value_heads", None) or num_attention_heads
         num_hidden_layers = getattr(model_config, "n_layer", None) or getattr(model_config, "num_hidden_layers")

--- a/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
@@ -755,21 +755,19 @@ class RBLNGemma3ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         cls,
         batch_size: int,
         query_length: int,
-        use_inputs_embeds: bool,
-        use_attention_mask: bool,
-        use_position_ids: bool,
-        max_seq_len: int,
-        kvcache_block_size: int,
-        kvcache_num_blocks: int,
-        num_key_value_heads: int,
-        num_hidden_layers: int,
-        hidden_size: int,
-        head_dim: int,
-        sliding_window: int,
-        sliding_window_pattern: int,
-        dec_batch_size: int,
+        rbln_config: RBLNGemma3ForCausalLMConfig,
+        model_config: PretrainedConfig,
     ):
-        if use_inputs_embeds:
+        num_attention_heads = getattr(model_config, "n_head", None) or getattr(model_config, "num_attention_heads")
+        num_key_value_heads = getattr(model_config, "num_key_value_heads", None) or num_attention_heads
+        num_hidden_layers = getattr(model_config, "n_layer", None) or getattr(model_config, "num_hidden_layers")
+        hidden_size = getattr(model_config, "n_embd", None) or getattr(model_config, "hidden_size")
+        head_dim = getattr(model_config, "head_dim", None) or hidden_size // num_attention_heads
+        sliding_window = getattr(model_config, "sliding_window", None)
+        sliding_window_pattern = getattr(model_config, "sliding_window_pattern", None)
+        dec_batch_size = max(rbln_config.decoder_batch_sizes)
+
+        if rbln_config.use_inputs_embeds:
             main_input = ("inputs_embeds", [batch_size, query_length, hidden_size], "float32")
         else:
             main_input = ("input_ids", [batch_size, query_length], "int64")
@@ -778,7 +776,7 @@ class RBLNGemma3ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             main_input,
             (
                 "attention_mask",
-                [batch_size, 1, query_length, max_seq_len] if not use_position_ids else [batch_size, max_seq_len],
+                [batch_size, 1, query_length, rbln_config.max_seq_len] if not rbln_config.use_position_ids else [batch_size, rbln_config.max_seq_len],
                 "float32",
             ),
             (
@@ -793,6 +791,13 @@ class RBLNGemma3ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             ),
         ]
 
+        max_block_cnt = rbln_config.max_seq_len // rbln_config.kvcache_block_size
+
+        if query_length > 1:
+            input_info.extend([("block_tables", [max_block_cnt], "int16")])
+        else:
+            input_info.extend([("block_tables", [batch_size, max_block_cnt], "int16")])
+
         if query_length > 1:
             input_info.extend(
                 [
@@ -800,7 +805,7 @@ class RBLNGemma3ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
                 ]
             )
 
-        max_block_cnt = max_seq_len // kvcache_block_size
+        max_block_cnt = rbln_config.max_seq_len // rbln_config.kvcache_block_size
 
         if query_length > 1:
             input_info.extend([("global_block_tables", [max_block_cnt], "int16")])
@@ -813,7 +818,7 @@ class RBLNGemma3ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             return bool((layer_idx + 1) % sliding_window_pattern)
 
         local_kvcache_shape = [dec_batch_size, num_key_value_heads, sliding_window, head_dim]
-        global_kvcache_shape = [kvcache_num_blocks, num_key_value_heads, kvcache_block_size, head_dim]
+        global_kvcache_shape = [rbln_config.kvcache_num_blocks, num_key_value_heads, rbln_config.kvcache_block_size, head_dim]
         input_info.extend(
             [
                 (
@@ -889,30 +894,11 @@ class RBLNGemma3ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             )
         logger.info(f"[KVCache] Compiling with num_blocks: {rbln_config.kvcache_num_blocks}")
 
-        num_attention_heads = getattr(model_config, "n_head", None) or getattr(model_config, "num_attention_heads")
-        num_key_value_heads = getattr(model_config, "num_key_value_heads", None) or num_attention_heads
-        num_hidden_layers = getattr(model_config, "n_layer", None) or getattr(model_config, "num_hidden_layers")
-        hidden_size = getattr(model_config, "n_embd", None) or getattr(model_config, "hidden_size")
-        head_dim = getattr(model_config, "head_dim", None) or hidden_size // num_attention_heads
-        sliding_window = getattr(model_config, "sliding_window", None)
-        sliding_window_pattern = getattr(model_config, "sliding_window_pattern", None)
-
         prefill_input_info = cls.get_input_info(
             batch_size=1,
             query_length=rbln_config.prefill_chunk_size,
-            use_inputs_embeds=rbln_config.use_inputs_embeds,
-            use_attention_mask=rbln_config.use_attention_mask,
-            use_position_ids=rbln_config.use_position_ids,
-            max_seq_len=rbln_config.max_seq_len,
-            kvcache_block_size=rbln_config.kvcache_block_size,
-            kvcache_num_blocks=rbln_config.kvcache_num_blocks,
-            num_key_value_heads=num_key_value_heads,
-            num_hidden_layers=num_hidden_layers,
-            hidden_size=hidden_size,
-            head_dim=head_dim,
-            sliding_window=sliding_window,
-            sliding_window_pattern=sliding_window_pattern,
-            dec_batch_size=max(rbln_config.decoder_batch_sizes),
+            rbln_config=rbln_config,
+            model_config=model_config,
         )
         prefill_compile_config = RBLNCompileConfig(compiled_model_name="prefill", input_info=prefill_input_info)
         image_prefill_compile_config = RBLNCompileConfig(
@@ -924,19 +910,8 @@ class RBLNGemma3ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             dec_input_info = cls.get_input_info(
                 batch_size=batch_size,
                 query_length=1,
-                use_inputs_embeds=rbln_config.use_inputs_embeds,
-                use_attention_mask=rbln_config.use_attention_mask,
-                use_position_ids=rbln_config.use_position_ids,
-                max_seq_len=rbln_config.max_seq_len,
-                kvcache_block_size=rbln_config.kvcache_block_size,
-                kvcache_num_blocks=rbln_config.kvcache_num_blocks,
-                num_key_value_heads=num_key_value_heads,
-                num_hidden_layers=num_hidden_layers,
-                hidden_size=hidden_size,
-                head_dim=head_dim,
-                sliding_window=sliding_window,
-                sliding_window_pattern=sliding_window_pattern,
-                dec_batch_size=batch_size,
+                rbln_config=rbln_config,
+                model_config=model_config,
             )
             dec_compile_configs.append(
                 RBLNCompileConfig(compiled_model_name=f"decoder_batch_{batch_size}", input_info=dec_input_info)

--- a/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
@@ -758,16 +758,6 @@ class RBLNGemma3ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         rbln_config: RBLNGemma3ForCausalLMConfig,
         model_config: PretrainedConfig,
     ):
-        """
-        Returns the input information for the RBLNGemma3ForCausalLM.
-
-        Args:
-            batch_size (int): The batch size.
-            query_length (int): The length of the query.
-            rbln_config (RBLNGemma3ForCausalLMConfig): The RBLN model configuration.
-            model_config (PretrainedConfig): The HuggingFace model configuration.
-        """
-
         num_attention_heads = getattr(model_config, "n_head", None) or getattr(model_config, "num_attention_heads")
         num_key_value_heads = getattr(model_config, "num_key_value_heads", None) or num_attention_heads
         num_hidden_layers = getattr(model_config, "n_layer", None) or getattr(model_config, "num_hidden_layers")

--- a/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
@@ -758,6 +758,16 @@ class RBLNGemma3ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         rbln_config: RBLNGemma3ForCausalLMConfig,
         model_config: PretrainedConfig,
     ):
+        """
+        Returns the input information for the RBLNGemma3ForCausalLM.
+
+        Args:
+            batch_size (int): The batch size.
+            query_length (int): The length of the query.
+            rbln_config (RBLNGemma3ForCausalLMConfig): The RBLN model configuration.
+            model_config (PretrainedConfig): The HuggingFace model configuration.
+        """
+        
         num_attention_heads = getattr(model_config, "n_head", None) or getattr(model_config, "num_attention_heads")
         num_key_value_heads = getattr(model_config, "num_key_value_heads", None) or num_attention_heads
         num_hidden_layers = getattr(model_config, "n_layer", None) or getattr(model_config, "num_hidden_layers")

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -37,6 +37,7 @@ from ....utils.logging import get_logger
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModelForCausalLM, RBLNDecoderOnlyOutput
 from .configuration_qwen2_5_vl import (
     RBLNQwen2_5_VisionTransformerPretrainedModelConfig,
+    RBLNQwen2_5_VLForConditionalGenerationConfig,
 )
 from .qwen2_5_vl_architecture import Qwen2_5_VisionTransformerWrapper, Qwen2_5_VL_LanguageModelWrapper
 
@@ -369,7 +370,7 @@ class RBLNQwen2_5_VLForConditionalGeneration(RBLNDecoderOnlyModelForCausalLM):
         cls,
         batch_size: int,
         query_length: int,
-        rbln_config: "RBLNQwen2_5_VLForConditionalGenerationConfig",
+        rbln_config: RBLNQwen2_5_VLForConditionalGenerationConfig,
         model_config: PretrainedConfig,
     ):
         """

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -374,62 +374,15 @@ class RBLNQwen2_5_VLForConditionalGeneration(RBLNDecoderOnlyModelForCausalLM):
         rbln_config: "RBLNQwen2_5_VLForConditionalGenerationConfig",
         model_config: PretrainedConfig,
     ):
-        num_attention_heads = getattr(model_config, "n_head", None) or getattr(model_config, "num_attention_heads")
-        num_key_value_heads = getattr(model_config, "num_key_value_heads", None) or num_attention_heads
-        num_hidden_layers = getattr(model_config, "n_layer", None) or getattr(model_config, "num_hidden_layers")
-        hidden_size = getattr(model_config, "n_embd", None) or getattr(model_config, "hidden_size")
-        head_dim = getattr(model_config, "head_dim", None) or hidden_size // num_attention_heads
-
-        if rbln_config.use_inputs_embeds:
-            main_input = ("inputs_embeds", [batch_size, query_length, model_config.hidden_size], "float32")
-        else:
-            main_input = ("input_ids", [batch_size, query_length], "int64")
-
-        input_info = [
-            main_input,
+        input_info = super().get_input_info(batch_size, query_length, rbln_config, model_config)
+        pos_idx = 3
+        input_info.insert(
+            pos_idx,
             (
-                "cache_position",
-                [batch_size, query_length],
-                "int32",
+                "position_emb",
+                [2, batch_size, 1, query_length, model_config.hidden_size // model_config.num_attention_heads],
+                "float32",
             ),
-        ]
-
-        max_block_cnt = rbln_config.max_seq_len // rbln_config.kvcache_block_size
-
-        if query_length > 1:
-            input_info.extend([("block_tables", [max_block_cnt], "int16")])
-        else:
-            input_info.extend([("block_tables", [batch_size, max_block_cnt], "int16")])
-
-        if query_length > 1:
-            input_info.extend(
-                [
-                    ("query_position", [], "int16"),
-                ]
-            )
-        if rbln_config.use_attention_mask:
-            input_info.extend(
-                [
-                    ("attention_mask", [batch_size, 1, query_length, rbln_config.max_seq_len], "float32"),
-                ]
-            )
-        if rbln_config.use_position_ids:
-            input_info.append(("position_ids", [batch_size, query_length], "int32"))
-
-        input_info.extend(
-            [
-                (
-                    f"past_key_values_{i}",
-                    [
-                        rbln_config.kvcache_num_blocks,
-                        num_key_value_heads,
-                        rbln_config.kvcache_block_size,
-                        head_dim,
-                    ],
-                    "float32",
-                )
-                for i in range(num_hidden_layers * 2)
-            ]
         )
 
         return input_info

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -51,8 +51,6 @@ if TYPE_CHECKING:
         PretrainedConfig,
     )
 
-    from .configuration_qwen2_5_vl import RBLNQwen2_5_VLForConditionalGenerationConfig
-
 
 class RBLNQwen2_5_VisionTransformerPretrainedModel(RBLNModel):
     auto_model_class = None

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -373,15 +373,6 @@ class RBLNQwen2_5_VLForConditionalGeneration(RBLNDecoderOnlyModelForCausalLM):
         rbln_config: RBLNQwen2_5_VLForConditionalGenerationConfig,
         model_config: PretrainedConfig,
     ):
-        """
-        Returns the input information for the RBLNQwen2_5_VLForConditionalGeneration.
-
-        Args:
-            batch_size (int): The batch size.
-            query_length (int): The length of the query.
-            rbln_config (RBLNQwen2_5_VLForConditionalGenerationConfig): The RBLN model configuration.
-            model_config (PretrainedConfig): The HuggingFace model configuration.
-        """
         input_info = super().get_input_info(batch_size, query_length, rbln_config, model_config)
         pos_idx = 3
         input_info.insert(

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -374,6 +374,15 @@ class RBLNQwen2_5_VLForConditionalGeneration(RBLNDecoderOnlyModelForCausalLM):
         rbln_config: "RBLNQwen2_5_VLForConditionalGenerationConfig",
         model_config: PretrainedConfig,
     ):
+        """
+        Returns the input information for the RBLNQwen2_5_VLForConditionalGeneration.
+
+        Args:
+            batch_size (int): The batch size.
+            query_length (int): The length of the query.
+            rbln_config (RBLNQwen2_5_VLForConditionalGenerationConfig): The RBLN model configuration.
+            model_config (PretrainedConfig): The HuggingFace model configuration.
+        """
         input_info = super().get_input_info(batch_size, query_length, rbln_config, model_config)
         pos_idx = 3
         input_info.insert(


### PR DESCRIPTION
# Pull Request Description

Modified the get_input_info method to accept model_config and rbln_config as parameters instead of individual variables. This change eliminates the inconvenience of having to define new parameters for decoderonly during overrides.


## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] New Model Support
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (If needed)

## Additional Information
<!-- Any additional information, configuration, or data that might be necessary to reproduce the issue or use the new feature -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only     
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update