### PR TITLE
doc: add docstrings for overridden `from_pretrained` methods

### DIFF
--- a/src/optimum/rbln/transformers/models/exaone/modeling_exaone.py
+++ b/src/optimum/rbln/transformers/models/exaone/modeling_exaone.py
@@ -14,16 +14,16 @@
 
 
 import inspect
-from typing import Any, Callable, Optional, Union, Dict
 from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Union
 
 from transformers import AutoModelForCausalLM
 from transformers.generation.utils import GenerationMixin
 
+from ....configuration_utils import RBLNModelConfig
 from ....utils import logging
 from ..decoderonly import RBLNDecoderOnlyModelForCausalLM
 from .exaone_architecture import ExaoneForCausalLMWrapper
-from ....configuration_utils import RBLNModelConfig
 
 
 logger = logging.get_logger(__name__)

--- a/src/optimum/rbln/transformers/models/midm/modeling_midm.py
+++ b/src/optimum/rbln/transformers/models/midm/modeling_midm.py
@@ -13,15 +13,17 @@
 # limitations under the License.
 
 import inspect
-from typing import Any, Callable, Optional, Union, Dict
 from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Union
+
 from transformers import AutoModelForCausalLM
 from transformers.generation.utils import GenerationMixin
 
+from ....configuration_utils import RBLNModelConfig
 from ....utils import logging
 from ..decoderonly import RBLNDecoderOnlyModelForCausalLM
 from .midm_architecture import MidmLMHeadModelWrapper
-from ....configuration_utils import RBLNModelConfig
+
 
 logger = logging.get_logger(__name__)
 


### PR DESCRIPTION
- docs: add docstrings for overridden classmethod `from_pretrained` (exaone, midm)

# Pull Request Description

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] New Model Support
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Checklist
<!-- Mark completed items with an [x] -->
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works (If needed)

## Additional Information
<!-- Any additional information, configuration, or data that might be necessary to reproduce the issue or use the new feature -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only     
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update