### PR TITLE
other: optimize package install in pytest

### DIFF
--- a/.github/workflows/check_code_quality.yml
+++ b/.github/workflows/check_code_quality.yml
@@ -23,9 +23,6 @@ jobs:
         with:
           ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
 
-      - name: Install dependencies
-        run: uv sync --frozen --only-group quality
-
       - name: Check style with ruff
         run: |
           uv run --no-sync ruff format --check .

--- a/.github/workflows/rbln_optimum_pytest.yaml
+++ b/.github/workflows/rbln_optimum_pytest.yaml
@@ -52,6 +52,9 @@ jobs:
     runs-on: ${{ (inputs.reuse_artifacts_path != '' && matrix.test_type == 'llm') && 'rbln-sw-k8s-4c-128gb' || (inputs.reuse_artifacts_path != '' && 'rbln-sw-k8s-4c-32gb' || 'rbln-sw-k8s-ca22-1') }}
     container:
       image: ${{ vars.DEV_CONTAINER_IMAGE }}
+    env:
+      # Use the uv cache baked into the CI image.
+      UV_CACHE_DIR: /opt/uv-cache
     strategy:
       fail-fast: ${{ inputs.fail_fast }}
       matrix: ${{ fromJson(
@@ -115,10 +118,21 @@ jobs:
           
           echo "skip=$SKIP" >> $GITHUB_OUTPUT
 
-      - name: Install optimum-rbln with tests group dependencies
+      - name: Install optimum-rbln (skip sync when possible)
         if: steps.should_skip.outputs.skip != 'true'
         run: |
-          uv sync --frozen --group tests --reinstall-package optimum-rbln
+          set -euo pipefail
+
+          # If the checked-out uv.lock matches what's already baked into the CI image,
+          # avoid `uv sync` (which can trigger index/network activity) and only install
+          # the local project into the existing environment.
+          if [ -f /opt/uv.lock.sha256 ] && sha256sum --check --status /opt/uv.lock.sha256; then
+            echo "uv.lock matches CI image; installing local checkout without syncing deps."
+            uv pip install --no-deps --no-build-isolation -e .
+          else
+            echo "uv.lock differs from CI image; syncing deps from lock."
+            uv sync --frozen --group tests
+          fi
 
       - name: Install rebel-compiler
         if: steps.should_skip.outputs.skip != 'true'

--- a/.github/workflows/rbln_optimum_pytest.yaml
+++ b/.github/workflows/rbln_optimum_pytest.yaml
@@ -128,7 +128,7 @@ jobs:
           # the local project into the existing environment.
           if [ -f /opt/uv.lock.sha256 ] && sha256sum --check --status /opt/uv.lock.sha256; then
             echo "uv.lock matches CI image; installing local checkout without syncing deps."
-            uv pip install --no-deps --no-build-isolation -e .
+            uv pip install --python /opt/venv/bin/python --no-deps --no-build-isolation -e .
           else
             echo "uv.lock differs from CI image; syncing deps from lock."
             uv sync --frozen --group tests

--- a/.github/workflows/rbln_optimum_pytest.yaml
+++ b/.github/workflows/rbln_optimum_pytest.yaml
@@ -52,9 +52,6 @@ jobs:
     runs-on: ${{ (inputs.reuse_artifacts_path != '' && matrix.test_type == 'llm') && 'rbln-sw-k8s-4c-128gb' || (inputs.reuse_artifacts_path != '' && 'rbln-sw-k8s-4c-32gb' || 'rbln-sw-k8s-ca22-1') }}
     container:
       image: ${{ vars.DEV_CONTAINER_IMAGE }}
-    env:
-      # Use the uv cache baked into the CI image.
-      UV_CACHE_DIR: /opt/uv-cache
     strategy:
       fail-fast: ${{ inputs.fail_fast }}
       matrix: ${{ fromJson(

--- a/.github/workflows/rbln_optimum_pytest.yaml
+++ b/.github/workflows/rbln_optimum_pytest.yaml
@@ -52,6 +52,9 @@ jobs:
     runs-on: ${{ (inputs.reuse_artifacts_path != '' && matrix.test_type == 'llm') && 'rbln-sw-k8s-4c-128gb' || (inputs.reuse_artifacts_path != '' && 'rbln-sw-k8s-4c-32gb' || 'rbln-sw-k8s-ca22-1') }}
     container:
       image: ${{ vars.DEV_CONTAINER_IMAGE }}
+    env:
+      # Use the uv cache baked into the CI image.
+      UV_CACHE_DIR: /opt/uv-cache
     strategy:
       fail-fast: ${{ inputs.fail_fast }}
       matrix: ${{ fromJson(

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -43,10 +43,6 @@ COPY --from=uv /uv /bin/uv
 ENV UV_PROJECT_ENVIRONMENT=/opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
 
-# Bake uv download cache into the image so CI jobs can reuse it without
-# relying on GitHub Actions cache between jobs/runs.
-ENV UV_CACHE_DIR=/opt/uv-cache
-
 WORKDIR /workspace
 
 # Copy only lockfiles first for better layer caching.
@@ -55,14 +51,8 @@ COPY pyproject.toml uv.lock /workspace/
 # Install dependencies (default + tests + quality) according to uv.lock.
 # We intentionally do NOT install the project itself, so the container can test arbitrary checkouts.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    UV_CACHE_DIR=/root/.cache/uv uv sync --frozen --group tests --group quality --no-install-project && \
-    # Build backends for installing local checkout without network (PEP 517/660).
-    # - hatchling/hatch-vcs: project build backend (version from VCS)
-    # - editables: required by hatchling for editable installs (PEP 660)
-    UV_CACHE_DIR=/root/.cache/uv uv pip install --python /opt/venv/bin/python packaging hatchling hatch-vcs editables && \
-    # Persist the populated uv cache into the image (runtime uses /opt/uv-cache).
-    mkdir -p /opt/uv-cache && cp -a /root/.cache/uv/. /opt/uv-cache/ && \
-    # Record the lockfile hash baked into this image (used by workflows to skip re-sync).
+    uv sync --frozen --group tests --group quality --no-install-project && \
+    uv pip install --python /opt/venv/bin/python packaging hatchling hatch-vcs editables && \
     sha256sum uv.lock > /opt/uv.lock.sha256
 
 

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -43,6 +43,10 @@ COPY --from=uv /uv /bin/uv
 ENV UV_PROJECT_ENVIRONMENT=/opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
 
+# Bake uv download cache into the image so CI jobs can reuse it without
+# relying on GitHub Actions cache between jobs/runs.
+ENV UV_CACHE_DIR=/opt/uv-cache
+
 WORKDIR /workspace
 
 # Copy only lockfiles first for better layer caching.
@@ -51,8 +55,14 @@ COPY pyproject.toml uv.lock /workspace/
 # Install dependencies (default + tests + quality) according to uv.lock.
 # We intentionally do NOT install the project itself, so the container can test arbitrary checkouts.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --group tests --group quality --no-install-project && \
-    uv pip install --python /opt/venv/bin/python packaging hatchling hatch-vcs editables && \
+    UV_CACHE_DIR=/root/.cache/uv uv sync --frozen --group tests --group quality --no-install-project && \
+    # Build backends for installing local checkout without network (PEP 517/660).
+    # - hatchling/hatch-vcs: project build backend (version from VCS)
+    # - editables: required by hatchling for editable installs (PEP 660)
+    UV_CACHE_DIR=/root/.cache/uv uv pip install --python /opt/venv/bin/python packaging hatchling hatch-vcs editables && \
+    # Persist the populated uv cache into the image (runtime uses /opt/uv-cache).
+    mkdir -p /opt/uv-cache && cp -a /root/.cache/uv/. /opt/uv-cache/ && \
+    # Record the lockfile hash baked into this image (used by workflows to skip re-sync).
     sha256sum uv.lock > /opt/uv.lock.sha256
 
 

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -43,6 +43,10 @@ COPY --from=uv /uv /bin/uv
 ENV UV_PROJECT_ENVIRONMENT=/opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
 
+# Bake uv download cache into the image so CI jobs can reuse it without
+# relying on GitHub Actions cache between jobs/runs.
+ENV UV_CACHE_DIR=/opt/uv-cache
+
 WORKDIR /workspace
 
 # Copy only lockfiles first for better layer caching.
@@ -51,7 +55,12 @@ COPY pyproject.toml uv.lock /workspace/
 # Install dependencies (default + tests + quality) according to uv.lock.
 # We intentionally do NOT install the project itself, so the container can test arbitrary checkouts.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --group tests --group quality --no-install-project && \
-    uv pip install packaging
+    UV_CACHE_DIR=/root/.cache/uv uv sync --frozen --group tests --group quality --no-install-project && \
+    # Build backends for installing local checkout without network (PEP 517/660).
+    UV_CACHE_DIR=/root/.cache/uv uv pip install hatchling hatch-vcs && \
+    # Persist the populated uv cache into the image (runtime uses /opt/uv-cache).
+    mkdir -p /opt/uv-cache && cp -a /root/.cache/uv/. /opt/uv-cache/ && \
+    # Record the lockfile hash baked into this image (used by workflows to skip re-sync).
+    sha256sum uv.lock > /opt/uv.lock.sha256
 
 

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -57,7 +57,9 @@ COPY pyproject.toml uv.lock /workspace/
 RUN --mount=type=cache,target=/root/.cache/uv \
     UV_CACHE_DIR=/root/.cache/uv uv sync --frozen --group tests --group quality --no-install-project && \
     # Build backends for installing local checkout without network (PEP 517/660).
-    UV_CACHE_DIR=/root/.cache/uv uv pip install hatchling hatch-vcs && \
+    # - hatchling/hatch-vcs: project build backend (version from VCS)
+    # - editables: required by hatchling for editable installs (PEP 660)
+    UV_CACHE_DIR=/root/.cache/uv uv pip install --python /opt/venv/bin/python packaging hatchling hatch-vcs editables && \
     # Persist the populated uv cache into the image (runtime uses /opt/uv-cache).
     mkdir -p /opt/uv-cache && cp -a /root/.cache/uv/. /opt/uv-cache/ && \
     # Record the lockfile hash baked into this image (used by workflows to skip re-sync).


### PR DESCRIPTION
# Pull Request Description

This PR optimizes CI installs for optimum-rbln by reducing unnecessary network traffic.
The CI Docker image now bakes in the uv download cache at /opt/uv-cache and records the baked uv.lock hash.
In the workflow, if the checked-out uv.lock matches the image, we skip uv sync and only install the local checkout (uv pip install -e .).
If uv.lock differs, we fall back to uv sync --frozen --group tests.
This keeps CI fast for most PRs while remaining correct when dependencies change.

> **⚠️ Important: Branch Target**
> - **New features, enhancements, and non-critical fixes**: Merge to `dev` branch
> - **Critical hotfixes only**: Merge to `main` branch (must also merge to `dev`)
> 
> Please ensure you've selected the correct base branch before submitting!

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Release (dev → main merge for production release)
- [ ] New Model Support
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Release
    - `release`: Merging dev to main for production release
      - ex) Release v1.2.0
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update