### PR TITLE
refactor(custom_op): align signatures with vllm-rbln and use kwargs at call sites

### DIFF
--- a/src/optimum/rbln/ops/attn.py
+++ b/src/optimum/rbln/ops/attn.py
@@ -33,7 +33,6 @@ def paged_attn_decode(
     scale: Tensor,
     block_table: Tensor,
     block_size: int,
-    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -50,7 +49,6 @@ def paged_attn_decode_fake(
     scale: Tensor,
     block_table: Tensor,
     block_size: int,
-    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -72,7 +70,6 @@ def paged_attn_decode_kv_fp8(
     block_size: int,
     k_scale: Tensor,
     v_scale: Tensor,
-    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -91,7 +88,6 @@ def paged_attn_decode_kv_fp8_fake(
     block_size: int,
     k_scale: Tensor,
     v_scale: Tensor,
-    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -111,7 +107,6 @@ def paged_attn_prefill(
     scale: Tensor,
     block_table: Tensor,
     block_size: int,
-    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     """Defines the computation pattern for prefill phase attention with KV cache updates.
 
@@ -152,7 +147,6 @@ def paged_attn_prefill_fake(
     scale: Tensor,
     block_table: Tensor,
     block_size: int,
-    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -174,7 +168,6 @@ def paged_attn_prefill_kv_fp8(
     block_size: int,
     k_scale: Tensor,
     v_scale: Tensor,
-    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -193,7 +186,6 @@ def paged_attn_prefill_kv_fp8_fake(
     block_size: int,
     k_scale: Tensor,
     v_scale: Tensor,
-    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -427,7 +419,6 @@ def paged_add_softmax_attn_decode(
     scale: Tensor,
     block_table: Tensor,
     block_size: int,
-    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     """Defines the computation pattern for fused attention with KV cache updates.
 
@@ -470,6 +461,5 @@ def paged_add_softmax_attn_decode_fake(
     scale: Tensor,
     block_table: Tensor,
     block_size: int,
-    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)

--- a/src/optimum/rbln/ops/attn.py
+++ b/src/optimum/rbln/ops/attn.py
@@ -33,6 +33,7 @@ def paged_attn_decode(
     scale: Tensor,
     block_table: Tensor,
     block_size: int,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -49,6 +50,7 @@ def paged_attn_decode_fake(
     scale: Tensor,
     block_table: Tensor,
     block_size: int,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -70,6 +72,7 @@ def paged_attn_decode_kv_fp8(
     block_size: int,
     k_scale: Tensor,
     v_scale: Tensor,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -88,6 +91,7 @@ def paged_attn_decode_kv_fp8_fake(
     block_size: int,
     k_scale: Tensor,
     v_scale: Tensor,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -107,6 +111,7 @@ def paged_attn_prefill(
     scale: Tensor,
     block_table: Tensor,
     block_size: int,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     """Defines the computation pattern for prefill phase attention with KV cache updates.
 
@@ -147,6 +152,7 @@ def paged_attn_prefill_fake(
     scale: Tensor,
     block_table: Tensor,
     block_size: int,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -168,6 +174,7 @@ def paged_attn_prefill_kv_fp8(
     block_size: int,
     k_scale: Tensor,
     v_scale: Tensor,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -186,6 +193,7 @@ def paged_attn_prefill_kv_fp8_fake(
     block_size: int,
     k_scale: Tensor,
     v_scale: Tensor,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -205,7 +213,7 @@ def paged_causal_attn_decode(
     block_table: Tensor,
     block_size: int,
     mask: Optional[Tensor] = None,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     """Defines the computation pattern for fused attention with KV cache updates.
 
@@ -229,7 +237,7 @@ def paged_causal_attn_decode(
     - block_table: [batch_size, max_seq_len // block_size] - Block indices for KV cache management
     - block_size: [] - Number of tokens per block
     - mask: [batch=1, max_seq_len] - attention mask when use position_ids
-    - s_aux: [num_attention_heads, sink_len] - auxiliary states for attention
+    - sinks: [num_attention_heads, sink_len] - auxiliary states for attention
 
     Returns:
         Tensor: attn_output: [batch=1, n_heads, n_groups, 1, head_dim] - Attention output
@@ -249,7 +257,7 @@ def paged_causal_attn_decode_fake(
     block_table: Tensor,
     block_size: int,
     mask: Optional[Tensor] = None,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -270,7 +278,7 @@ def paged_causal_attn_prefill(
     block_size: int,
     is_bidirectional: bool,
     mask: Optional[Tensor] = None,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     """Defines the computation pattern for prefill phase attention with KV cache updates.
 
@@ -294,7 +302,7 @@ def paged_causal_attn_prefill(
     - block_size: [] - Number of tokens per block
     - is_bidirectional: [] - Whether the attention is bidirectional at current sequence position
     - mask: [batch=1, max_seq_len] - attention mask when use position_ids
-    - s_aux: [num_attention_heads, sink_len] - auxiliary states for attention
+    - sinks: [num_attention_heads, sink_len] - auxiliary states for attention
 
     Returns:
         Tensor: attn_output: [batch=1, n_heads, n_groups, seq_len, head_dim] - Attention output
@@ -315,7 +323,7 @@ def paged_causal_attn_prefill_fake(
     block_size: int,
     is_bidirectional: bool,
     mask: Optional[Tensor] = None,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -337,7 +345,7 @@ def paged_causal_attn_decode_kv_fp8(
     k_scale: Tensor,
     v_scale: Tensor,
     mask: Optional[Tensor] = None,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -356,7 +364,7 @@ def paged_causal_attn_decode_kv_fp8_fake(
     k_scale: Tensor,
     v_scale: Tensor,
     mask: Optional[Tensor] = None,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -379,7 +387,7 @@ def paged_causal_attn_prefill_kv_fp8(
     k_scale: Tensor,
     v_scale: Tensor,
     mask: Optional[Tensor] = None,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -399,7 +407,7 @@ def paged_causal_attn_prefill_kv_fp8_fake(
     k_scale: Tensor,
     v_scale: Tensor,
     mask: Optional[Tensor] = None,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -419,6 +427,7 @@ def paged_add_softmax_attn_decode(
     scale: Tensor,
     block_table: Tensor,
     block_size: int,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     """Defines the computation pattern for fused attention with KV cache updates.
 
@@ -461,5 +470,6 @@ def paged_add_softmax_attn_decode_fake(
     scale: Tensor,
     block_table: Tensor,
     block_size: int,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)

--- a/src/optimum/rbln/ops/flash_attn.py
+++ b/src/optimum/rbln/ops/flash_attn.py
@@ -34,7 +34,6 @@ def paged_flash_attn_decode(
     block_table: Tensor,
     block_size: int,
     partition: int,
-    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     """Defines the computation pattern for fused flash attention with KV cache for decoding.
 
@@ -56,7 +55,6 @@ def paged_flash_attn_decode_fake(
     block_table: Tensor,
     block_size: int,
     partition: int,
-    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -79,7 +77,6 @@ def paged_flash_attn_decode_kv_fp8(
     partition: int,
     k_scale: Tensor,
     v_scale: Tensor,
-    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -99,7 +96,6 @@ def paged_flash_attn_decode_kv_fp8_fake(
     partition: int,
     k_scale: Tensor,
     v_scale: Tensor,
-    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -120,7 +116,6 @@ def paged_flash_attn_prefill(
     block_table: Tensor,
     block_size: int,
     partition: int,
-    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     """Defines the computation pattern for fused flash attention with KV cache for prefill.
 
@@ -142,7 +137,6 @@ def paged_flash_attn_prefill_fake(
     block_table: Tensor,
     block_size: int,
     partition: int,
-    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -165,7 +159,6 @@ def paged_flash_attn_prefill_kv_fp8(
     partition: int,
     k_scale: Tensor,
     v_scale: Tensor,
-    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -185,7 +178,6 @@ def paged_flash_attn_prefill_kv_fp8_fake(
     partition: int,
     k_scale: Tensor,
     v_scale: Tensor,
-    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 

--- a/src/optimum/rbln/ops/flash_attn.py
+++ b/src/optimum/rbln/ops/flash_attn.py
@@ -34,6 +34,7 @@ def paged_flash_attn_decode(
     block_table: Tensor,
     block_size: int,
     partition: int,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     """Defines the computation pattern for fused flash attention with KV cache for decoding.
 
@@ -55,6 +56,7 @@ def paged_flash_attn_decode_fake(
     block_table: Tensor,
     block_size: int,
     partition: int,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -77,6 +79,7 @@ def paged_flash_attn_decode_kv_fp8(
     partition: int,
     k_scale: Tensor,
     v_scale: Tensor,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -96,6 +99,7 @@ def paged_flash_attn_decode_kv_fp8_fake(
     partition: int,
     k_scale: Tensor,
     v_scale: Tensor,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -116,6 +120,7 @@ def paged_flash_attn_prefill(
     block_table: Tensor,
     block_size: int,
     partition: int,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     """Defines the computation pattern for fused flash attention with KV cache for prefill.
 
@@ -137,6 +142,7 @@ def paged_flash_attn_prefill_fake(
     block_table: Tensor,
     block_size: int,
     partition: int,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -159,6 +165,7 @@ def paged_flash_attn_prefill_kv_fp8(
     partition: int,
     k_scale: Tensor,
     v_scale: Tensor,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -178,6 +185,7 @@ def paged_flash_attn_prefill_kv_fp8_fake(
     partition: int,
     k_scale: Tensor,
     v_scale: Tensor,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -198,7 +206,7 @@ def paged_flash_causal_attn_decode(
     block_size: int,
     partition: int,
     mask: Optional[Tensor] = None,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     """Defines the computation pattern for fused causal flash attention with KV cache for decoding.
 
@@ -220,7 +228,7 @@ def paged_flash_causal_attn_decode_fake(
     block_size: int,
     partition: int,
     mask: Optional[Tensor] = None,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -243,7 +251,7 @@ def paged_flash_causal_attn_decode_kv_fp8(
     k_scale: Tensor,
     v_scale: Tensor,
     mask: Optional[Tensor] = None,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -263,7 +271,7 @@ def paged_flash_causal_attn_decode_kv_fp8_fake(
     k_scale: Tensor,
     v_scale: Tensor,
     mask: Optional[Tensor] = None,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -285,7 +293,7 @@ def paged_flash_causal_attn_prefill(
     partition: int,
     is_bidirectional: bool,
     mask: Optional[Tensor] = None,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     """Defines the computation pattern for fused causal flash attention with KV cache for prefill.
 
@@ -308,7 +316,7 @@ def paged_flash_causal_attn_prefill_fake(
     partition: int,
     is_bidirectional: bool,
     mask: Optional[Tensor] = None,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -332,7 +340,7 @@ def paged_flash_causal_attn_prefill_kv_fp8(
     k_scale: Tensor,
     v_scale: Tensor,
     mask: Optional[Tensor] = None,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -353,6 +361,6 @@ def paged_flash_causal_attn_prefill_kv_fp8_fake(
     k_scale: Tensor,
     v_scale: Tensor,
     mask: Optional[Tensor] = None,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)

--- a/src/optimum/rbln/ops/moe.py
+++ b/src/optimum/rbln/ops/moe.py
@@ -34,6 +34,8 @@ def custom_moe_glu(
     gate_proj_bias: Optional[Tensor] = None,
     up_proj_bias: Optional[Tensor] = None,
     down_proj_bias: Optional[Tensor] = None,
+    expert_map: Optional[Tensor] = None,
+    dp_mask: Optional[Tensor] = None,
 ) -> Tensor:
     """
     Customized MoE GLU operation.
@@ -52,6 +54,8 @@ def custom_moe_glu(
     - gate_proj_bias: [num_experts, intermediate_size]
     - up_proj_bias: [num_experts, intermediate_size]
     - down_proj_bias: [num_experts, hidden_size]
+    - expert_map: [num_experts] global->local expert index mapping (torch.distributed)
+    - dp_mask: data-parallel mask (torch.distributed)
 
     Returns:
         Tensor: [batch * seq_len, hidden_size]
@@ -73,6 +77,8 @@ def custom_moe_glu_fake(
     gate_proj_bias: Optional[Tensor] = None,
     up_proj_bias: Optional[Tensor] = None,
     down_proj_bias: Optional[Tensor] = None,
+    expert_map: Optional[Tensor] = None,
+    dp_mask: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(hidden_states)
 
@@ -88,6 +94,8 @@ def custom_moe_ff(
     masked_routing_weight: Tensor,
     gate_proj_bias: Optional[Tensor] = None,
     down_proj_bias: Optional[Tensor] = None,
+    expert_map: Optional[Tensor] = None,
+    dp_mask: Optional[Tensor] = None,
 ) -> Tensor:
     """
     Customized MoE FF operation.
@@ -99,6 +107,8 @@ def custom_moe_ff(
     - masked_routing_weight: [batch * seq_len, num_experts]
     - gate_proj_bias: [num_experts * intermediate_size]
     - down_proj_bias: [hidden_size]
+    - expert_map: [num_experts] global->local expert index mapping (torch.distributed)
+    - dp_mask: data-parallel mask (torch.distributed)
 
     Returns:
         Tensor: [batch * seq_len, hidden_size]
@@ -114,6 +124,8 @@ def custom_moe_ff_fake(
     masked_routing_weight: Tensor,
     gate_proj_bias: Optional[Tensor] = None,
     down_proj_bias: Optional[Tensor] = None,
+    expert_map: Optional[Tensor] = None,
+    dp_mask: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(hidden_states)
 
@@ -139,6 +151,8 @@ def custom_moe_glu_mxfp4(
     limit: Tensor,
     k: int,
     post_norm: bool,
+    expert_map: Optional[Tensor] = None,
+    dp_mask: Optional[Tensor] = None,
 ) -> Tensor:
     """
     Customized MoE GLU operation.
@@ -189,5 +203,7 @@ def custom_moe_glu_mxfp4_fake(
     limit: Tensor,
     k: int,
     post_norm: bool,
+    expert_map: Optional[Tensor] = None,
+    dp_mask: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(hidden_states)

--- a/src/optimum/rbln/ops/sliding_window_attn.py
+++ b/src/optimum/rbln/ops/sliding_window_attn.py
@@ -35,7 +35,7 @@ def paged_sliding_window_attn_prefill(
     block_table: Tensor,
     block_size: int,
     is_bidirectional: bool,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     """Defines the computation pattern for prefill phase attention with KV cache updates.
 
@@ -56,7 +56,7 @@ def paged_sliding_window_attn_prefill(
     - cache_offset: [] - The valid length in the combined sequence of the KV cache and the current projected key states.
     - scale: [] - Attention scale factor
     - is_bidirectional: [] - Whether the attention is bidirectional
-    - s_aux: [num_attention_heads, sink_len] - auxiliary states for attention
+    - sinks: [num_attention_heads, sink_len] - auxiliary states for attention
     Returns:
         Tensor: attn_output: [batch=1, n_heads, n_groups, seq_len, head_dim] - Attention output
     """
@@ -76,7 +76,7 @@ def paged_sliding_window_attn_prefill_fake(
     block_table: Tensor,
     block_size: int,
     is_bidirectional: bool,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -97,7 +97,7 @@ def paged_sliding_window_attn_decode(
     block_table: Tensor,
     block_size: int,
     attn_mask: Tensor,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)
 
@@ -115,6 +115,6 @@ def paged_sliding_window_attn_decode_fake(
     block_table: Tensor,
     block_size: int,
     attn_mask: Tensor,
-    s_aux: Optional[Tensor] = None,
+    sinks: Optional[Tensor] = None,
 ) -> Tensor:
     return torch.empty_like(q)

--- a/src/optimum/rbln/transformers/models/decoderonly/decoderonly_architecture.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/decoderonly_architecture.py
@@ -850,7 +850,7 @@ class DecoderOnlyAttention(nn.Module):
             block_size=self.kvcache_block_size,
             k_scale=k_scale,
             v_scale=v_scale,
-            s_aux=getattr(self, "sinks", None),
+            sinks=getattr(self, "sinks", None),
         )
 
         # Check if using LoRALinear (which accepts lora_int_id) or standard linear layers
@@ -923,7 +923,7 @@ class AttentionOp(nn.Module):
         block_size: int,
         k_scale: Optional[torch.Tensor] = None,
         v_scale: Optional[torch.Tensor] = None,
-        s_aux: Optional[torch.Tensor] = None,
+        sinks: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Compute attention with static shapes and explicit cache management.
 
@@ -940,7 +940,7 @@ class AttentionOp(nn.Module):
             block_size: Block size for paged attention
             k_scale: Scale applied to key
             v_scale: Scale applied to value
-            s_aux: Auxiliary states for attention sinks
+            sinks: Auxiliary states for attention sinks
 
         Returns:
             Tensor: attention_output: [batch, num_heads, seq_len, head_dim]
@@ -996,8 +996,8 @@ class AttentionOp(nn.Module):
             op_args["k_scale"] = k_scale
             op_args["v_scale"] = v_scale
 
-        if s_aux is not None:
-            op_args["s_aux"] = s_aux
+        if sinks is not None:
+            op_args["sinks"] = sinks
 
         attn_op_name = self.get_attn_op_name()
         attn_op = getattr(torch.ops.rbln_custom_ops, attn_op_name, None)
@@ -1063,7 +1063,7 @@ class FlashAttentionOp(AttentionOp):
         block_size,
         k_scale=None,
         v_scale=None,
-        s_aux=None,
+        sinks=None,
     ):
         # reshape for removing repeat_kv (batch=1 , num_head, 1, q_len=1, head_dim)
         key_state = key_state.unsqueeze(2)
@@ -1117,8 +1117,8 @@ class FlashAttentionOp(AttentionOp):
             op_args["k_scale"] = k_scale
             op_args["v_scale"] = v_scale
 
-        if s_aux is not None:
-            op_args["s_aux"] = s_aux
+        if sinks is not None:
+            op_args["sinks"] = sinks
 
         attn_op_name = self.get_attn_op_name()
         attn_op = getattr(torch.ops.rbln_custom_ops, attn_op_name, None)
@@ -1172,7 +1172,7 @@ class SlidingWindowAttentionOp(AttentionOp):
         block_size: int,
         k_scale: Optional[torch.Tensor] = None,
         v_scale: Optional[torch.Tensor] = None,
-        s_aux: Optional[torch.Tensor] = None,
+        sinks: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         assert self.quantization is None, "Sliding window attention does not support quantization"
         assert k_scale is None and v_scale is None, "Sliding window attention does not support quantization"
@@ -1219,8 +1219,8 @@ class SlidingWindowAttentionOp(AttentionOp):
         elif self.phase == "decode":
             op_args["attn_mask"] = attn_mask
 
-        if s_aux is not None:
-            op_args["s_aux"] = s_aux
+        if sinks is not None:
+            op_args["sinks"] = sinks
 
         attn_op_name = self.get_attn_op_name()
         attn_op = getattr(torch.ops.rbln_custom_ops, attn_op_name, None)

--- a/src/optimum/rbln/transformers/models/seq2seq/seq2seq_architecture.py
+++ b/src/optimum/rbln/transformers/models/seq2seq/seq2seq_architecture.py
@@ -477,7 +477,6 @@ class Seq2SeqSelfAttention(nn.Module):
             "block_table": block_tables,
             "block_size": block_size,
             "mask": attention_mask.unsqueeze(2) if attention_mask is not None else None,
-            "sinks": None,
         }
 
         attn_output = self.attn_decode(**op_args)

--- a/src/optimum/rbln/transformers/models/seq2seq/seq2seq_architecture.py
+++ b/src/optimum/rbln/transformers/models/seq2seq/seq2seq_architecture.py
@@ -108,7 +108,10 @@ class Seq2SeqEncoderWrapper(nn.Module):
         cross_key_values = list(cross_key_values)
         for i in range(self.n_layer * 2):
             cross_key_values[i] = torch.ops.rbln_custom_ops.rbln_cache_update(
-                cross_key_values[i], cross_kv[i], b_idx[0], batch_axis
+                cache=cross_key_values[i],
+                state=cross_kv[i],
+                position=b_idx[0],
+                axis=batch_axis,
             )
 
         return cross_key_values
@@ -463,23 +466,21 @@ class Seq2SeqSelfAttention(nn.Module):
         value_states = self._shape(value_states, -1, bsz)
 
         block_size = past_key_value[0].shape[-2]
-        args = [
-            query_states,
-            key_states,
-            value_states,
-            past_key_value[0].view(bsz, self.num_heads, 1, -1, self.head_dim),
-            past_key_value[1].view(bsz, self.num_heads, 1, -1, self.head_dim),
-            cache_position,
-            torch.tensor(1.0, dtype=torch.float32),  # scale
-            block_tables,
-            block_size,
-        ]
-        if attention_mask is not None:
-            args.insert(3, attention_mask.unsqueeze(2))
-        else:
-            args.append(None)
+        op_args = {
+            "q": query_states,
+            "k": key_states,
+            "v": value_states,
+            "kcache": past_key_value[0].view(bsz, self.num_heads, 1, -1, self.head_dim),
+            "vcache": past_key_value[1].view(bsz, self.num_heads, 1, -1, self.head_dim),
+            "seq": cache_position,
+            "scale": torch.tensor(1.0, dtype=torch.float32),
+            "block_table": block_tables,
+            "block_size": block_size,
+            "mask": attention_mask.unsqueeze(2) if attention_mask is not None else None,
+            "sinks": None,
+        }
 
-        attn_output = self.attn_decode(*args)
+        attn_output = self.attn_decode(**op_args)
 
         attn_output = attn_output.view(bsz, self.num_heads, -1, self.head_dim).transpose(1, 2)
         attn_output = attn_output.reshape(bsz, -1, self.num_heads * self.head_dim)

--- a/src/optimum/rbln/transformers/models/t5/t5_architecture.py
+++ b/src/optimum/rbln/transformers/models/t5/t5_architecture.py
@@ -210,7 +210,6 @@ class T5LayerSelfAttention(Seq2SeqSelfAttention):
             scale=torch.tensor(1.0, dtype=torch.float32),
             block_table=block_tables,
             block_size=block_size,
-            sinks=None,
         )
 
         attn_output = attn_output.view(bsz, self.num_heads, -1, self.head_dim).transpose(1, 2)

--- a/src/optimum/rbln/transformers/models/t5/t5_architecture.py
+++ b/src/optimum/rbln/transformers/models/t5/t5_architecture.py
@@ -198,19 +198,19 @@ class T5LayerSelfAttention(Seq2SeqSelfAttention):
         value_states = self._shape(value_states, -1, bsz)
 
         block_size = past_key_value[0].shape[-2]
+        # Unsqueeze group axis since CustomKernel expects it for group query attention
         attn_output = self.attn_decode(
-            query_states,
-            key_states,
-            value_states,
-            attention_mask.unsqueeze(
-                2
-            ),  # Unsqueeze group axis since CustomKernel expects it for group query attention
-            past_key_value[0].view(bsz, self.num_heads, 1, -1, self.head_dim),
-            past_key_value[1].view(bsz, self.num_heads, 1, -1, self.head_dim),
-            cache_position,
-            torch.tensor(1.0, dtype=torch.float32),  # scale
-            block_tables,
-            block_size,
+            q=query_states,
+            k=key_states,
+            v=value_states,
+            mask=attention_mask.unsqueeze(2),
+            kcache=past_key_value[0].view(bsz, self.num_heads, 1, -1, self.head_dim),
+            vcache=past_key_value[1].view(bsz, self.num_heads, 1, -1, self.head_dim),
+            seq=cache_position,
+            scale=torch.tensor(1.0, dtype=torch.float32),
+            block_table=block_tables,
+            block_size=block_size,
+            sinks=None,
         )
 
         attn_output = attn_output.view(bsz, self.num_heads, -1, self.head_dim).transpose(1, 2)

--- a/src/optimum/rbln/transformers/models/time_series_transformer/time_series_transformers_architecture.py
+++ b/src/optimum/rbln/transformers/models/time_series_transformer/time_series_transformers_architecture.py
@@ -78,7 +78,12 @@ class TimeSeriesTransformersEncoderWrapper(torch.nn.Module):
         # 3. update cross_attention's past_key_value to the device-dram for optimization.
         bidx = torch.tensor(0, dtype=torch.int16)
         axis = torch.tensor(1, dtype=torch.int16)
-        enc_output = torch.ops.rbln_custom_ops.rbln_cache_update(cross_key_values, cross_kv, bidx, axis)
+        enc_output = torch.ops.rbln_custom_ops.rbln_cache_update(
+            cache=cross_key_values,
+            state=cross_kv,
+            position=bidx,
+            axis=axis,
+        )
 
         return enc_output
 

--- a/src/optimum/rbln/transformers/models/whisper/whisper_architecture.py
+++ b/src/optimum/rbln/transformers/models/whisper/whisper_architecture.py
@@ -71,7 +71,10 @@ class WhisperEncoderWrapper(torch.nn.Module):
         # 3. update cross_attention's past_key_value to the device-dram for optimization.
         batch_axis = torch.tensor(1, dtype=torch.int16)
         cross_key_values = torch.ops.rbln_custom_ops.rbln_cache_update(
-            cross_key_values, cross_kv, b_idx[0], batch_axis
+            cache=cross_key_values,
+            state=cross_kv,
+            position=b_idx[0],
+            axis=batch_axis,
         )
 
         return cross_key_values


### PR DESCRIPTION
## Summary
- Align custom_op signatures with vllm-rbln to reduce maintenance burden between the two interfaces (motivated by torch.distributed-related arg differences).
- Rename `s_aux` -> `sinks` across attention ops and add `sinks: Optional[Tensor] = None` to non-causal variants (`paged_attn_*`, `paged_flash_attn_*`, `paged_add_softmax_attn_decode`).
- Add `expert_map`, `dp_mask` Optional kwargs (torch.distributed args from vllm-rbln, default `None`) to MoE ops (`custom_moe_glu`, `custom_moe_ff`, `custom_moe_glu_mxfp4`).
- Convert remaining positional custom_op call sites to keyword arguments — pass `None` where the arg does not apply.
  - `t5_architecture.py` `self.attn_decode(...)`
  - `seq2seq_architecture.py` `self.attn_decode(*args)` (positional list with `insert`/`append`)
  - `rbln_cache_update(...)` in `whisper`, `seq2seq`, `time_series_transformer`
- Rename `s_aux` parameter to `sinks` in `decoderonly_architecture.py` (`AttentionOp`, `FlashAttentionOp`, `SlidingWindowAttentionOp`) so callers align with the new op signatures.

Out of scope:
- Op renames (e.g., `paged_attn_decode` -> `attention_naive_decode`) — tied to RBLN compiler pattern matching.
- Structural arg shape changes (separate `kcache`/`vcache` vs. vllm-rbln's combined `kv_cache`) — fundamental architectural difference.

## Test plan
- [x] `python -c "import optimum.rbln"` (sanity import) — verified locally.
- [x] Unit/integration tests covering each model touched: decoder-only LLM, T5, BART, Pegasus, Whisper, Time Series Transformer, Mixtral/Qwen2-MoE/Qwen3-MoE/Qwen3-VL-MoE/GPT-OSS.
- [x] Compilation smoke test for at least one attention variant and one MoE model to confirm the new signatures still match the RBLN compiler's expected pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)