### PR TITLE
model: add output_hidden_states into RBLNSiglipVisionModel forward kwargs

### DIFF
--- a/src/optimum/rbln/transformers/models/siglip/modeling_siglip.py
+++ b/src/optimum/rbln/transformers/models/siglip/modeling_siglip.py
@@ -119,7 +119,7 @@ class RBLNSiglipVisionModel(RBLNModel):
                 f"Variable interpolate_pos_encoding {output_hidden_states} is not equal to rbln_config.interpolate_pos_encoding {self.rbln_config.output_hidden_states}"
                 f"Please compile again with the correct argument."
             )
-            
+
         if interpolate_pos_encoding != self.rbln_config.interpolate_pos_encoding:
             raise ValueError(
                 f"Variable interpolate_pos_encoding {interpolate_pos_encoding} is not equal to rbln_config.interpolate_pos_encoding {self.rbln_config.interpolate_pos_encoding}"

--- a/src/optimum/rbln/transformers/models/siglip/modeling_siglip.py
+++ b/src/optimum/rbln/transformers/models/siglip/modeling_siglip.py
@@ -105,6 +105,7 @@ class RBLNSiglipVisionModel(RBLNModel):
         self,
         pixel_values: Optional[torch.FloatTensor] = None,
         return_dict: bool = None,
+        output_hidden_states: bool = None,
         interpolate_pos_encoding: bool = False,
         **kwargs,
     ) -> Union[Tuple, BaseModelOutputWithPooling]:
@@ -113,11 +114,18 @@ class RBLNSiglipVisionModel(RBLNModel):
                 f"Currently, optimum-rbln does not support kwargs {kwargs.keys()} for {self.__class__.__name__}."
             )
 
+        if output_hidden_states != self.rbln_config.output_hidden_states:
+            raise ValueError(
+                f"Variable interpolate_pos_encoding {output_hidden_states} is not equal to rbln_config.interpolate_pos_encoding {self.rbln_config.output_hidden_states}"
+                f"Please compile again with the correct argument."
+            )
+            
         if interpolate_pos_encoding != self.rbln_config.interpolate_pos_encoding:
             raise ValueError(
                 f"Variable interpolate_pos_encoding {interpolate_pos_encoding} is not equal to rbln_config.interpolate_pos_encoding {self.rbln_config.interpolate_pos_encoding}"
                 f"Please compile again with the correct argument."
             )
+
         output = super().forward(pixel_values, return_dict=return_dict)
         return output
 


### PR DESCRIPTION
# Pull Request Description
Add `output_hidden_states` into RBLNSiglipVisionModel forward kwargs.
If `output_hidden_states` in forward kwargs is not equal to `output_hidden_states` in `rbln_config`, it always raise ValueError.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] New Model Support
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (If needed)

## Additional Information
<!-- Any additional information, configuration, or data that might be necessary to reproduce the issue or use the new feature -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only     
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update