### PR TITLE
model(distilbert): accept and ignore token_type_ids in QA forward

### DIFF
--- a/src/optimum/rbln/transformers/models/distilbert/modeling_distilbert.py
+++ b/src/optimum/rbln/transformers/models/distilbert/modeling_distilbert.py
@@ -48,7 +48,6 @@ class RBLNDistilBertForQuestionAnswering(RBLNModelForQuestionAnswering):
             The model outputs. If return_dict=False is passed, returns a tuple of tensors. Otherwise, returns a QuestionAnsweringModelOutput object.
         """
 
-        # DistilBERT has no token-type (segment) embeddings; drop token_type_ids if a tokenizer
-        # provides it (AutoTokenizer resolves to BertTokenizer for DistilBERT in transformers v5).
+        # DistilBERT has no token-type embeddings; drop token_type_ids if a tokenizer emits it.
         kwargs.pop("token_type_ids", None)
         return super().forward(input_ids, attention_mask, **kwargs)

--- a/src/optimum/rbln/transformers/models/distilbert/modeling_distilbert.py
+++ b/src/optimum/rbln/transformers/models/distilbert/modeling_distilbert.py
@@ -35,7 +35,6 @@ class RBLNDistilBertForQuestionAnswering(RBLNModelForQuestionAnswering):
         self,
         input_ids: Optional[torch.Tensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
-        token_type_ids: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Union[Tuple, QuestionAnsweringModelOutput]:
         """
@@ -44,10 +43,12 @@ class RBLNDistilBertForQuestionAnswering(RBLNModelForQuestionAnswering):
         Args:
             input_ids (torch.Tensor of shape (batch_size, sequence_length), optional): Indices of input sequence tokens in the vocabulary.
             attention_mask (torch.Tensor of shape (batch_size, sequence_length), optional): Mask to avoid performing attention on padding token indices.
-            token_type_ids (torch.Tensor of shape (batch_size, sequence_length), optional): Ignored; DistilBERT has no token-type embeddings.
 
         Returns:
             The model outputs. If return_dict=False is passed, returns a tuple of tensors. Otherwise, returns a QuestionAnsweringModelOutput object.
         """
 
+        # DistilBERT has no token-type (segment) embeddings; drop token_type_ids if a tokenizer
+        # provides it (AutoTokenizer resolves to BertTokenizer for DistilBERT in transformers v5).
+        kwargs.pop("token_type_ids", None)
         return super().forward(input_ids, attention_mask, **kwargs)

--- a/src/optimum/rbln/transformers/models/distilbert/modeling_distilbert.py
+++ b/src/optimum/rbln/transformers/models/distilbert/modeling_distilbert.py
@@ -48,6 +48,7 @@ class RBLNDistilBertForQuestionAnswering(RBLNModelForQuestionAnswering):
             The model outputs. If return_dict=False is passed, returns a tuple of tensors. Otherwise, returns a QuestionAnsweringModelOutput object.
         """
 
-        # DistilBERT has no token-type embeddings; drop token_type_ids if a tokenizer emits it.
+        # DistilBERT has no token-type (segment) embeddings; drop token_type_ids if a tokenizer
+        # provides it (AutoTokenizer resolves to BertTokenizer for DistilBERT in transformers v5).
         kwargs.pop("token_type_ids", None)
         return super().forward(input_ids, attention_mask, **kwargs)

--- a/src/optimum/rbln/transformers/models/distilbert/modeling_distilbert.py
+++ b/src/optimum/rbln/transformers/models/distilbert/modeling_distilbert.py
@@ -44,9 +44,7 @@ class RBLNDistilBertForQuestionAnswering(RBLNModelForQuestionAnswering):
         Args:
             input_ids (torch.Tensor of shape (batch_size, sequence_length), optional): Indices of input sequence tokens in the vocabulary.
             attention_mask (torch.Tensor of shape (batch_size, sequence_length), optional): Mask to avoid performing attention on padding token indices.
-            token_type_ids (torch.Tensor of shape (batch_size, sequence_length), optional): Accepted for tokenizer
-                compatibility and ignored. DistilBERT has no token-type (segment) embeddings, so it is not a compiled
-                input; this mirrors the native model, which also ignores it.
+            token_type_ids (torch.Tensor of shape (batch_size, sequence_length), optional): Ignored; DistilBERT has no token-type embeddings.
 
         Returns:
             The model outputs. If return_dict=False is passed, returns a tuple of tensors. Otherwise, returns a QuestionAnsweringModelOutput object.

--- a/src/optimum/rbln/transformers/models/distilbert/modeling_distilbert.py
+++ b/src/optimum/rbln/transformers/models/distilbert/modeling_distilbert.py
@@ -35,6 +35,7 @@ class RBLNDistilBertForQuestionAnswering(RBLNModelForQuestionAnswering):
         self,
         input_ids: Optional[torch.Tensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
+        token_type_ids: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Union[Tuple, QuestionAnsweringModelOutput]:
         """
@@ -43,6 +44,9 @@ class RBLNDistilBertForQuestionAnswering(RBLNModelForQuestionAnswering):
         Args:
             input_ids (torch.Tensor of shape (batch_size, sequence_length), optional): Indices of input sequence tokens in the vocabulary.
             attention_mask (torch.Tensor of shape (batch_size, sequence_length), optional): Mask to avoid performing attention on padding token indices.
+            token_type_ids (torch.Tensor of shape (batch_size, sequence_length), optional): Accepted for tokenizer
+                compatibility and ignored. DistilBERT has no token-type (segment) embeddings, so it is not a compiled
+                input; this mirrors the native model, which also ignores it.
 
         Returns:
             The model outputs. If return_dict=False is passed, returns a tuple of tensors. Otherwise, returns a QuestionAnsweringModelOutput object.


### PR DESCRIPTION
## What

`RBLNDistilBertForQuestionAnswering.forward` now accepts `token_type_ids` and ignores it, so callers that pass the full tokenizer output (including `token_type_ids`) work without manual filtering.

## Why

In transformers v5, `AutoTokenizer` resolves `distilbert` to **`BertTokenizer`** (`models/auto/tokenization_auto.py`: `("distilbert", "BertTokenizer")`; in v4 it was `DistilBertTokenizer`). `BertTokenizer.model_input_names` includes `token_type_ids`, so `tokenizer(question, context)` now returns it for a text pair.

The native `DistilBertForQuestionAnswering` tolerates this — its `forward` has `**kwargs` and silently ignores `token_type_ids` (DistilBERT has no token-type/segment embeddings). But `RBLNDistilBertForQuestionAnswering` forwarded the extra key to the compiled 2-input runtime, which raised:

```
RuntimeError: Number of inputs (3) exceeds the expected number (2).
```

So `model(**tokenizer(question, context))` — the canonical usage in the HF docs — failed on RBLN while working on native.

## Change

Add `token_type_ids` to the `forward` signature and drop it (it is captured by the parameter and not passed to `super().forward`). This mirrors native leniency. The compiled graph is unchanged and stays 2-input (`input_ids`, `attention_mask`); `rbln_model_input_names` is untouched.
