### PR TITLE
other: fix circular import error

### DIFF
--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -1,12 +1,15 @@
 import math
 from collections import defaultdict
-from typing import Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple
 
 import rebel
 
 from ..utils.logging import get_logger
 from ..utils.runtime_utils import get_available_dram, is_compiler_supports_buffer_resize
-from .models.decoderonly.configuration_decoderonly import RBLNDecoderOnlyModelForCausalLMConfig
+
+
+if TYPE_CHECKING:
+    from .models.decoderonly.configuration_decoderonly import RBLNDecoderOnlyModelForCausalLMConfig
 
 
 logger = get_logger()
@@ -102,7 +105,7 @@ def validate_attention_method(attn_impl: str, kvcache_partition_len: int, kvcach
             )
 
 
-def validate_sliding_window(rbln_config: RBLNDecoderOnlyModelForCausalLMConfig):
+def validate_sliding_window(rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig"):
     if rbln_config.sliding_window > MAX_SLIDING_WINDOW_SIZE - rbln_config.prefill_chunk_size:
         raise ValueError(
             f"Sliding window size ({rbln_config.sliding_window}) must be less than 32768 - prefill_chunk_size ({32768 - rbln_config.prefill_chunk_size})"
@@ -145,7 +148,7 @@ def format_byte_size(nbytes: int) -> str:
 class RBLNDecoderOnlyFlashAttentionMixin:
     @classmethod
     def set_kvcache_num_blocks_after_compilation(
-        cls, compiled_models: dict[str, rebel.RBLNCompiledModel], rbln_config: RBLNDecoderOnlyModelForCausalLMConfig
+        cls, compiled_models: dict[str, rebel.RBLNCompiledModel], rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig"
     ):
         rbln_config.kvcache_num_blocks = cls.estimate_num_kvcache_blocks(
             compiled_models=compiled_models, rbln_config=rbln_config
@@ -163,7 +166,7 @@ class RBLNDecoderOnlyFlashAttentionMixin:
     def estimate_num_kvcache_blocks(
         cls,
         compiled_models: dict[str, rebel.RBLNCompiledModel],
-        rbln_config: RBLNDecoderOnlyModelForCausalLMConfig,
+        rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
         available_dram: Optional[int] = None,
     ) -> int:
         if available_dram is None:
@@ -269,7 +272,7 @@ class RBLNDecoderOnlyFlashAttentionMixin:
     def multiply_kv_cache_num_blocks(
         cls,
         compiled_models: dict[str, rebel.RBLNCompiledModel],
-        rbln_config: RBLNDecoderOnlyModelForCausalLMConfig,
+        rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
         multiplier: int,
     ):
         if not is_compiler_supports_buffer_resize():


### PR DESCRIPTION
# Pull Request Description
## Fix circular import in `modeling_attention_utils`
Importing constants like `DEFAULT_FLASH_ATTN_PARTITION_LENGTH` from `modeling_attention_utils` as the first entry point triggers a circular import error. This happens because the module unconditionally imports `RBLNDecoderOnlyModelForCausalLMConfig` at the top level, which kicks off a cycle back to this module before it finishes initializing.
Since `RBLNDecoderOnlyModelForCausalLMConfig` is only used in type annotations, move the import under `TYPE_CHECKING` and quote the annotation strings.

> **⚠️ Important: Branch Target**
> - **New features, enhancements, and non-critical fixes**: Merge to `dev` branch
> - **Critical hotfixes only**: Merge to `main` branch (must also merge to `dev`)
> 
> Please ensure you've selected the correct base branch before submitting!

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Release (dev → main merge for production release)
- [ ] New Model Support
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Release
    - `release`: Merging dev to main for production release
      - ex) Release v1.2.0
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update