### PR TITLE
model(whisper): restore [batch, seq] long-form generate output rank

### DIFF
--- a/src/optimum/rbln/transformers/models/whisper/generation_whisper.py
+++ b/src/optimum/rbln/transformers/models/whisper/generation_whisper.py
@@ -77,7 +77,7 @@ class RBLNWhisperGenerationMixin(WhisperGenerationMixin, GenerationMixin):
                     "Please set num_beams=1 for greedy search or adjust your configuration."
                 )
 
-        return super().generate(
+        outputs = super().generate(
             input_features,
             attention_mask=attention_mask,
             generation_config=generation_config,
@@ -86,6 +86,18 @@ class RBLNWhisperGenerationMixin(WhisperGenerationMixin, GenerationMixin):
             return_token_timestamps=return_token_timestamps,
             **kwargs,
         )
+
+        # transformers' WhisperGenerationMixin returns long-form sequences as a
+        # 2D [batch, seq] tensor. RBLN long-form decoding can leave a spurious
+        # singleton segment dim ([batch, 1, seq]); without removing it,
+        # processor.batch_decode(..., decode_with_timestamps=True) iterates one
+        # level too deep and raises
+        # "'>=' not supported between instances of 'list' and 'int'".
+        # Restore the documented [batch, seq] contract (no-op for 2D output).
+        if isinstance(outputs, torch.Tensor) and outputs.dim() == 3 and outputs.shape[1] == 1:
+            outputs = outputs.squeeze(1)
+
+        return outputs
 
     def _postprocess_outputs(
         self,


### PR DESCRIPTION
## Summary

Long-form Whisper transcription via the canonical HF pattern fails under transformers v5:

```python
outputs = model.generate(**inputs, return_timestamps=True)        # long-form, truncation=False
processor.batch_decode(outputs, skip_special_tokens=True, decode_with_timestamps=True)
```
```
File ".../transformers/models/whisper/tokenization_whisper.py", line 294, in _decode_with_timestamps
    if token >= timestamp_begin:
TypeError: '>=' not supported between instances of 'list' and 'int'
```

`batch_decode` iterates one level too deep because `outputs` carries a spurious
singleton segment dim `[batch, 1, seq]` instead of the `[batch, seq]` that
`transformers.WhisperGenerationMixin` documents and returns.

## Root cause

- The model-zoo example follows the **documented** transformers long-form pattern.
- transformers 5.8.1 `WhisperGenerationMixin.generate`, for `return_timestamps=True`
  without `return_segments` / `return_token_timestamps` / `return_dict_in_generate`,
  returns `padded_outputs` — a **2D `[batch, seq]`** tensor (`_pad_to_max_length`
  stacks 1D per-segment token sequences).
- `RBLNWhisperGenerationMixin.generate` is a thin pass-through to `super().generate()`,
  and `_postprocess_outputs` mirrors the upstream contract. The extra singleton dim is
  introduced by the RBLN long-form decode runtime, so the returned tensor violates the
  upstream `[batch, seq]` contract.

## Fix

Restore the contract at the `generate()` boundary by squeezing a spurious singleton
segment dim. The guard (`dim() == 3 and shape[1] == 1`) makes it a **no-op** for
already-2D output, so short-form and pipeline paths are unaffected.

## Repro / scope

- Surfaced by `huggingface/transformers/automatic-speech-recognition/whisper/without_token_timestamps`
  in the `standalone-rbln-deploy` suite (compiler `0.10.5.dev*`, optimum `0.11.0a6`, transformers `5.8.1`).
- `with_token_timestamps` (pipeline path) is unaffected — it does not call `batch_decode` on the raw tensor.

## Validation note

The `[batch, 1, seq]` shape is inferred from the decode error (one extra nesting level).
Please confirm the exact runtime shape on an NPU box; if long-form returns a genuine
multi-segment `[batch, N>1, seq]`, a flatten (not a squeeze) would be required instead.
Marked draft pending that runtime confirmation.