### PR TITLE
doc(t5): fix Optimum RBLN Overview link for MkDocs

### DIFF
--- a/src/optimum/rbln/transformers/models/t5/modeling_t5.py
+++ b/src/optimum/rbln/transformers/models/t5/modeling_t5.py
@@ -48,7 +48,7 @@ class RBLNT5EncoderModel(RBLNTransformerEncoderForFeatureExtraction):
 
     Important Note:
         This model supports various sizes of the T5EncoderModel. For optimal performance, it is highly recommended to adjust the tensor parallelism setting
-        based on the model size. Please refer to the [Optimum RBLN Overview](../../../optimum_rbln.md) for guidance on choosing the appropriate tensor parallelism size for your model.
+        based on the model size. Please refer to the [Optimum RBLN Overview](../../../index.md) for guidance on choosing the appropriate tensor parallelism size for your model.
 
     Examples:
         ```python
@@ -93,7 +93,7 @@ class RBLNT5ForConditionalGeneration(RBLNModelForSeq2SeqLM):
 
     Important Note:
         This model supports various sizes of the T5ForConditionalGeneration. For optimal performance, it is highly recommended to adjust the tensor parallelism setting
-        based on the model size. Please refer to the [Optimum RBLN Overview](../../../optimum_rbln.md) for guidance on choosing the appropriate tensor parallelism size for your model.
+        based on the model size. Please refer to the [Optimum RBLN Overview](../../../index.md) for guidance on choosing the appropriate tensor parallelism size for your model.
 
 
     Examples:


### PR DESCRIPTION
## Summary
T5 model docstrings used `../../../optimum_rbln.md`, which does not exist in the RBLN SDK documentation build. Linkchecker on `rbln_sdk_doc` then reported 404s from the generated T5 API pages.

## Change
Point the **Optimum RBLN Overview** link to `../../../index.md`, which resolves to `software/optimum/index.md` in the built site (same section as the main Optimum RBLN overview).

## Note
Rebased onto current `dev` (replaces the previous branch tip that was based on an older commit).