### PR TITLE
model(paligemma): tolerate the labels kwarg from the processor during generation

### DIFF
--- a/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
@@ -220,8 +220,9 @@ class RBLNPaliGemmaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
         labels=None,
         **kwargs,
     ):
-        # Accept and drop `labels`: PaliGemmaProcessor may emit this training-only field. Declaring it
-        # keeps `generate`'s `_validate_model_kwargs` from rejecting the processor output.
+        # `labels` is a training-only field that PaliGemmaProcessor may include in its output; it has no
+        # effect on generation and is ignored here. Declaring it also mirrors the upstream model (whose
+        # forward lists `labels`), so generate's `_validate_model_kwargs` accepts the processor output as-is.
         is_prefill_phase = generate_idx is None
 
         model_inputs = self.language_model.prepare_inputs_for_generation(

--- a/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
@@ -220,9 +220,8 @@ class RBLNPaliGemmaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
         labels=None,
         **kwargs,
     ):
-        # `labels` is a training-only field that PaliGemmaProcessor can include in its output. It has no
-        # role in generation, so accept and drop it. Declaring it here also keeps `generate`'s
-        # `_validate_model_kwargs` from rejecting the processor output (the native model declares `labels`).
+        # Accept and drop `labels`: PaliGemmaProcessor may emit this training-only field. Declaring it
+        # keeps `generate`'s `_validate_model_kwargs` from rejecting the processor output.
         is_prefill_phase = generate_idx is None
 
         model_inputs = self.language_model.prepare_inputs_for_generation(

--- a/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
@@ -217,9 +217,12 @@ class RBLNPaliGemmaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
         generate_idx=None,
         position_ids=None,
         token_type_ids=None,
+        labels=None,
         **kwargs,
     ):
-        # Prepare HF generation
+        # `labels` is a training-only field that PaliGemmaProcessor can include in its output. It has no
+        # role in generation, so accept and drop it. Declaring it here also keeps `generate`'s
+        # `_validate_model_kwargs` from rejecting the processor output (the native model declares `labels`).
         is_prefill_phase = generate_idx is None
 
         model_inputs = self.language_model.prepare_inputs_for_generation(


### PR DESCRIPTION
## Problem

Running PaliGemma / PaliGemma 2 with the standard processor output fails at `generate`:

```python
model_inputs = processor(text=prompt, images=image, return_tensors="pt")
model.generate(**model_inputs, max_new_tokens=100)
# ValueError: The following `model_kwargs` are not used by the model: ['labels']
```

`PaliGemmaProcessor` can include a training-only `labels` field in its output. During generation, transformers' `_validate_model_kwargs` builds the accepted-argument set from `prepare_inputs_for_generation` (unioned with `forward`, since it takes `**kwargs`). The **native** `PaliGemmaForConditionalGeneration` declares `labels` in its forward signature, so the native model accepts the processor output as-is; the RBLN model did not, so the same call is rejected.

## Fix

Accept `labels` in `RBLNPaliGemmaForConditionalGeneration.prepare_inputs_for_generation` and drop it — it has no role in generation. Declaring it in the signature also lets `_validate_model_kwargs` pass the standard processor output unchanged, matching native behavior. The `labels` value is consumed at this boundary so it does not leak into the language-model submodule.

PaliGemma and PaliGemma 2 share this RBLN class, so the change covers both.
