### PR TITLE
refactor: rename tensor_parallel_size to num_devices

### DIFF
--- a/examples/image-to-text/run_idefics3.py
+++ b/examples/image-to-text/run_idefics3.py
@@ -14,7 +14,7 @@ def main(
     from_transformers: bool = False,
     prompt: typing.Optional[str] = None,
     max_seq_len: typing.Optional[int] = None,
-    tensor_parallel_size: typing.Optional[int] = 4,
+    num_devices: typing.Optional[int] = 4,
 ):
     processor = AutoProcessor.from_pretrained(model_id)
 
@@ -27,7 +27,7 @@ def main(
                     "attn_impl": "flash_attn",
                     "max_seq_len": max_seq_len,
                     "use_inputs_embeds": True,
-                    "tensor_parallel_size": tensor_parallel_size,
+                    "num_devices": num_devices,
                     "batch_size": batch_size,
                 }
             },

--- a/examples/image-to-text/run_llava_next_image_to_text.py
+++ b/examples/image-to-text/run_llava_next_image_to_text.py
@@ -14,7 +14,7 @@ def main(
     from_transformers: bool = False,
     prompt: typing.Optional[str] = None,
     max_seq_len: typing.Optional[int] = None,
-    tensor_parallel_size: typing.Optional[int] = 4,
+    num_devices: typing.Optional[int] = 4,
     num_text_only: typing.Optional[int] = None,
 ):
     if from_transformers:
@@ -25,7 +25,7 @@ def main(
             export=True,
             rbln_config={
                 "language_model": {
-                    "tensor_parallel_size": tensor_parallel_size,
+                    "num_devices": num_devices,
                     "max_seq_len": max_seq_len,
                     "use_inputs_embeds": True,
                     "batch_size": batch_size,

--- a/examples/text2text-generation/run_llama_peft.py
+++ b/examples/text2text-generation/run_llama_peft.py
@@ -13,7 +13,7 @@ def main(
     batch_size: int = 1,
     from_transformers: bool = False,
     max_seq_len: typing.Optional[int] = None,
-    tensor_parallel_size: typing.Optional[int] = 4,
+    num_devices: typing.Optional[int] = 4,
     use_inputs_embeds: bool = None,
 ):
     if from_transformers:
@@ -30,7 +30,7 @@ def main(
             model,
             rbln_batch_size=batch_size,
             rbln_max_seq_len=max_seq_len,
-            rbln_tensor_parallel_size=tensor_parallel_size,
+            rbln_num_devices=num_devices,
             rbln_use_inputs_embeds=use_inputs_embeds,
         )
         model.save_pretrained(os.path.basename(model_id))

--- a/examples/text2text-generation/run_llama_text2text_generation.py
+++ b/examples/text2text-generation/run_llama_text2text_generation.py
@@ -12,7 +12,7 @@ def main(
     batch_size: int = 1,
     from_transformers: bool = False,
     max_seq_len: typing.Optional[int] = None,
-    tensor_parallel_size: typing.Optional[int] = 4,
+    num_devices: typing.Optional[int] = 4,
 ):
     # Example input sentences for the model
     sentences = [
@@ -28,7 +28,7 @@ def main(
             # The following arguments are specific to RBLN compilation
             rbln_batch_size=batch_size,
             rbln_max_seq_len=max_seq_len,
-            rbln_tensor_parallel_size=tensor_parallel_size,
+            rbln_num_devices=num_devices,
             torch_dtype="auto",
         )
         model.save_pretrained(os.path.basename(model_id))

--- a/src/optimum/rbln/cli.py
+++ b/src/optimum/rbln/cli.py
@@ -312,11 +312,11 @@ def _print_rbln_config_options(class_name: str):
     # Curated: common compile-time options that live in RBLNModelConfig (non-runtime)
     print(_underline("\nCommon compile-time options (in rbln_config):"))
     print("  • npu: Target NPU for compilation (e.g., 'RBLN-CA25').")
-    print("  • tensor_parallel_size: Number of NPUs to shard the model at compile time.")
+    print("  • num_devices: Number of NPUs to shard the model across at compile time.")
 
     print(_underline("\nTips:"))
     print("  - Pass config keys as CLI flags, e.g., --batch_size 2 --max_seq_len 4096")
-    print("  - Compile-time examples: --npu RBLN-CA25 --tensor_parallel_size 4")
+    print("  - Compile-time examples: --npu RBLN-CA25 --num_devices 4")
     print("  - Use dot-notation for submodules, e.g., --vision_tower.image_size 336 --language_model.batch_size 1")
     print("  - To see examples: optimum-rbln-cli --examples")
 

--- a/src/optimum/rbln/configuration_utils.py
+++ b/src/optimum/rbln/configuration_utils.py
@@ -15,7 +15,7 @@
 import importlib
 import inspect
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Protocol, Tuple, Type, Union, runtime_checkable
 
@@ -77,13 +77,13 @@ class RBLNCompileConfig:
         compiled_model_name (str): Name of the compiled model.
         input_info (Union[List[TypeInputInfo], TypeInputInfo]): Information about input tensors.
         npu (Optional[str]): NPU configuration.
-        tensor_parallel_size (Optional[int]): Size for tensor parallelism.
+        num_devices (Optional[int]): Number of devices to distribute the model across.
     """
 
     compiled_model_name: str = DEFAULT_COMPILED_MODEL_NAME
     input_info: Union[List[TypeInputInfo], TypeInputInfo] = None
     npu: Optional[str] = None
-    tensor_parallel_size: Optional[int] = None
+    num_devices: Optional[int] = None
 
     @staticmethod
     def normalize_dtype(dtype: Union[str, torch.dtype, np.dtype]) -> str:
@@ -137,7 +137,7 @@ class RBLNCompileConfig:
         self.compiled_model_name = kwargs.get("compiled_model_name", self.compiled_model_name)
         self.input_info = kwargs.get("input_info", self.input_info)
         self.npu = kwargs.get("npu", self.npu)
-        self.tensor_parallel_size = kwargs.get("tensor_parallel_size", self.tensor_parallel_size)
+        self.num_devices = kwargs.get("num_devices", self.num_devices)
         return self
 
     def get_dummy_inputs(
@@ -250,7 +250,7 @@ class RBLNAutoConfig:
             >>> data = {
             ...     "cls_name": "RBLNLlamaForCausalLMConfig",
             ...     "create_runtimes": False,
-            ...     "tensor_parallel_size": 4
+            ...     "num_devices": 4
             ... }
             >>> cfg = RBLNAutoConfig.load_from_dict(data)
         """
@@ -440,7 +440,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
         config = RBLNLlamaForCausalLMConfig(
             max_seq_len=4096,
             device=[0, 1, 2, 3],
-            tensor_parallel_size=4  # For multi-NPU parallel inference
+            num_devices=4  # For multi-NPU parallel inference
         )
         ```
 
@@ -463,7 +463,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
                     "image_size": 336,
                 },
                 "language_model": {
-                    "tensor_parallel_size": 4,  # Distribute across 4 NPUs
+                    "num_devices": 4,  # Distribute across 4 NPUs
                     "max_seq_len": 8192,
                     "use_inputs_embeds": True,
                     "batch_size": 1,
@@ -479,7 +479,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
         # Setup a complex multi-device configuration for large language models
         llm_config = RBLNLlamaForCausalLMConfig(
             # Split model across 8 NPUs
-            tensor_parallel_size=8,
+            num_devices=8,
 
             # Runtime options
             device=[8, 9, 10, 11, 12, 13, 14, 15],
@@ -502,7 +502,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
             create_runtimes=False,  # Compile only, don't create runtime
             npu="RBLN-CA25",  # Specify target NPU for compilation
             max_seq_len=4096,
-            tensor_parallel_size=4,
+            num_devices=4,
             batch_size=1
         )
 
@@ -555,7 +555,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
         "_runtime_options",
         "npu",
         "dtype",
-        "tensor_parallel_size",
+        "num_devices",
         "create_runtimes",
         "device",
         "device_map",
@@ -583,7 +583,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
             from_predecessor.update(
                 {
                     "npu": self.npu,
-                    "tensor_parallel_size": self.tensor_parallel_size,
+                    "num_devices": self.num_devices,
                     "optimum_rbln_version": self.optimum_rbln_version,
                 }
             )
@@ -632,7 +632,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
 
         if model_cls is not None:
             if not getattr(model_cls, "_tp_support", False):
-                filtered_out_params.add("tensor_parallel_size")
+                filtered_out_params.add("num_devices")
 
         filtered_params = {}
         for key, value in parameters.items():
@@ -680,6 +680,12 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
         super().__setattr__(key, value)
 
     @deprecate_kwarg(
+        old_name="tensor_parallel_size",
+        new_name="num_devices",
+        version="0.12.0",
+        raise_if_greater_or_equal_version=False,
+    )
+    @deprecate_kwarg(
         old_name="_torch_dtype",
         new_name="dtype",
         version="0.12.0",
@@ -695,7 +701,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
         device_map: Optional[Dict[str, Union[int, List[int]]]] = None,
         activate_profiler: Optional[bool] = None,
         npu: Optional[str] = None,
-        tensor_parallel_size: Optional[int] = None,
+        num_devices: Optional[int] = None,
         timeout: Optional[int] = None,
         optimum_rbln_version: Optional[str] = None,
         dtype: Optional[Union[str, torch.dtype]] = None,
@@ -714,7 +720,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
             device_map (Optional[Dict[str, Union[int, List[int]]]]): Mapping from compiled model names to device IDs.
             activate_profiler (Optional[bool]): Whether to activate the profiler for performance analysis.
             npu (Optional[str]): The NPU device name to use for compilation.
-            tensor_parallel_size (Optional[int]): Size for tensor parallelism to distribute the model across devices.
+            num_devices (Optional[int]): Number of devices to distribute the model across.
             timeout (Optional[int]): The timeout for the runtime in seconds. If it isn't provided, it will be set to 60 by default.
             optimum_rbln_version (Optional[str]): The optimum-rbln version used for this configuration.
             dtype (Optional[Union[str, torch.dtype]]): The data type to use for the model.
@@ -743,9 +749,9 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
         if optimize_host_memory is not None:
             logger.warning("`optimize_host_memory` is deprecated and will be removed in future versions.")
 
-        # Automatically pass npu, tensor_parallel_size to compile_cfgs
+        # Automatically pass npu, num_devices to compile_cfgs
         self.npu = npu
-        self.tensor_parallel_size = tensor_parallel_size
+        self.num_devices = num_devices
 
         if dtype is not None and isinstance(dtype, torch.dtype):
             dtype = RBLNCompileConfig.normalize_dtype(dtype)
@@ -760,7 +766,13 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
         if not isinstance(self._compile_cfgs, list):
             raise ValueError("`compile_cfgs` must be a list of `RBLNCompileConfig`.")
         if len(self._compile_cfgs) > 0 and not isinstance(self._compile_cfgs[0], RBLNCompileConfig):
-            self.set_compile_cfgs([RBLNCompileConfig(**cfg) for cfg in self._compile_cfgs])
+            compile_cfg_fields = {f.name for f in fields(RBLNCompileConfig)}
+            self.set_compile_cfgs(
+                [
+                    RBLNCompileConfig(**{k: v for k, v in cfg.items() if k in compile_cfg_fields})
+                    for cfg in self._compile_cfgs
+                ]
+            )
 
         if len(kwargs) > 0:
             if optimum_rbln_version is not None:  # loaded from file
@@ -857,7 +869,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
         self._compile_cfgs = compile_cfgs
         for compile_cfg in self._compile_cfgs:
             compile_cfg.npu = self.npu
-            compile_cfg.tensor_parallel_size = self.tensor_parallel_size
+            compile_cfg.num_devices = self.num_devices
 
         target_npu = self.npu or next((cfg.npu for cfg in self._compile_cfgs if cfg.npu is not None), None)
         warn_deprecated_npu(target_npu)

--- a/src/optimum/rbln/diffusers/pipelines/cosmos/configuration_cosmos_guardrail.py
+++ b/src/optimum/rbln/diffusers/pipelines/cosmos/configuration_cosmos_guardrail.py
@@ -79,13 +79,13 @@ class RBLNCosmosSafetyCheckerConfig(RBLNModelConfig):
         if max_seq_len is None:
             max_seq_len = 512
 
-        tensor_parallel_size = kwargs.get("tensor_parallel_size")
+        num_devices = kwargs.get("num_devices", kwargs.get("tensor_parallel_size"))
 
         self.qwen3guard = self.initialize_submodule_config(
             qwen3guard,
             cls_name="RBLNQwen3ForCausalLMConfig",
             batch_size=batch_size,
-            tensor_parallel_size=tensor_parallel_size,
+            num_devices=num_devices,
             max_seq_len=max_seq_len,
         )
         # VideoContentSafetyFilter is omitted because it is not supported in cosmos-guardrail==0.3.1

--- a/src/optimum/rbln/modeling_base.py
+++ b/src/optimum/rbln/modeling_base.py
@@ -27,7 +27,7 @@ from transformers.utils.hub import PushToHubMixin
 from .configuration_utils import RBLNCompileConfig, RBLNModelConfig, get_rbln_config_class
 from .utils.hub import pull_compiled_model_from_hub, validate_files
 from .utils.logging import get_logger
-from .utils.runtime_utils import UnavailableRuntime, tp_and_devices_are_ok
+from .utils.runtime_utils import UnavailableRuntime, compiler_num_devices_kwarg, tp_and_devices_are_ok
 from .utils.save_utils import maybe_load_preprocessors
 from .utils.submodule import SubModulesMixin
 
@@ -441,7 +441,7 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
     ):
         if create_runtimes:
             runtime_cannot_be_created = tp_and_devices_are_ok(
-                tensor_parallel_size=rbln_compile_config.tensor_parallel_size,
+                num_devices=rbln_compile_config.num_devices,
                 device=device,
                 npu=rbln_compile_config.npu,
             )
@@ -452,7 +452,7 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
             model,
             input_info=rbln_compile_config.input_info,
             npu=rbln_compile_config.npu,
-            tensor_parallel_size=rbln_compile_config.tensor_parallel_size,
+            **{compiler_num_devices_kwarg(): rbln_compile_config.num_devices},
             **kwargs,
         )
         return compiled_model

--- a/src/optimum/rbln/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/optimum/rbln/transformers/models/blip_2/modeling_blip_2.py
@@ -303,7 +303,7 @@ class RBLNBlip2ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
                 "language_model": {
                     "batch_size": 1,
                     "max_seq_len": 2048,
-                    "tensor_parallel_size": 1,
+                    "num_devices": 1,
                     "use_inputs_embeds": True,
                 },
             },

--- a/src/optimum/rbln/transformers/models/colpali/configuration_colpali.py
+++ b/src/optimum/rbln/transformers/models/colpali/configuration_colpali.py
@@ -37,7 +37,7 @@ class RBLNColPaliForRetrievalConfig(RBLNModelConfig):
                 "language_model": {"prefill_chunk_size": 8192},
             }
             output_hidden_states=False,
-            tensor_parallel_size=4
+            num_devices=4
         )
 
         # Use the configuration with from_pretrained

--- a/src/optimum/rbln/transformers/models/colpali/modeling_colpali.py
+++ b/src/optimum/rbln/transformers/models/colpali/modeling_colpali.py
@@ -99,7 +99,7 @@ class RBLNColPaliForRetrieval(RBLNModel):
                 "language_model": {"prefill_chunk_size": 8192},
             },
             output_hidden_states=False,
-            tensor_parallel_size=4
+            num_devices=4
         )
         model = RBLNColPaliForRetrieval.from_pretrained(
             "vidore/colpali-v1.3-hf",

--- a/src/optimum/rbln/transformers/models/colqwen2/configuration_colqwen2.py
+++ b/src/optimum/rbln/transformers/models/colqwen2/configuration_colqwen2.py
@@ -38,7 +38,7 @@ class RBLNColQwen2ForRetrievalConfig(RBLNDecoderOnlyModelConfig):
                     "device": 0,
                 },
                 "max_seq_len": 32_768,
-                "tensor_parallel_size": 4,
+                "num_devices": 4,
                 "device": [0, 1, 2, 3],
                 "output_hidden_states": False,
                 }

--- a/src/optimum/rbln/transformers/models/colqwen2/modeling_colqwen2.py
+++ b/src/optimum/rbln/transformers/models/colqwen2/modeling_colqwen2.py
@@ -52,7 +52,7 @@ class RBLNColQwen2ForRetrieval(RBLNModel):
                 "visual": {
                     "max_seq_len": 6400,
                 },
-                "tensor_parallel_size": 4,
+                "num_devices": 4,
                 "kvcache_partition_len": 16384,
                 "max_seq_len": 16384 * 7,
             },

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_lora.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_lora.py
@@ -45,7 +45,7 @@ class RBLNLoRAAdapterConfig(RBLNSerializableConfigProtocol):
 
         model = RBLNLlamaForCausalLM.from_pretrained(
             model_id,
-            rbln_config=RBLNLlamaForCausalLMConfig(lora_config=lora_config, tensor_parallel_size=tp_size, max_seq_len=8192),
+            rbln_config=RBLNLlamaForCausalLMConfig(lora_config=lora_config, num_devices=tp_size, max_seq_len=8192),
             dtype="auto",
         )
 

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -636,7 +636,7 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
             "\n\nTo reduce memory usage for a decoder-only model, consider the following:\n"
             "1. Reduce `max_seq_len`, the context length used during inference.\n"
             "2. Reduce `kvcache_num_blocks`, the number of blocks allocated for the paged attention KV cache.\n"
-            "3. Increase `tensor_parallel_size` to distribute memory across more NPUs."
+            "3. Increase `num_devices` to distribute memory across more NPUs."
         )
 
         return help_msg

--- a/src/optimum/rbln/transformers/models/exaone/configuration_exaone.py
+++ b/src/optimum/rbln/transformers/models/exaone/configuration_exaone.py
@@ -29,7 +29,7 @@ class RBLNExaoneForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
     config = RBLNExaoneForCausalLMConfig(
         batch_size=1,
         max_seq_len=4096,
-        tensor_parallel_size=4
+        num_devices=4
     )
 
     # Use the configuration with from_pretrained

--- a/src/optimum/rbln/transformers/models/exaone/modeling_exaone.py
+++ b/src/optimum/rbln/transformers/models/exaone/modeling_exaone.py
@@ -56,7 +56,7 @@ class RBLNExaoneForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             "LGAI-EXAONE/EXAONE-3.0-7.8B-Instruct",
             export=True,
             rbln_batch_size=1,
-            rbln_tensor_parallel_size=4,
+            rbln_num_devices=4,
         )
 
 
@@ -64,7 +64,7 @@ class RBLNExaoneForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         rbln_config = {
             "batch_size": 1,
             "max_seq_len": 4096,
-            "tensor_parallel_size": 4,
+            "num_devices": 4,
         }
         model = RBLNExaoneForCausalLM.from_pretrained(
             "LGAI-EXAONE/EXAONE-3.0-7.8B-Instruct",
@@ -79,7 +79,7 @@ class RBLNExaoneForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         config = RBLNExaoneForCausalLMConfig(
             batch_size=1,
             max_seq_len=4096,
-            tensor_parallel_size=4
+            num_devices=4
         )
         model = RBLNExaoneForCausalLM.from_pretrained(
             "LGAI-EXAONE/EXAONE-3.0-7.8B-Instruct",

--- a/src/optimum/rbln/transformers/models/gemma/configuration_gemma.py
+++ b/src/optimum/rbln/transformers/models/gemma/configuration_gemma.py
@@ -29,7 +29,7 @@ class RBLNGemmaForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
     config = RBLNGemmaForCausalLMConfig(
         batch_size=1,
         max_seq_len=4096,
-        tensor_parallel_size=4
+        num_devices=4
     )
 
     # Use the configuration with from_pretrained

--- a/src/optimum/rbln/transformers/models/gemma/modeling_gemma.py
+++ b/src/optimum/rbln/transformers/models/gemma/modeling_gemma.py
@@ -47,7 +47,7 @@ class RBLNGemmaForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             "google/gemma-7b",
             export=True,
             rbln_batch_size=1,
-            rbln_tensor_parallel_size=4,
+            rbln_num_devices=4,
         )
 
 
@@ -55,7 +55,7 @@ class RBLNGemmaForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         rbln_config = {
             "batch_size": 1,
             "max_seq_len": 4096,
-            "tensor_parallel_size": 4,
+            "num_devices": 4,
         }
         model = RBLNGemmaForCausalLM.from_pretrained(
             "google/gemma-7b",
@@ -70,7 +70,7 @@ class RBLNGemmaForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         config = RBLNGemmaForCausalLMConfig(
             batch_size=1,
             max_seq_len=4096,
-            tensor_parallel_size=4
+            num_devices=4
         )
         model = RBLNGemmaForCausalLM.from_pretrained(
             "google/gemma-7b",

--- a/src/optimum/rbln/transformers/models/gemma2/configuration_gemma2.py
+++ b/src/optimum/rbln/transformers/models/gemma2/configuration_gemma2.py
@@ -26,7 +26,7 @@ class RBLNGemma2ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
     config = RBLNGemma2ForCausalLMConfig(
         batch_size=1,
         max_seq_len=8192,
-        tensor_parallel_size=4
+        num_devices=4
     )
     # Use the configuration with from_pretrained
     model = RBLNGemma2ForCausalLM.from_pretrained(

--- a/src/optimum/rbln/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/optimum/rbln/transformers/models/gemma2/modeling_gemma2.py
@@ -49,13 +49,13 @@ class RBLNGemma2ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             "google/gemma-2-9b",
             export=True,
             rbln_batch_size=1,
-            rbln_tensor_parallel_size=4,
+            rbln_num_devices=4,
         )
         # Using a config dictionary
         rbln_config = {
             "batch_size": 1,
             "max_seq_len": 8192,
-            "tensor_parallel_size": 4,
+            "num_devices": 4,
         }
         model = RBLNGemma2ForCausalLM.from_pretrained(
             "google/gemma-2-9b",
@@ -67,7 +67,7 @@ class RBLNGemma2ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         config = RBLNGemma2ForCausalLMConfig(
             batch_size=1,
             max_seq_len=8192,
-            tensor_parallel_size=4
+            num_devices=4
         )
         model = RBLNGemma2ForCausalLM.from_pretrained(
             "google/gemma-2-9b",

--- a/src/optimum/rbln/transformers/models/gpt2/configuration_gpt2.py
+++ b/src/optimum/rbln/transformers/models/gpt2/configuration_gpt2.py
@@ -37,7 +37,7 @@ class RBLNGPT2ModelConfig(RBLNDecoderOnlyModelConfig):
     config = RBLNGPT2ModelConfig(
         batch_size=1,
         max_seq_len=1024,
-        tensor_parallel_size=4
+        num_devices=4
     )
 
     # Use the configuration with from_pretrained

--- a/src/optimum/rbln/transformers/models/gpt_oss/configuration_gpt_oss.py
+++ b/src/optimum/rbln/transformers/models/gpt_oss/configuration_gpt_oss.py
@@ -28,7 +28,7 @@ class RBLNGptOssForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
     # Create a configuration object
     config = RBLNGptOssForCausalLMConfig(
         batch_size=1,
-        tensor_parallel_size=8,
+        num_devices=8,
         kvcache_partition_len=8192,
     )
 

--- a/src/optimum/rbln/transformers/models/gpt_oss/modeling_gpt_oss.py
+++ b/src/optimum/rbln/transformers/models/gpt_oss/modeling_gpt_oss.py
@@ -63,7 +63,7 @@ class RBLNGptOssForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             "openai/gpt-oss-20b",
             export=True,
             rbln_batch_size=1,
-            rbln_tensor_parallel_size=8,
+            rbln_num_devices=8,
             rbln_kvcache_partition_len=8192,
         )
 
@@ -71,7 +71,7 @@ class RBLNGptOssForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         # Using a config dictionary
         rbln_config = {
             "batch_size": 1,
-            "tensor_parallel_size": 8,
+            "num_devices": 8,
             "kvcache_partition_len": 8192,
         }
         model = RBLNGptOssForCausalLM.from_pretrained(
@@ -86,7 +86,7 @@ class RBLNGptOssForCausalLM(RBLNDecoderOnlyModelForCausalLM):
 
         config = RBLNGptOssForCausalLMConfig(
             batch_size=1,
-            tensor_parallel_size=8,
+            num_devices=8,
             kvcache_partition_len=8192,
         )
         model = RBLNGptOssForCausalLM.from_pretrained(

--- a/src/optimum/rbln/transformers/models/idefics3/modeling_idefics3.py
+++ b/src/optimum/rbln/transformers/models/idefics3/modeling_idefics3.py
@@ -209,7 +209,7 @@ class RBLNIdefics3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationM
                 "text_model": {
                     "batch_size": 1,
                     "max_seq_len": 131_072,
-                    "tensor_parallel_size": 8,
+                    "num_devices": 8,
                     "use_inputs_embeds": True,
                     "attn_impl": "flash_attn",
                     "kvcache_partition_len": 16_384,

--- a/src/optimum/rbln/transformers/models/llama/configuration_llama.py
+++ b/src/optimum/rbln/transformers/models/llama/configuration_llama.py
@@ -29,7 +29,7 @@ class RBLNLlamaForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
     config = RBLNLlamaForCausalLMConfig(
         batch_size=1,
         max_seq_len=4096,
-        tensor_parallel_size=4
+        num_devices=4
     )
 
     # Use the configuration with from_pretrained

--- a/src/optimum/rbln/transformers/models/llama/modeling_llama.py
+++ b/src/optimum/rbln/transformers/models/llama/modeling_llama.py
@@ -47,7 +47,7 @@ class RBLNLlamaForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             "meta-llama/Llama-2-7b-hf",
             export=True,
             rbln_batch_size=1,
-            rbln_tensor_parallel_size=4,
+            rbln_num_devices=4,
         )
 
 
@@ -55,7 +55,7 @@ class RBLNLlamaForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         rbln_config = {
             "batch_size": 1,
             "max_seq_len": 4096,
-            "tensor_parallel_size": 4,
+            "num_devices": 4,
         }
         model = RBLNLlamaForCausalLM.from_pretrained(
             "meta-llama/Llama-2-7b-hf",
@@ -70,7 +70,7 @@ class RBLNLlamaForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         config = RBLNLlamaForCausalLMConfig(
             batch_size=1,
             max_seq_len=4096,
-            tensor_parallel_size=4
+            num_devices=4
         )
         model = RBLNLlamaForCausalLM.from_pretrained(
             "meta-llama/Llama-2-7b-hf",

--- a/src/optimum/rbln/transformers/models/llava/modeling_llava.py
+++ b/src/optimum/rbln/transformers/models/llava/modeling_llava.py
@@ -129,7 +129,7 @@ class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
             rbln_config={
                 "vision_tower": {"output_hidden_states": True},
                 "language_model": {
-                    "tensor_parallel_size": 4,
+                    "num_devices": 4,
                     "use_inputs_embeds": True,  # In Llava, language model must use inputs_embeds as input.
                 },
             },
@@ -146,7 +146,7 @@ class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
             batch_size=1,
             max_seq_len=4096,
             use_inputs_embeds=True,
-            tensor_parallel_size=4
+            num_devices=4
         )
         llava_config = RBLNLlavaForConditionalGenerationConfig(
             batch_size=1,

--- a/src/optimum/rbln/transformers/models/llava_next/modeling_llava_next.py
+++ b/src/optimum/rbln/transformers/models/llava_next/modeling_llava_next.py
@@ -114,7 +114,7 @@ class RBLNLlavaNextForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
             export=True,
             rbln_config={
                 "language_model": {
-                    "tensor_parallel_size": 4,
+                    "num_devices": 4,
                     "use_inputs_embeds": True,  # In Llava-Next, language model must use inputs_embeds as input.
                 },
             },

--- a/src/optimum/rbln/transformers/models/midm/configuration_midm.py
+++ b/src/optimum/rbln/transformers/models/midm/configuration_midm.py
@@ -29,7 +29,7 @@ class RBLNMidmLMHeadModelConfig(RBLNDecoderOnlyModelForCausalLMConfig):
     config = RBLNMidmLMHeadModelConfig(
         batch_size=1,
         max_seq_len=4096,
-        tensor_parallel_size=4
+        num_devices=4
     )
 
     # Use the configuration with from_pretrained

--- a/src/optimum/rbln/transformers/models/midm/modeling_midm.py
+++ b/src/optimum/rbln/transformers/models/midm/modeling_midm.py
@@ -55,7 +55,7 @@ class RBLNMidmLMHeadModel(RBLNDecoderOnlyModelForCausalLM):
             "KT-AI/midm-bitext-S-7B-inst-v1",
             export=True,
             rbln_batch_size=1,
-            rbln_tensor_parallel_size=4,
+            rbln_num_devices=4,
         )
 
 
@@ -63,7 +63,7 @@ class RBLNMidmLMHeadModel(RBLNDecoderOnlyModelForCausalLM):
         rbln_config = {
             "batch_size": 1,
             "max_seq_len": 4096,
-            "tensor_parallel_size": 4,
+            "num_devices": 4,
         }
         model = RBLNMidmLMHeadModel.from_pretrained(
             "KT-AI/midm-bitext-S-7B-inst-v1",
@@ -78,7 +78,7 @@ class RBLNMidmLMHeadModel(RBLNDecoderOnlyModelForCausalLM):
         config = RBLNMidmLMHeadModelConfig(
             batch_size=1,
             max_seq_len=4096,
-            tensor_parallel_size=4
+            num_devices=4
         )
         model = RBLNMidmLMHeadModel.from_pretrained(
             "KT-AI/midm-bitext-S-7B-inst-v1",

--- a/src/optimum/rbln/transformers/models/mistral/configuration_mistral.py
+++ b/src/optimum/rbln/transformers/models/mistral/configuration_mistral.py
@@ -29,7 +29,7 @@ class RBLNMistralForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
     config = RBLNMistralForCausalLMConfig(
         batch_size=1,
         max_seq_len=4096,
-        tensor_parallel_size=4
+        num_devices=4
     )
 
     # Use the configuration with from_pretrained

--- a/src/optimum/rbln/transformers/models/mistral/modeling_mistral.py
+++ b/src/optimum/rbln/transformers/models/mistral/modeling_mistral.py
@@ -50,14 +50,14 @@ class RBLNMistralForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             "mistralai/Mistral-7B-v0.1",
             export=True,
             rbln_batch_size=1,
-            rbln_tensor_parallel_size=4,
+            rbln_num_devices=4,
         )
 
         # Using a config dictionary
         rbln_config = {
             "batch_size": 1,
             "max_seq_len": 4096,
-            "tensor_parallel_size": 4,
+            "num_devices": 4,
         }
         model = RBLNMistralForCausalLM.from_pretrained(
             "mistralai/Mistral-7B-v0.1",
@@ -71,7 +71,7 @@ class RBLNMistralForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         config = RBLNMistralForCausalLMConfig(
             batch_size=1,
             max_seq_len=4096,
-            tensor_parallel_size=4
+            num_devices=4
         )
         model = RBLNMistralForCausalLM.from_pretrained(
             "mistralai/Mistral-7B-v0.1",

--- a/src/optimum/rbln/transformers/models/mixtral/configuration_mixtral.py
+++ b/src/optimum/rbln/transformers/models/mixtral/configuration_mixtral.py
@@ -26,7 +26,7 @@ class RBLNMixtralForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
     config = RBLNMixtralForCausalLMConfig(
         batch_size=1,
         max_seq_len=32768,
-        tensor_parallel_size=4
+        num_devices=4
     )
     # Use the configuration with from_pretrained
     model = RBLNMixtralForCausalLM.from_pretrained(

--- a/src/optimum/rbln/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/optimum/rbln/transformers/models/mixtral/modeling_mixtral.py
@@ -37,13 +37,13 @@ class RBLNMixtralForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             "mistralai/Mixtral-8x7B-Instruct-v0.1",
             export=True,
             rbln_batch_size=1,
-            rbln_tensor_parallel_size=4,
+            rbln_num_devices=4,
         )
         # Using a config dictionary
         rbln_config = {
             "batch_size": 1,
             "max_seq_len": 32768,
-            "tensor_parallel_size": 4,
+            "num_devices": 4,
         }
         model = RBLNMixtralForCausalLM.from_pretrained(
             "mistralai/Mixtral-8x7B-Instruct-v0.1",
@@ -55,7 +55,7 @@ class RBLNMixtralForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         config = RBLNMixtralForCausalLMConfig(
             batch_size=1,
             max_seq_len=32768,
-            tensor_parallel_size=4
+            num_devices=4
         )
         model = RBLNMixtralForCausalLM.from_pretrained(
             "mistralai/Mixtral-8x7B-Instruct-v0.1",

--- a/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
@@ -85,7 +85,7 @@ class RBLNPaliGemmaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
                     "prefill_chunk_size": 8192,
                 }
             },
-            rbln_tensor_parallel_size=4,
+            rbln_num_devices=4,
         )
 
         model.save_pretrained("compiled-paligemma2-3b-mix-224")
@@ -389,7 +389,7 @@ class RBLNPaliGemmaModel(RBLNModel):
                     "prefill_chunk_size": 8192,
                 }
             },
-            rbln_tensor_parallel_size=4,
+            rbln_num_devices=4,
         )
 
         model.save_pretrained("compiled-paligemma2-3b-mix-224")

--- a/src/optimum/rbln/transformers/models/phi/configuration_phi.py
+++ b/src/optimum/rbln/transformers/models/phi/configuration_phi.py
@@ -29,7 +29,7 @@ class RBLNPhiForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
     config = RBLNPhiForCausalLMConfig(
         batch_size=1,
         max_seq_len=4096,
-        tensor_parallel_size=4
+        num_devices=4
     )
 
     # Use the configuration with from_pretrained

--- a/src/optimum/rbln/transformers/models/phi/modeling_phi.py
+++ b/src/optimum/rbln/transformers/models/phi/modeling_phi.py
@@ -47,7 +47,7 @@ class RBLNPhiForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             "microsoft/phi-2",
             export=True,
             rbln_batch_size=1,
-            rbln_tensor_parallel_size=4,
+            rbln_num_devices=4,
         )
 
 
@@ -55,7 +55,7 @@ class RBLNPhiForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         rbln_config = {
             "batch_size": 1,
             "max_seq_len": 4096,
-            "tensor_parallel_size": 4,
+            "num_devices": 4,
         }
         model = RBLNPhiForCausalLM.from_pretrained(
             "microsoft/phi-2",
@@ -70,7 +70,7 @@ class RBLNPhiForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         config = RBLNPhiForCausalLMConfig(
             batch_size=1,
             max_seq_len=4096,
-            tensor_parallel_size=4
+            num_devices=4
         )
         model = RBLNPhiForCausalLM.from_pretrained(
             "microsoft/phi-2",

--- a/src/optimum/rbln/transformers/models/qwen2/configuration_qwen2.py
+++ b/src/optimum/rbln/transformers/models/qwen2/configuration_qwen2.py
@@ -29,7 +29,7 @@ class RBLNQwen2ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
     config = RBLNQwen2ForCausalLMConfig(
         batch_size=1,
         max_seq_len=4096,
-        tensor_parallel_size=4
+        num_devices=4
     )
 
     # Use the configuration with from_pretrained

--- a/src/optimum/rbln/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/optimum/rbln/transformers/models/qwen2/modeling_qwen2.py
@@ -50,7 +50,7 @@ class RBLNQwen2ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             "Qwen/Qwen2-7B-Instruct",
             export=True,
             rbln_batch_size=1,
-            rbln_tensor_parallel_size=4,
+            rbln_num_devices=4,
         )
 
 
@@ -58,7 +58,7 @@ class RBLNQwen2ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         rbln_config = {
             "batch_size": 1,
             "max_seq_len": 4096,
-            "tensor_parallel_size": 4,
+            "num_devices": 4,
         }
         model = RBLNQwen2ForCausalLM.from_pretrained(
             "Qwen/Qwen2-7B-Instruct",
@@ -73,7 +73,7 @@ class RBLNQwen2ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         config = RBLNQwen2ForCausalLMConfig(
             batch_size=1,
             max_seq_len=4096,
-            tensor_parallel_size=4
+            num_devices=4
         )
         model = RBLNQwen2ForCausalLM.from_pretrained(
             "Qwen/Qwen2-7B-Instruct",

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -620,7 +620,7 @@ class RBLNQwen2_5_VLForConditionalGeneration(RBLNQwen2_5_VLModel, RBLNDecoderOnl
                     "max_seq_len": 6400,
                     "device": 0,
                 },
-                "tensor_parallel_size": 8,
+                "num_devices": 8,
                 "kvcache_partition_len": 16_384,
                 "max_seq_len": 114_688,
                 "device": [0, 1, 2, 3, 4, 5, 6, 7],

--- a/src/optimum/rbln/transformers/models/qwen2_moe/configuration_qwen2_moe.py
+++ b/src/optimum/rbln/transformers/models/qwen2_moe/configuration_qwen2_moe.py
@@ -26,7 +26,7 @@ class RBLNQwen2MoeForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
     config = RBLNQwen2MoeForCausalLMConfig(
         batch_size=1,
         max_seq_len=8192,
-        tensor_parallel_size=4
+        num_devices=4
     )
     # Use the configuration with from_pretrained
     model = RBLNQwen2MoeForCausalLM.from_pretrained(

--- a/src/optimum/rbln/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/optimum/rbln/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -37,13 +37,13 @@ class RBLNQwen2MoeForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             "Qwen/Qwen1.5-MoE-A2.7B",
             export=True,
             rbln_batch_size=1,
-            rbln_tensor_parallel_size=4,
+            rbln_num_devices=4,
         )
         # Using a config dictionary
         rbln_config = {
             "batch_size": 1,
             "max_seq_len": 8192,
-            "tensor_parallel_size": 4,
+            "num_devices": 4,
         }
         model = RBLNQwen2MoeForCausalLM.from_pretrained(
             "Qwen/Qwen1.5-MoE-A2.7B",
@@ -55,7 +55,7 @@ class RBLNQwen2MoeForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         config = RBLNQwen2MoeForCausalLMConfig(
             batch_size=1,
             max_seq_len=8192,
-            tensor_parallel_size=4
+            num_devices=4
         )
         model = RBLNQwen2MoeForCausalLM.from_pretrained(
             "Qwen/Qwen1.5-MoE-A2.7B",

--- a/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -509,7 +509,7 @@ class RBLNQwen2VLForConditionalGeneration(RBLNQwen2VLModel, RBLNDecoderOnlyModel
                     "max_seq_len": 6400,
                     "device": 0,
                 },
-                "tensor_parallel_size": 8,
+                "num_devices": 8,
                 "max_seq_len": 32_768,
                 "device": [0, 1, 2, 3, 4, 5, 6, 7],
             },

--- a/src/optimum/rbln/transformers/models/qwen3/configuration_qwen3.py
+++ b/src/optimum/rbln/transformers/models/qwen3/configuration_qwen3.py
@@ -29,7 +29,7 @@ class RBLNQwen3ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
     config = RBLNQwen3ForCausalLMConfig(
         batch_size=1,
         max_seq_len=40960,
-        tensor_parallel_size=4,
+        num_devices=4,
         kvcache_partition_len=16384
     )
 
@@ -57,7 +57,7 @@ class RBLNQwen3ModelConfig(RBLNDecoderOnlyModelConfig):
     config = RBLNQwen3ModelConfig(
         batch_size=1,
         max_seq_len=40960,
-        tensor_parallel_size=4,
+        num_devices=4,
         kvcache_partition_len=16384
     )
 

--- a/src/optimum/rbln/transformers/models/qwen3/modeling_qwen3.py
+++ b/src/optimum/rbln/transformers/models/qwen3/modeling_qwen3.py
@@ -45,13 +45,13 @@ class RBLNQwen3ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             "Qwen/Qwen3-4B",
             export=True,
             rbln_batch_size=1,
-            rbln_tensor_parallel_size=4,
+            rbln_num_devices=4,
         )
         # Using a config dictionary
         rbln_config = {
             "batch_size": 1,
             "max_seq_len": 40_960,
-            "tensor_parallel_size": 4,
+            "num_devices": 4,
             "kvcache_partition_len": 8192,
         }
         model = RBLNQwen3ForCausalLM.from_pretrained(
@@ -64,7 +64,7 @@ class RBLNQwen3ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         config = RBLNQwen3ForCausalLMConfig(
             batch_size=1,
             max_seq_len=40_960,
-            tensor_parallel_size=4,
+            num_devices=4,
             kvcache_partition_len=8192,
         )
         model = RBLNQwen3ForCausalLM.from_pretrained(
@@ -104,7 +104,7 @@ class RBLNQwen3Model(RBLNDecoderOnlyModel):
             export=True,
             rbln_batch_size=1,
             rbln_max_seq_len=40_960,
-            rbln_tensor_parallel_size=4,
+            rbln_num_devices=4,
             rbln_kvcache_partition_len=8192,
         )
     """

--- a/src/optimum/rbln/transformers/models/qwen3_moe/configuration_qwen3_moe.py
+++ b/src/optimum/rbln/transformers/models/qwen3_moe/configuration_qwen3_moe.py
@@ -26,7 +26,7 @@ class RBLNQwen3MoeForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
     config = RBLNQwen3MoeForCausalLMConfig(
         batch_size=1,
         max_seq_len=262144,
-        tensor_parallel_size=4
+        num_devices=4
     )
     # Use the configuration with from_pretrained
     model = RBLNQwen3MoeForCausalLM.from_pretrained(

--- a/src/optimum/rbln/transformers/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/optimum/rbln/transformers/models/qwen3_moe/modeling_qwen3_moe.py
@@ -37,13 +37,13 @@ class RBLNQwen3MoeForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             "Qwen/Qwen3-30B-A3B-Thinking-2507",
             export=True,
             rbln_batch_size=1,
-            rbln_tensor_parallel_size=4,
+            rbln_num_devices=4,
         )
         # Using a config dictionary
         rbln_config = {
             "batch_size": 1,
             "max_seq_len": 262144,
-            "tensor_parallel_size": 4,
+            "num_devices": 4,
         }
         model = RBLNQwen3MoeForCausalLM.from_pretrained(
             "Qwen/Qwen3-30B-A3B-Thinking-2507",
@@ -55,7 +55,7 @@ class RBLNQwen3MoeForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         config = RBLNQwen3MoeForCausalLMConfig(
             batch_size=1,
             max_seq_len=262144,
-            tensor_parallel_size=4
+            num_devices=4
         )
         model = RBLNQwen3MoeForCausalLM.from_pretrained(
             "Qwen/Qwen3-30B-A3B-Thinking-2507",

--- a/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -792,7 +792,7 @@ class RBLNQwen3VLForConditionalGeneration(RBLNQwen3VLModel, RBLNDecoderOnlyModel
                     "max_seq_len": 6400,
                     "device": 0,
                 },
-                "tensor_parallel_size": 8,
+                "num_devices": 8,
                 "kvcache_partition_len": 16_384,
                 "max_seq_len": 262_144,
                 "device": [0, 1, 2, 3, 4, 5, 6, 7],

--- a/src/optimum/rbln/transformers/models/t5/modeling_t5.py
+++ b/src/optimum/rbln/transformers/models/t5/modeling_t5.py
@@ -64,7 +64,7 @@ class RBLNT5EncoderModel(RBLNTransformerEncoderForFeatureExtraction):
         model = RBLNT5EncoderModel.from_pretrained(
             "sentence-transformers/sentence-t5-xxl",
             export=True,
-            rbln_tensor_parallel_size=4,
+            rbln_num_devices=4,
         )
 
         model.save_pretrained("compiled-sentence-t5-xxl")
@@ -110,7 +110,7 @@ class RBLNT5ForConditionalGeneration(RBLNModelForSeq2SeqLM):
         model = RBLNT5ForConditionalGeneration.from_pretrained(
             "google-t5/t5-11b",
             export=True,
-            rbln_tensor_parallel_size=4,
+            rbln_num_devices=4,
         )
 
         model.save_pretrained("compiled-sentence-t5-xxl")

--- a/src/optimum/rbln/utils/runtime_utils.py
+++ b/src/optimum/rbln/utils/runtime_utils.py
@@ -12,12 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import re
 import threading
+from functools import lru_cache
 from typing import Any, List, Optional, Union
 
 import rebel
 import torch
+
+
+@lru_cache(maxsize=1)
+def compiler_num_devices_kwarg() -> str:
+    """Return the kwarg name the installed rebel-compiler expects for the device count.
+
+    Compilers expose this as `num_devices`, but ones predating that name only accept
+    `tensor_parallel_size`. `compile_from_torch` forwards `**kwargs` to `compile`, so we probe
+    `rebel.compile`'s signature to pick the name the installed compiler accepts.
+    """
+    try:
+        params = inspect.signature(rebel.compile).parameters
+    except (ValueError, TypeError):
+        return "num_devices"
+    return "num_devices" if "num_devices" in params else "tensor_parallel_size"
 
 
 def is_compiler_supports_buffer_resize() -> bool:
@@ -103,24 +120,22 @@ def normalize_npu(npu: str) -> str:
 
 
 def tp_and_devices_are_ok(
-    tensor_parallel_size: Optional[int] = None,
+    num_devices: Optional[int] = None,
     device: Optional[Union[int, List[int]]] = None,
     npu: Optional[str] = None,
 ) -> Optional[str]:
-    if tensor_parallel_size is None:
-        tensor_parallel_size = 1
+    if num_devices is None:
+        num_devices = 1
 
     if device is None:
-        device = list(range(tensor_parallel_size))
+        device = list(range(num_devices))
     elif isinstance(device, int):
         device = [device]
     elif isinstance(device, list):
         if any(not isinstance(d, int) for d in device):
             return "Device must be a(n) (list of) integer(s)."
-        if len(device) != tensor_parallel_size:
-            return (
-                f"The number of devices ({len(device)}) does not match tensor parallel size ({tensor_parallel_size})."
-            )
+        if len(device) != num_devices:
+            return f"The number of devices ({len(device)}) does not match `num_devices` ({num_devices})."
     else:
         return f"Invalid device: {device}"
 
@@ -132,11 +147,8 @@ def tp_and_devices_are_ok(
                 f"Device {device_id} is not a valid NPU device. Please check your NPU status with 'rbln-smi' command."
             )
 
-    if rebel.device_count() < tensor_parallel_size:
-        return (
-            f"Tensor parallel size {tensor_parallel_size} is greater than "
-            f"the number of available devices {rebel.device_count()}."
-        )
+    if rebel.device_count() < num_devices:
+        return f"`num_devices` ({num_devices}) is greater than the number of available devices {rebel.device_count()}."
 
     if npu is not None:
         for device_id in device:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -214,13 +214,23 @@ def test_submodule_config_object():
     assert model.rbln_config.language_model.batch_size == 2
 
 
+def test_num_devices_deprecated_alias():
+    """`tensor_parallel_size` is the deprecated alias of `num_devices` and must still map through."""
+    cfg = RBLNMistralForCausalLMConfig(num_devices=4)
+    assert cfg.num_devices == 4
+
+    legacy = RBLNMistralForCausalLMConfig(tensor_parallel_size=4)
+    assert legacy.num_devices == 4
+    assert not hasattr(legacy, "tensor_parallel_size")
+
+
 @pytest.mark.parametrize(
     "invalid_param",
     [
         {"rbln_nonexistent_param": "value"},
         {"rbln_image_size": "not_an_integer"},  # Type error
         {"rbln_batch_size": -1},  # Negative value
-        {"rbln_tensor_parallel_size": 32},  # Tensor parallel size is not supported
+        {"rbln_tensor_parallel_size": 32},  # deprecated alias of num_devices; too many devices is unsupported
         {"rbln_npu": "RBLN-Unknown"},  # NPU is not supported
         {"rbln_device": 32},  # Device is not supported
     ],

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -661,7 +661,7 @@ class TestQwen2VLForConditionalGeneration(LLMTest.TestLLM):
     RBLN_CLASS_KWARGS = {
         "rbln_config": {
             "visual": {"max_seq_len": 512},
-            "tensor_parallel_size": 1,
+            "num_devices": 1,
             "max_seq_len": 32_768,
         }
     }
@@ -704,7 +704,7 @@ class TestQwen2_5_VLForConditionalGeneration(LLMTest.TestLLM):
     RBLN_CLASS_KWARGS = {
         "rbln_config": {
             "visual": {"max_seq_len": 512},
-            "tensor_parallel_size": 1,
+            "num_devices": 1,
             "kvcache_partition_len": 16_384,
             "max_seq_len": 32_768,
         }
@@ -744,7 +744,7 @@ class TestQwen3VLForConditionalGeneration(LLMTest.TestLLM):
     RBLN_CLASS_KWARGS = {
         "rbln_config": {
             "visual": {"max_seq_len": 512},
-            "tensor_parallel_size": 1,
+            "num_devices": 1,
             "kvcache_partition_len": 8192,
             "max_seq_len": 16_384,
         }
@@ -780,7 +780,7 @@ class TestQwen3VLMoeForConditionalGeneration(LLMTest.TestLLM):
     RBLN_CLASS_KWARGS = {
         "rbln_config": {
             "visual": {"max_seq_len": 512},
-            "tensor_parallel_size": 1,
+            "num_devices": 1,
             "kvcache_partition_len": 8192,
             "max_seq_len": 16_384,
         }
@@ -891,7 +891,7 @@ class TestLlamaForCausalLM_fp8(LLMTest.TestLLM):
             "attn_impl": "flash_attn",
             "kvcache_partition_len": 4096,
             "max_seq_len": 8192,
-            "tensor_parallel_size": 1,
+            "num_devices": 1,
         },
     }
 

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -421,7 +421,7 @@ class TestColQwen2Model(BaseTest.TestModel):
         "rbln_config": {
             "vlm": {
                 "visual": {"max_seq_len": 512},
-                "tensor_parallel_size": 1,
+                "num_devices": 1,
                 "max_seq_len": 32_768,
             }
         }


### PR DESCRIPTION
# Pull Request Description

Since the compiler's `tensor_parallel_size` has been renamed to `num_devices`, we are also renaming the `tensor_parallel_size` used here. However, for backward compatibility, we are marking it as deprecated. 

## Type of Change
- [x] Code refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes Overview
rebel-compiler renamed its public compile argument `tensor_parallel_size` to the parallelization-neutral `num_devices`, keeping the old name as a deprecated alias (SR-15, rebel_compiler#11330). This PR ports the same rename into optimum-rbln.

- Renamed the public knob `tensor_parallel_size` to `num_devices` on `RBLNModelConfig` and `RBLNCompileConfig`. The old name is kept as a deprecated alias via `deprecate_kwarg`, so both `tensor_parallel_size` and `rbln_tensor_parallel_size` keep working (they map to `num_devices` with a deprecation notice).
- At the compiler boundary (`rebel.compile_from_torch` in `modeling_base.py`), feature-detect whether `rebel.compile` accepts `num_devices` via `inspect.signature`. If it does, pass `num_devices`; otherwise fall back to `tensor_parallel_size`. This avoids version-string comparison, so it works against both new and pre-rename compilers and stays correct after the alias is eventually removed.
- Models compiled with an older version still load: when reconstructing `RBLNCompileConfig` from a serialized `rbln_config.json` (whose compile cfgs carry `tensor_parallel_size`), unknown keys are dropped and `num_devices` is repopulated from the parent config.
- Updated CLI help, docstrings, example scripts, and tests to the new name, and added a test asserting the deprecated alias maps to `num_devices`.

Since `num_devices` is not specific to tensor parallelism, user-facing wording was changed from "tensor parallel size" to "number of devices". The internal `_tp_support` flag was left as-is, because it genuinely describes a model's tensor-parallelism support.

## Motivation and Context
Keeps optimum-rbln's public API aligned with the rebel-compiler rename (SR-15). The deprecated alias ensures existing user code and previously compiled artifacts do not break.

## Related Issues
Related to SR-15 (rebel_compiler#11330)

----
# Conventional commit
```
refactor: rename tensor_parallel_size to num_devices
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
