### PR TITLE
model: patch SiglipVisionModel's forward handle output_attention as hf

### DIFF
--- a/src/optimum/rbln/transformers/models/siglip/configuration_siglip.py
+++ b/src/optimum/rbln/transformers/models/siglip/configuration_siglip.py
@@ -47,8 +47,8 @@ class RBLNSiglipVisionModelConfig(RBLNModelConfig):
 
         self.image_size = image_size
         self.interpolate_pos_encoding = interpolate_pos_encoding or False
-        self.output_hidden_states = output_hidden_states
-        self.output_attentions = output_attentions
+        self.output_hidden_states = output_hidden_states or False
+        self.output_attentions = output_attentions or False
 
     @property
     def image_width(self):

--- a/src/optimum/rbln/transformers/models/siglip/configuration_siglip.py
+++ b/src/optimum/rbln/transformers/models/siglip/configuration_siglip.py
@@ -47,8 +47,8 @@ class RBLNSiglipVisionModelConfig(RBLNModelConfig):
 
         self.image_size = image_size
         self.interpolate_pos_encoding = interpolate_pos_encoding or False
-        self.output_hidden_states = output_hidden_states or False
-        self.output_attentions = output_attentions or False
+        self.output_hidden_states = output_hidden_states
+        self.output_attentions = output_attentions
 
     @property
     def image_width(self):

--- a/src/optimum/rbln/transformers/models/siglip/modeling_siglip.py
+++ b/src/optimum/rbln/transformers/models/siglip/modeling_siglip.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Tuple, Union, Any, Dict
 
 import torch
 from transformers import SiglipVisionConfig, SiglipVisionModel
@@ -109,18 +109,20 @@ class RBLNSiglipVisionModel(RBLNModel):
 
     def forward(
         self,
-        pixel_values,
-        return_dict: Optional[bool] = None,
-        output_attentions: Optional[bool] = None,
-        output_hidden_states: Optional[bool] = None,
-        interpolate_pos_encoding: Optional[bool] = False,
-        **kwargs,
+        pixel_values: torch.Tensor,
+        return_dict: bool = None,
+        output_attentions: bool = False, #FIXME
+        output_hidden_states: bool = False, #FIXME
+        interpolate_pos_encoding: bool = False,
+        **kwargs: Dict[str, Any],
     ) -> Union[Tuple, BaseModelOutputWithPooling]:
         if len(kwargs) > 0 and any(value is not None for value in kwargs.values()):
             logger.warning(
                 f"Currently, optimum-rbln does not support kwargs {kwargs.keys()} for {self.__class__.__name__}."
             )
 
+        # output_attentions, output_hidden_states, interpolate_pos_encoding is False by default.
+        # difference from huggingface which get from config.output_attentions, config.output_hidden_states, config.interpolate_pos_encoding
         if output_attentions != self.rbln_config.output_attentions:
             raise ValueError(
                 f"Variable output_attentions {output_attentions} is not equal to rbln_config.output_attentions {self.rbln_config.output_attentions} "

--- a/src/optimum/rbln/transformers/models/siglip/modeling_siglip.py
+++ b/src/optimum/rbln/transformers/models/siglip/modeling_siglip.py
@@ -126,9 +126,9 @@ class RBLNSiglipVisionModel(RBLNModel):
                 f"Currently, optimum-rbln does not support kwargs {kwargs.keys()} for {self.__class__.__name__}."
             )
 
-        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_attentions = output_attentions if output_attentions is not None else self.rbln_config.output_attentions
         output_hidden_states = (
-            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+            output_hidden_states if output_hidden_states is not None else self.rbln_config.output_hidden_states
         )
 
         if output_attentions != self.rbln_config.output_attentions:


### PR DESCRIPTION
# Pull Request Description

Make the saving of rbln_config for output_attention, output_hiddens_states behave like huggingface and follow it at inference time.


## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] New Model Support
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (If needed)

## Additional Information
<!-- Any additional information, configuration, or data that might be necessary to reproduce the issue or use the new feature -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only     
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update