### PR TITLE
model: respect checkpoint torch_dtype in RBLNModel.get_pytorch_model

### DIFF
--- a/src/optimum/rbln/modeling.py
+++ b/src/optimum/rbln/modeling.py
@@ -231,6 +231,14 @@ class RBLNModel(RBLNBaseModel):
     ) -> "PreTrainedModel":
         kwargs = cls.update_kwargs(kwargs)
 
+        # Default to following the checkpoint's dtype (config.json `torch_dtype`).
+        # Without this, HF `from_pretrained` upcasts all weights to torch.float32
+        # (the global default dtype), which silently inflates trace precision and
+        # can mask precision-sensitive compile decisions downstream.
+        # Users can still override by passing `dtype=...` or `torch_dtype=...`.
+        if "dtype" not in kwargs and "torch_dtype" not in kwargs:
+            kwargs["dtype"] = "auto"
+
         return cls.get_hf_class().from_pretrained(
             model_id,
             subfolder=subfolder,

--- a/src/optimum/rbln/modeling.py
+++ b/src/optimum/rbln/modeling.py
@@ -231,11 +231,7 @@ class RBLNModel(RBLNBaseModel):
     ) -> "PreTrainedModel":
         kwargs = cls.update_kwargs(kwargs)
 
-        # Default to following the checkpoint's dtype (config.json `torch_dtype`).
-        # Without this, HF `from_pretrained` upcasts all weights to torch.float32
-        # (the global default dtype), which silently inflates trace precision and
-        # can mask precision-sensitive compile decisions downstream.
-        # Users can still override by passing `dtype=...` or `torch_dtype=...`.
+        # Follow the checkpoint's dtype by default; override with `dtype=...`.
         if "dtype" not in kwargs and "torch_dtype" not in kwargs:
             kwargs["dtype"] = "auto"
 


### PR DESCRIPTION
## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Overview

Default `dtype` to `"auto"` in `RBLNModel.get_pytorch_model` so HF
`from_pretrained` follows the checkpoint's declared `torch_dtype`
(typically `bfloat16` for modern Hub models) instead of silently
upcasting every parameter to FP32.

```python
# src/optimum/rbln/modeling.py — RBLNModel.get_pytorch_model
if "dtype" not in kwargs and "torch_dtype" not in kwargs:
    kwargs["dtype"] = "auto"
```

Users can still override explicitly with `dtype=...` or the legacy
`torch_dtype=...` — both paths short-circuit the default.

## Motivation and Context

HF transformers `from_pretrained` upcasts every parameter to
`torch.float32` (PyTorch's global default dtype) when neither `dtype`
nor `torch_dtype` is passed, even if `config.json` declares
`torch_dtype: bfloat16`. The current `RBLNModel.get_pytorch_model`
passes `**kwargs` through without defaulting either field, so:

- **Memory waste at load**: a BF16 Hub checkpoint (e.g. Qwen2-VL)
  doubles in size when materialized as FP32 on host before tracing.
- **Trace precision drift**: the traced wrapper graph is FP32 end-to-end
  even for ops that should run BF16. Downstream rebel compiler passes
  then make precision decisions on an FP32 trace rather than the
  intended BF16 trace.
- **Hidden by `"auto"` opt-in**: HF documents that `dtype="auto"` is
  needed to pick up the checkpoint dtype — easy to miss. Most Hub
  models in 2025 ship `torch_dtype: bfloat16`, so "follow the
  checkpoint" is the better default for an inference-focused library.

### Concrete example

`Qwen2VisionTransformer`'s LayerNorm/Linear weights are stored as BF16
on the Hub. Without this fix, the optimum-rbln wrapper sees them as
FP32 (because `nn.LayerNorm`/`nn.Linear` `__init__` defaults to
`dtype=None` → `torch.get_default_dtype() == torch.float32`, and HF
doesn't override that without `dtype="auto"`). With this fix the
trace stays BF16 end-to-end, matching the checkpoint.

### Why this is safe

- **Backward compatible**: explicit user kwargs (`dtype=...` or
  `torch_dtype=...`) take precedence.
- **Quantized models**: `rbln_quantization.py` pops `dtype`/`torch_dtype`
  and ignores them — no conflict.
- **gpt-oss**: overrides `get_pytorch_model` entirely and has its own
  `_get_dtype` (bf16 default) — unaffected.
- **decoder-only**: calls `super().get_pytorch_model(...)` so picks up
  the new default; this matches the desired behavior for BF16-pretrained
  LLMs.
- **diffusers**: uses its own `from_pretrained` path (not
  `get_pytorch_model`) — unaffected.

## Related Issues

Investigation thread on the rebel_compiler side (DLF16/BF16 dtype
dispatch confusion in `DevFuncTypeCast` for Qwen2-VL vision tower).

🤖 Generated with [Claude Code](https://claude.com/claude-code)