### PR TITLE
performance(decoderonly): per-chiplet KV cache block estimation to prevent CR03 OOM (SR-244)

### DIFF
--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -6,7 +6,12 @@ from typing import TYPE_CHECKING, Optional, Tuple
 import rebel
 
 from ..utils.logging import get_logger
-from ..utils.runtime_utils import get_available_dram, is_compiler_supports_buffer_resize
+from ..utils.runtime_utils import (
+    get_available_dram,
+    get_available_dram_per_chiplet,
+    is_compiler_supports_buffer_resize,
+    is_compiler_supports_chiplet_alloc,
+)
 
 
 if TYPE_CHECKING:
@@ -191,75 +196,111 @@ class RBLNDecoderOnlyFlashAttentionMixin:
         rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
         available_dram: Optional[int] = None,
     ) -> int:
-        if available_dram is None:
-            available_dram = get_available_dram(rbln_config.npu)
-
         if "prefill" not in rbln_config.phases:
             logger.warning(
                 "Not estimating number of KV cache blocks since `prefill` phase is not in the `phases` list."
             )
             return 1
 
-        num_node = rbln_config.tensor_parallel_size or 1
-        alloc_per_node_without_dram = [0] * num_node
+        # Device DRAM is partitioned per chiplet, so a block count that fits the node
+        # total can still OOM a single chiplet; the search below bounds blocks by the
+        # tightest chiplet.
+        alloc_without_dram, kvcache_tensor_sizes, available_per_chiplet, chiplets = (
+            cls._collect_chiplet_kvcache_inputs(compiled_models, rbln_config, available_dram)
+        )
+        return cls._search_num_kvcache_blocks(
+            rbln_config, alloc_without_dram, kvcache_tensor_sizes, available_per_chiplet, chiplets
+        )
 
+    @classmethod
+    def _collect_chiplet_kvcache_inputs(
+        cls,
+        compiled_models: dict[str, rebel.RBLNCompiledModel],
+        rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
+        available_dram: Optional[int] = None,
+    ) -> Tuple[dict[Tuple[int, int], int], dict[str, list[list[int]]], int, set[Tuple[int, int]]]:
+        # Returns non-KV alloc, KV sizes, per-bucket DRAM budget, and the (node, chiplet)
+        # buckets to check. ATOM reports one chiplet, so it shares the per-chiplet path.
+        alloc_without_dram: dict[Tuple[int, int], int] = defaultdict(int)
+        chiplets: set[Tuple[int, int]] = set()
+
+        if is_compiler_supports_chiplet_alloc():
+            for compiled_model in compiled_models.values():
+                for key, alloc_per_chiplet in compiled_model.get_alloc_per_chiplet_by_key().items():
+                    if key == "DramTensor":
+                        continue
+                    for node_id, sizes_at_chiplet in enumerate(alloc_per_chiplet):
+                        for chiplet_id, size in enumerate(sizes_at_chiplet):
+                            alloc_without_dram[(node_id, chiplet_id)] += size
+                            chiplets.add((node_id, chiplet_id))
+
+            # kvcache_tensor_sizes[key][node_id][chiplet_id] = alloc_size
+            kvcache_tensor_sizes: dict[str, list[list[int]]] = compiled_models["prefill"].exp_get_dram_tensor_sizes()
+            for sizes_at_node in kvcache_tensor_sizes.values():
+                for node_id, sizes_at_chiplet in enumerate(sizes_at_node):
+                    for chiplet_id in range(len(sizes_at_chiplet)):
+                        chiplets.add((node_id, chiplet_id))
+
+            num_chiplets = max((chiplet_id for _, chiplet_id in chiplets), default=0) + 1
+            available_per_chiplet = get_available_dram_per_chiplet(num_chiplets, rbln_config.npu)
+            return alloc_without_dram, kvcache_tensor_sizes, available_per_chiplet, chiplets
+
+        # Legacy compiler exposes only node totals, so collapse each node into one bucket
+        # with the whole-node budget; the search then reduces to the node-level check.
         for compiled_model in compiled_models.values():
             for key, alloc_per_node in compiled_model.get_alloc_per_node_by_key().items():
                 if key == "DramTensor":
                     continue
+                for node_id, size in enumerate(alloc_per_node):
+                    alloc_without_dram[(node_id, 0)] += size
+                    chiplets.add((node_id, 0))
 
-                if len(alloc_per_node) != num_node:
-                    alloc_per_node += [0] * (num_node - len(alloc_per_node))
+        # Sum the per-chiplet KV sizes into the single bucket to match alloc's shape.
+        raw_kvcache: dict[str, list[list[int]]] = compiled_models["prefill"].exp_get_dram_tensor_sizes()
+        kvcache_tensor_sizes = {}
+        for key, sizes_at_node in raw_kvcache.items():
+            kvcache_tensor_sizes[key] = [[sum(sizes_at_chiplet)] for sizes_at_chiplet in sizes_at_node]
+            for node_id in range(len(sizes_at_node)):
+                chiplets.add((node_id, 0))
 
-                alloc_per_node_without_dram = [
-                    a + b for a, b in zip(alloc_per_node_without_dram, alloc_per_node, strict=False)
-                ]
+        available_per_chiplet = available_dram if available_dram is not None else get_available_dram(rbln_config.npu)
+        return alloc_without_dram, kvcache_tensor_sizes, available_per_chiplet, chiplets
 
-        remaining_dram_at_node: list[int] = [
-            available_dram - without_dramtensor for without_dramtensor in alloc_per_node_without_dram
-        ]
-
-        # kvcache_tensor_sizes[key][node_id][chiplet_id] = alloc_size
-        kvcache_tensor_sizes: dict[str, list[list[int]]] = compiled_models["prefill"].exp_get_dram_tensor_sizes()
+    @classmethod
+    def _search_num_kvcache_blocks(
+        cls,
+        rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
+        alloc_without_dram: dict[Tuple[int, int], int],
+        kvcache_tensor_sizes: dict[str, list[list[int]]],
+        available_per_chiplet: int,
+        chiplets: set[Tuple[int, int]],
+    ) -> int:
+        remaining_dram_at_chiplet: dict[Tuple[int, int], int] = {
+            key: available_per_chiplet - alloc_without_dram.get(key, 0) for key in chiplets
+        }
         kvcache_meta_can_resize: dict[str, bool] = {
             kvcache_meta.name: kvcache_meta.can_resize for kvcache_meta in rbln_config.kvcache_metas
         }
 
-        def get_updated_kvcache_tensor_sizes(
-            kvcache_tensor_sizes: dict[str, list[list[int]]], multiplier: int
-        ) -> dict[str, list[list[int]]]:
-            # Get the updated KV cache tensor sizes by multiplying the multiplier
-            # with considering attention type (full or sliding), and memory alignment.
-            ret: dict[str, list[list[int]]] = {}
+        def kvcache_sizes_at_chiplet(multiplier: int) -> dict[Tuple[int, int], int]:
+            # Resize multiplier applies only to resizable tensors; 2MB-aligned.
+            sizes: dict[Tuple[int, int], int] = defaultdict(int)
             for key, sizes_at_node in kvcache_tensor_sizes.items():
                 m = multiplier if kvcache_meta_can_resize[key] else 1
-                ret[key] = [
-                    [align_2MB(size_at_chiplet * m) for size_at_chiplet in sizes_at_node_at_chiplet]
-                    for sizes_at_node_at_chiplet in sizes_at_node
-                ]
-            return ret
+                for node_id, sizes_at_chiplet in enumerate(sizes_at_node):
+                    for chiplet_id, size in enumerate(sizes_at_chiplet):
+                        sizes[(node_id, chiplet_id)] += align_2MB(size * m)
+            return sizes
 
-        def check_memory_fits(multiplier: int) -> tuple[bool, list[int]]:
-            # Check if the given multiplier fits in memory
-            # Returns (fits: bool, kvcache_tensor_sizes_at_node: list[int])
-            updated_kvcache_tensor_sizes = get_updated_kvcache_tensor_sizes(kvcache_tensor_sizes, multiplier)
-
-            kvcache_tensor_sizes_at_node: list[int] = [0] * num_node
-            for tensor_sizes_at_node in updated_kvcache_tensor_sizes.values():
-                tensor_sizes_at_node: list[list[int]]
-                for node_id, sizes_at_chiplet in enumerate(tensor_sizes_at_node):
-                    sizes_at_chiplet: list[int]
-                    kvcache_tensor_sizes_at_node[node_id] += sum(sizes_at_chiplet)
-
-            fits = all(
-                remaining_dram_at_node[node_id] >= kvcache_tensor_sizes_at_node[node_id] for node_id in range(num_node)
-            )
-            return fits, kvcache_tensor_sizes_at_node
+        def check_memory_fits(multiplier: int) -> Tuple[bool, dict[Tuple[int, int], int]]:
+            # Fits only if every chiplet bucket has room.
+            kvcache_sizes = kvcache_sizes_at_chiplet(multiplier)
+            fits = all(remaining_dram_at_chiplet[key] >= kvcache_sizes.get(key, 0) for key in chiplets)
+            return fits, kvcache_sizes
 
         # Fast path: try maximum blocks first (most common case)
         fits, _ = check_memory_fits(rbln_config.num_full_blocks)
         if fits:
-            # Best case: maximum blocks fit in memory
             return rbln_config.num_full_blocks
 
         # Slow path: binary search for optimal multiplier
@@ -273,18 +314,19 @@ class RBLNDecoderOnlyFlashAttentionMixin:
 
         while left <= right:
             mid = (left + right) // 2
-            fits, kvcache_tensor_sizes_at_node = check_memory_fits(mid)
+            fits, kvcache_sizes = check_memory_fits(mid)
 
             if fits:
-                # Memory is sufficient, try larger multiplier
                 multiplier = mid
                 left = mid + 1
             else:
-                # Memory is insufficient, try smaller multiplier
+                tightest = min(
+                    (remaining_dram_at_chiplet[key] - kvcache_sizes.get(key, 0) for key in chiplets),
+                    default=0,
+                )
                 logger.debug(
-                    f"[KVCache] Not enough memory for {mid} blocks. Remaining DRAM: "
-                    f"{[format_byte_size(remaining_dram) for remaining_dram in remaining_dram_at_node]}, "
-                    f"KV cache tensor sizes: {[format_byte_size(size) for size in kvcache_tensor_sizes_at_node]}"
+                    f"[KVCache] Not enough memory for {mid} blocks. "
+                    f"Tightest chiplet headroom: {format_byte_size(tightest)}"
                 )
                 right = mid - 1
 

--- a/src/optimum/rbln/utils/runtime_utils.py
+++ b/src/optimum/rbln/utils/runtime_utils.py
@@ -24,9 +24,30 @@ def is_compiler_supports_buffer_resize() -> bool:
     return hasattr(rebel.RBLNCompiledModel, "exp_multiply_buffer_size")
 
 
+def is_compiler_supports_chiplet_alloc() -> bool:
+    return hasattr(rebel.RBLNCompiledModel, "get_alloc_per_chiplet_by_key")
+
+
+def _resolve_npu(npu: Optional[str] = None) -> str:
+    if npu is None:
+        if not rebel.npu_is_available(0):
+            raise RuntimeError("No NPU is available to get available DRAM size.")
+        npu = rebel.get_npu_name(0)
+    return npu
+
+
+# Total device DRAM and the system DRAM reserved per chiplet, by NPU family.
+def _dram_spec(npu: str) -> tuple[int, int]:
+    if npu.startswith("RBLN-CR"):
+        return 144 * 2**30, 1 * 2**30
+    elif npu.startswith("RBLN-CA"):
+        return 16 * 2**30, 288 * 2**20
+    raise ValueError(f"Unknown npu name: {npu}")
+
+
 def get_available_dram(npu: Optional[str] = None) -> int:
     """
-    Get the available DRAM size of the specified NPU.
+    Get the available DRAM size of the specified NPU at the node (device) level.
 
     Args:
         npu : Optional[str], default=None
@@ -37,23 +58,33 @@ def get_available_dram(npu: Optional[str] = None) -> int:
         int
             The available DRAM size in bytes.
     """
-    if npu is None:
-        if not rebel.npu_is_available(0):
-            raise RuntimeError("No NPU is available to get available DRAM size.")
-
-        npu = rebel.get_npu_name(0)
-
+    npu = _resolve_npu(npu)
+    dram_nbytes, sys_per_chiplet = _dram_spec(npu)
+    # Node total = full DRAM minus the per-chiplet system reservation on every chiplet.
     if npu.startswith("RBLN-CR"):
-        # TODO(jongho): Assuming 4 chiplets.
-        DRAM_NBYTES = 144 * 2**30
-        SYS_DRAM_NBYTES = 4 * 2**30
-    elif npu.startswith("RBLN-CA"):
-        DRAM_NBYTES = 16 * 2**30
-        SYS_DRAM_NBYTES = 288 * 2**20
-    else:
-        raise ValueError(f"Unknown npu name: {npu}")
+        return dram_nbytes - sys_per_chiplet * 4
+    return dram_nbytes - sys_per_chiplet
 
-    return DRAM_NBYTES - SYS_DRAM_NBYTES
+
+def get_available_dram_per_chiplet(num_chiplets: int, npu: Optional[str] = None) -> int:
+    """
+    Get the available DRAM per chiplet. Device DRAM is physically partitioned across
+    chiplets, so an allocation pinned to a chiplet must fit within this amount, not the
+    node total.
+
+    Args:
+        num_chiplets : int
+            Number of chiplets the device DRAM is split across.
+        npu : Optional[str], default=None
+            The NPU to get the available DRAM size. Resolved from the local device if None.
+
+    Returns:
+        int
+            The available DRAM per chiplet in bytes.
+    """
+    npu = _resolve_npu(npu)
+    dram_nbytes, sys_per_chiplet = _dram_spec(npu)
+    return dram_nbytes // num_chiplets - sys_per_chiplet
 
 
 def normalize_npu(npu: str) -> str:


### PR DESCRIPTION
# Pull Request Description

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

## Changes Overview
KV-cache block estimation for flash-attention decoder models now checks device memory **per chiplet** instead of per node, through a single estimation path.

- `estimate_num_kvcache_blocks` always runs one per-chiplet search (`_search_num_kvcache_blocks`) over inputs gathered by `_collect_chiplet_kvcache_inputs`. There is no separate node-level algorithm.
- New compilers feed real per-chiplet allocation via `get_alloc_per_chiplet_by_key`. The block count is bounded by the tightest chiplet.
- ATOM is a single chiplet, so the per-chiplet check naturally degenerates to a node check — no ATOM-specific branch.
- Older compilers that don't expose per-chiplet accounting collapse each node into one chiplet bucket, which reproduces the legacy node-level estimate through the same code path (verified to give the identical block count).
- Add `get_available_dram_per_chiplet` (CR: `DRAM / num_chiplets - 1 GiB` system per chiplet); `get_available_dram` is retained only for the collapsed legacy path.

## Motivation and Context
RBLN-CR03 device DRAM is physically partitioned per chiplet. The estimator only compared against the node(device) total, so a block count whose chiplet sum fit the node could still overflow a single chiplet and OOM at runtime init (`SYS_EBUSY`, `key=Init`, chiplet 0).

Reproduced on `DeepSeek-R1-Distill-Qwen-14B` (128K / B8 / TP1 / KV16k) on a single CR03: the node-level estimate picks **37** blocks, at which chiplet 0 reaches 35.113 GiB against a 35.0 GiB per-chiplet budget (−0.113 GiB → OOM) while the other chiplets have +0.223 GiB headroom — ConstBuf is concentrated on chiplet 0. The per-chiplet estimate picks **36** blocks (fits every chiplet), and loading the artifact with `create_runtimes=True` then completes with no `SYS_EBUSY`. The collapsed legacy path was verified to still return 37 on the same compile, confirming behavior is preserved for old compilers.

Requires the per-chiplet accounting API added in rebel_compiler (SR-239).

## Related Issues
SR-244
