### PR TITLE
other(test): fix disallowed flash-attn tests after lowered minimums (#569)

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -996,7 +996,7 @@ class TestDisallowedLlama_3(DisallowedTestBase.DisallowedTest):
 
 
 class TestDisallowedLlama_4(DisallowedTestBase.DisallowedTest):
-    # Flash attn : too short max_seq_len
+    # Flash attn : max_seq_len smaller than 2 * kvcache_partition_len (fewer than 2 partitions)
     RBLN_CLASS = RBLNLlamaForCausalLM
     HF_MODEL_ID = "afmck/testing-llama-tiny"
     HF_CONFIG_KWARGS = {"num_hidden_layers": 1, "max_position_embeddings": 1024}

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -992,14 +992,14 @@ class TestDisallowedLlama_3(DisallowedTestBase.DisallowedTest):
     RBLN_CLASS = RBLNLlamaForCausalLM
     HF_MODEL_ID = "afmck/testing-llama-tiny"
     HF_CONFIG_KWARGS = {"num_hidden_layers": 1, "max_position_embeddings": 8192}
-    RBLN_CLASS_KWARGS = {"rbln_config": {"attn_impl": "flash_attn", "kvcache_partition_len": 1024}}
+    RBLN_CLASS_KWARGS = {"rbln_config": {"attn_impl": "flash_attn", "kvcache_partition_len": 512}}
 
 
 class TestDisallowedLlama_4(DisallowedTestBase.DisallowedTest):
     # Flash attn : too short max_seq_len
     RBLN_CLASS = RBLNLlamaForCausalLM
     HF_MODEL_ID = "afmck/testing-llama-tiny"
-    HF_CONFIG_KWARGS = {"num_hidden_layers": 1, "max_position_embeddings": 2048}
+    HF_CONFIG_KWARGS = {"num_hidden_layers": 1, "max_position_embeddings": 1024}
     RBLN_CLASS_KWARGS = {"rbln_config": {"attn_impl": "flash_attn", "kvcache_partition_len": 1024}}
 
 


### PR DESCRIPTION
## What

#569 (016ddbf0) lowered the flash-attn minimums:
- `MIN_FLASH_ATTN_MAX_SEQ_LEN`: 8192 → 2048
- `MIN_FLASH_ATTN_PARTITION_LENGTH`: 4096 → 1024

This made two `DisallowedTest` cases in `tests/test_llm.py` stop raising, so they failed. This PR adjusts the test inputs to stay below the new minimums.

- `TestDisallowedLlama_3` (too-short partition): `kvcache_partition_len` 1024 → 512
- `TestDisallowedLlama_4` (too-short max_seq_len): `max_position_embeddings` 2048 → 1024

🤖 Generated with [Claude Code](https://claude.com/claude-code)