### PR TITLE
model: use F.scaled_dot_product_attention for ViT-family attention

### DIFF
--- a/src/optimum/rbln/transformers/models/pixtral/pixtral_architecture.py
+++ b/src/optimum/rbln/transformers/models/pixtral/pixtral_architecture.py
@@ -61,12 +61,10 @@ class PixtralAttention(nn.Module):
         sin = sin[None, None, None, :, :]
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
-        attn_weights = torch.matmul(query_states, key_states.transpose(3, 4)) * self.scaling
-        attn_weights = attn_weights + attention_mask
-        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32)
-        attn_output = torch.matmul(attn_weights, value_states)
+        attn_output = nn.functional.scaled_dot_product_attention(
+            query_states, key_states, value_states, attn_mask=attention_mask, scale=self.scaling
+        )
         attn_output = attn_output.transpose(1, 3)
-
         attn_output = attn_output.reshape(batch_size, patches, -1)
         attn_output = self.o_proj(attn_output)
 

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/qwen2_5_vl_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/qwen2_5_vl_architecture.py
@@ -111,10 +111,9 @@ class Qwen2_5_VLVisionFullAttention(nn.Module):
         cos, sin = position_embeddings
         q, k = apply_rotary_pos_emb(q, k, cos, sin)
 
-        attn_weights = torch.matmul(q, k.transpose(2, 3)) * self.scale
-        attn_weights = attn_weights + attn_masks
-        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=hidden_states.dtype)
-        attn_output = torch.matmul(attn_weights, v)
+        attn_output = nn.functional.scaled_dot_product_attention(
+            q, k, v, attn_mask=attn_masks, scale=self.scale
+        )
         attn_output = attn_output.transpose(1, 2)
         attn_output = attn_output.reshape(1, seq_length, -1)
         attn_output = self.proj(attn_output).squeeze(0)
@@ -161,11 +160,9 @@ class Qwen2_5_VLVisionWindowAttention(nn.Module):
         sin = sin.reshape(num_windows, 1, seq_length // num_windows, -1)
         q, k = apply_rotary_pos_emb(q, k, cos, sin)
 
-        attn_weights = torch.matmul(q, k.transpose(2, 3)) * self.scale
-
-        attn_weights = attn_weights + attn_masks
-        attn_weights = nn.functional.softmax(attn_weights, dim=-1)
-        attn_output = torch.matmul(attn_weights, v)
+        attn_output = nn.functional.scaled_dot_product_attention(
+            q, k, v, attn_mask=attn_masks, scale=self.scale
+        )
         attn_output = attn_output.transpose(1, 2)
         attn_output = attn_output.reshape(1, seq_length, -1)
         attn_output = self.proj(attn_output).squeeze(0)

--- a/src/optimum/rbln/transformers/models/qwen2_vl/qwen2_vl_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen2_vl/qwen2_vl_architecture.py
@@ -95,10 +95,9 @@ class VisionAttention(nn.Module):
         cos, sin = position_embeddings
         q, k = apply_rotary_pos_emb(q, k, cos, sin)
 
-        attn_weights = torch.matmul(q, k.transpose(2, 3)) * self.scale
-        attn_weights = attn_weights + attn_masks
-        attn_weights = nn.functional.softmax(attn_weights, dim=-1)
-        attn_output = torch.matmul(attn_weights, v)
+        attn_output = torch.nn.functional.scaled_dot_product_attention(
+            q, k, v, attn_mask=attn_masks, scale=self.scale
+        )
         attn_output = attn_output.transpose(1, 2)
         attn_output = attn_output.reshape(1, seq_length, -1)
         attn_output = self.proj(attn_output).squeeze(0)


### PR DESCRIPTION
## Summary

Replace manual `matmul → softmax → matmul` attention in ViT-family vision modules with `F.scaled_dot_product_attention`. This routes the op through rbln-compiler's dedicated SDPA custom-op path (mapped to `__paged_normal_*_sdpa_{5d,6d}_` kernels) instead of the generic relay fallback, improving numerical stability under `compDtype=bfloat`.

### Affected models

- `qwen2_vl` — `VisionAttention`
- `qwen2_5_vl` — `Qwen2_5_VLVisionFullAttention`, `Qwen2_5_VLVisionWindowAttention`
- `pixtral` — `PixtralAttention`

`Qwen3VLVisionAttention` already uses SDPA. GroundingDINO variants use non-standard attention (dual-softmax / grid_sample) and are not applicable.

## 4D vs 5D tensor rank

Each model keeps its **original Q/K/V rank** — no forced unification. rbln-compiler dispatches to different kernels based on rank:

| Input rank | Internal layout | Kernel |
|---|---|---|
| 4D `[B, H, L, D]` | `NHCW64c` | `__paged_normal_*_sdpa_5d_` |
| 5D `[B, H, 1, L, D]` | `NDHCW64c` | `__paged_normal_*_sdpa_6d_` |

The SDPA converter path in `rebel.core.custom_converter._pt_attention` has no rank assertion, so both 4D and 5D work.

| Model | Rank | Kernel |
|---|---|---|
| Qwen2-VL | 4D | `_5d_` |
| Qwen2.5-VL Full / Window | 4D | `_5d_` |
| Pixtral | 5D | `_6d_` |
| Qwen3-VL (unchanged) | 4D | `_5d_` |

## Test plan

- [ ] Qwen2-VL / ColQwen2 retrieval — compile + accuracy
- [ ] Qwen2.5-VL image/video — compile + correlation vs native
- [ ] Pixtral vision encoder — compile + accuracy
- [ ] Qwen3-VL regression (shares compiler path)