### PR TITLE
model: qwen3vl vit encoder support with tp

### DIFF
--- a/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -62,6 +62,7 @@ class RBLNQwen3VLVisionModel(RBLNModel):
 
     auto_model_class = None
     _supports_non_fp32 = True
+    _tp_support = True
 
     def __post_init__(self, **kwargs):
         self.transformer = self.model[0]

--- a/src/optimum/rbln/transformers/models/qwen3_vl/qwen3_vl_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/qwen3_vl_architecture.py
@@ -112,11 +112,6 @@ class Qwen3VLVisionAttention(nn.Module):
         self.head_dim = getattr(model, "head_dim", model.proj.in_features // model.num_heads)
         self.qkv = model.qkv
         self.proj = model.proj
-        self.q_dim = self.num_heads * self.head_dim
-        qkv_out_dim = getattr(self.qkv, "out_features", self.q_dim * 3)
-        kv_total_dim = qkv_out_dim - self.q_dim
-        self.kv_dim = kv_total_dim // 2
-        self.num_key_value_heads = self.kv_dim // self.head_dim
         self.scale = torch.tensor(1 / math.sqrt(self.head_dim), dtype=rbln_config.dtype)
 
     def forward(
@@ -126,16 +121,10 @@ class Qwen3VLVisionAttention(nn.Module):
         position_embeddings: Tuple[torch.Tensor, torch.Tensor],
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
-        qkv = self.qkv(hidden_states)
-        q, k, v = torch.split(qkv, [self.q_dim, self.kv_dim, self.kv_dim], dim=-1)
-
-        q = q.view(seq_length, self.num_heads, self.head_dim).permute(1, 0, 2).unsqueeze(0)
-        k = k.view(seq_length, self.num_key_value_heads, self.head_dim)
-        v = v.view(seq_length, self.num_key_value_heads, self.head_dim)
-        repeat_factor = self.num_heads // self.num_key_value_heads
-        k = k.repeat_interleave(repeat_factor, dim=1).permute(1, 0, 2).unsqueeze(0)
-        v = v.repeat_interleave(repeat_factor, dim=1).permute(1, 0, 2).unsqueeze(0)
-
+        hidden_states = hidden_states.unsqueeze(0)
+        q, k, v = (
+            self.qkv(hidden_states).reshape(1, seq_length, 3, self.num_heads, -1).permute(2, 0, 3, 1, 4).unbind(0)
+        )
         cos, sin = position_embeddings
         q, k = apply_rotary_pos_emb(q, k, cos, sin)
         attn_output = nn.functional.scaled_dot_product_attention(

--- a/src/optimum/rbln/transformers/models/qwen3_vl/qwen3_vl_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/qwen3_vl_architecture.py
@@ -112,6 +112,11 @@ class Qwen3VLVisionAttention(nn.Module):
         self.head_dim = getattr(model, "head_dim", model.proj.in_features // model.num_heads)
         self.qkv = model.qkv
         self.proj = model.proj
+        self.q_dim = self.num_heads * self.head_dim
+        qkv_out_dim = getattr(self.qkv, "out_features", self.q_dim * 3)
+        kv_total_dim = qkv_out_dim - self.q_dim
+        self.kv_dim = kv_total_dim // 2
+        self.num_key_value_heads = self.kv_dim // self.head_dim
         self.scale = torch.tensor(1 / math.sqrt(self.head_dim), dtype=rbln_config.dtype)
 
     def forward(
@@ -121,10 +126,16 @@ class Qwen3VLVisionAttention(nn.Module):
         position_embeddings: Tuple[torch.Tensor, torch.Tensor],
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
-        hidden_states = hidden_states.unsqueeze(0)
-        q, k, v = (
-            self.qkv(hidden_states).reshape(1, seq_length, 3, self.num_heads, -1).permute(2, 0, 3, 1, 4).unbind(0)
-        )
+        qkv = self.qkv(hidden_states)
+        q, k, v = torch.split(qkv, [self.q_dim, self.kv_dim, self.kv_dim], dim=-1)
+
+        q = q.view(seq_length, self.num_heads, self.head_dim).permute(1, 0, 2).unsqueeze(0)
+        k = k.view(seq_length, self.num_key_value_heads, self.head_dim)
+        v = v.view(seq_length, self.num_key_value_heads, self.head_dim)
+        repeat_factor = self.num_heads // self.num_key_value_heads
+        k = k.repeat_interleave(repeat_factor, dim=1).permute(1, 0, 2).unsqueeze(0)
+        v = v.repeat_interleave(repeat_factor, dim=1).permute(1, 0, 2).unsqueeze(0)
+
         cos, sin = position_embeddings
         q, k = apply_rotary_pos_emb(q, k, cos, sin)
         attn_output = nn.functional.scaled_dot_product_attention(


### PR DESCRIPTION
# Pull Request Description

As the attention-forward architecture of the ViT encoder is incompatible with compiler sharding, the model has been redesigned to support RSD.

> **⚠️ Important: Branch Target**
> - **New features, enhancements, and non-critical fixes**: Merge to `dev` branch
> - **Critical hotfixes only**: Merge to `main` branch (must also merge to `dev`)
> 
> Please ensure you've selected the correct base branch before submitting!

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Release (dev → main merge for production release)
- [x] New Model Support
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Release
    - `release`: Merging dev to main for production release
      - ex) Release v1.2.0
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update