### PR TITLE
model: honor deprecated tensor_parallel_size in nested submodule config

### DIFF
--- a/src/optimum/rbln/configuration_utils.py
+++ b/src/optimum/rbln/configuration_utils.py
@@ -592,6 +592,12 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
             init_kwargs = from_predecessor
             init_kwargs.update(submodule_config)
 
+            # Drop the inherited `num_devices` so a submodule using the deprecated
+            # `tensor_parallel_size` alias isn't shadowed by it; an explicit submodule
+            # `num_devices` already wins on its own.
+            if "tensor_parallel_size" in submodule_config and "num_devices" not in submodule_config:
+                init_kwargs.pop("num_devices", None)
+
             if force_kwargs:
                 for key, value in kwargs.items():
                     if key in init_kwargs:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -243,9 +243,7 @@ def test_submodule_config_dict_deprecated_tensor_parallel_size():
 
     # With nothing specified, the parent's value is still inherited.
     parent_tp = RBLNMistralForCausalLMConfig(num_devices=2)
-    sub_inherit = parent_tp.initialize_submodule_config(
-        submodule_config={"cls_name": "RBLNMistralForCausalLMConfig"}
-    )
+    sub_inherit = parent_tp.initialize_submodule_config(submodule_config={"cls_name": "RBLNMistralForCausalLMConfig"})
     assert sub_inherit.num_devices == 2
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -224,6 +224,31 @@ def test_num_devices_deprecated_alias():
     assert not hasattr(legacy, "tensor_parallel_size")
 
 
+def test_submodule_config_dict_deprecated_tensor_parallel_size():
+    """Regression: a nested submodule dict using the deprecated `tensor_parallel_size` alias
+    must still set `num_devices`. The parent's inherited `num_devices` previously shadowed it,
+    so TP sharding was silently dropped (leading to DRAM OOM)."""
+    parent = RBLNMistralForCausalLMConfig()  # num_devices unset -> None
+    sub = parent.initialize_submodule_config(
+        submodule_config={"cls_name": "RBLNMistralForCausalLMConfig", "tensor_parallel_size": 4}
+    )
+    assert sub.num_devices == 4
+    assert not hasattr(sub, "tensor_parallel_size")
+
+    # An explicit `num_devices` in the submodule keeps winning.
+    sub_new = parent.initialize_submodule_config(
+        submodule_config={"cls_name": "RBLNMistralForCausalLMConfig", "num_devices": 8}
+    )
+    assert sub_new.num_devices == 8
+
+    # With nothing specified, the parent's value is still inherited.
+    parent_tp = RBLNMistralForCausalLMConfig(num_devices=2)
+    sub_inherit = parent_tp.initialize_submodule_config(
+        submodule_config={"cls_name": "RBLNMistralForCausalLMConfig"}
+    )
+    assert sub_inherit.num_devices == 2
+
+
 @pytest.mark.parametrize(
     "invalid_param",
     [


### PR DESCRIPTION
## Type of Change
- [ ] Release (dev → main merge for production release)
- [ ] New Model Support
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Changes Overview

`initialize_submodule_config` now drops the inherited `num_devices` when a submodule supplies only the deprecated `tensor_parallel_size` alias, so the existing `@deprecate_kwarg` rename applies to the submodule's own value (and still emits its deprecation warning). An explicit `num_devices` in the submodule keeps winning, and inheritance from the parent is unchanged when the submodule specifies neither.

Added a regression test in `tests/test_config.py` that calls `initialize_submodule_config` directly:

| Case | Before | After |
|---|---|---|
| nested `tensor_parallel_size=4` | `None` | `4` |
| nested `num_devices=8` | `8` | `8` |
| inherited from parent (`=2`) | `2` | `2` |

## Motivation and Context

Several multimodal models failed with DRAM OOM on the ATOM schedule CI (build #39), surfacing when optimum-rbln moved from a10 to a11. The cause is the `tensor_parallel_size` → `num_devices` rename (#597) colliding with the nested submodule config path.

When tensor parallelism is passed as a nested dict — as rbln-executor does with `rbln_config={"language_model": {"tensor_parallel_size": 4, ...}}` — `initialize_submodule_config` first seeds `num_devices` from the parent and then overlays the submodule dict, which still carries the old name `tensor_parallel_size`. The `@deprecate_kwarg` alias on `__init__` then sees both names present, keeps the inherited `num_devices` (usually `None`), and silently drops the submodule's request. TP sharding is therefore never applied, per-chiplet memory blows up, and it ends in DRAM OOM. The runtime warning shows it exactly:

> Both `tensor_parallel_size` and `num_devices` are set... Using `num_devices=None` and ignoring deprecated `tensor_parallel_size=4`.

## Related Issues

Regression introduced by #597 (`tensor_parallel_size` → `num_devices` rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
