### PR TITLE
refactor: Gemma3 effcient prefill

### DIFF
--- a/src/optimum/rbln/transformers/models/decoderonly/decoderonly_architecture.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/decoderonly_architecture.py
@@ -1217,7 +1217,13 @@ class SlidingWindowAttentionOp(AttentionOp):
                 else:
                     op_args["is_bidirectional"] = False
 
-        if self.phase == "decode" or self.phase == "image_prefill":
+        if self.phase == "decode":
+            op_args["attn_mask"] = attn_mask
+        elif self.phase == "image_prefill" and attn_mask is not None and attn_mask.dim() == 4:
+            # Only a model that supplies a 4D sliding-window mask for image_prefill (e.g. Gemma4)
+            # feeds it to the op. Otherwise (e.g. 2D causal mask) the sliding-window prefill
+            # op computes the causal window internally — passing a 2D mask trips the op's 4D mask
+            # assertion at compile time.
             op_args["attn_mask"] = attn_mask
         else:
             op_args["attn_mask"] = None

--- a/src/optimum/rbln/transformers/models/decoderonly/decoderonly_architecture.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/decoderonly_architecture.py
@@ -309,6 +309,57 @@ class DecoderOnlyForCausalLM(nn.Module):
         return logits, all_hidden_states
 
 
+def build_image_prefill_swa_custom_op_args(model, position_ids, query_position):
+    """Shared sliding-window custom-op args builder for image-prefill-capable models (Gemma3, Gemma4).
+
+    Returns (cache_seq_len, cache_offset, attn_mask) where attn_mask is:
+      - decode: a 4D causal sliding-window mask of shape (1, 1, 1, max_cache_len)
+      - prefill / image_prefill: a 4D mask of shape (1, 1, prefill_chunk_size, max_compute_len)
+        with max_compute_len = sliding_window + prefill_chunk_size. image_prefill additionally
+        allows bidirectional attention within the current chunk.
+    """
+    max_cache_len = model.config.sliding_window
+    valid_input_len = 1 if query_position is None else query_position + 1
+    cache_seq_len = torch.clamp(position_ids.to(torch.int32), max=max_cache_len)[:, :1]  # past seen tokens
+    cache_offset = (
+        torch.clamp(position_ids.to(torch.int32), max=max_cache_len)[:, :1] + valid_input_len
+    )  # cache offset for next steps
+
+    if model.phase == "decode":
+        # Causal mask for sliding window attention
+        attn_mask = torch.arange(max_cache_len)[None, :] - cache_seq_len
+        attn_mask = torch.where(attn_mask > 0, 0.0, 1.0)[:, None, None, :]
+    else:
+        #   - axis 2 (query):  the current prefill chunk being processed
+        #   - axis 3 (key/value): the sliding-window KV cache concatenated with the chunk's keys
+        _, prefill_chunk_size = position_ids.shape
+        max_compute_len = max_cache_len + prefill_chunk_size
+        cache_seq_len_b = torch.zeros(1, 1, 1, max_compute_len, dtype=torch.int32) + cache_seq_len
+        cache_offset_b = torch.zeros(1, 1, 1, max_compute_len, dtype=torch.int32) + cache_offset
+
+        q_idx = torch.zeros(1, 1, prefill_chunk_size, max_compute_len, dtype=torch.int32, device=position_ids.device)
+        q_idx = q_idx + torch.arange(prefill_chunk_size, dtype=torch.int32, device=position_ids.device).reshape(
+            1, 1, -1, 1
+        )
+
+        compute_idx = torch.arange(max_compute_len, dtype=torch.int32).reshape(1, 1, 1, -1)
+        in_chunk = (compute_idx >= cache_seq_len_b) & (compute_idx < cache_offset_b)
+        in_past = compute_idx < cache_seq_len_b
+
+        gap = cache_seq_len_b + q_idx - compute_idx
+        swa = (gap >= 0) & (gap < max_cache_len)
+
+        valid_q = q_idx < valid_input_len
+        valid_kv = torch.logical_or(in_past, in_chunk)
+        if model.phase == "image_prefill":
+            attn = valid_q & valid_kv & torch.logical_or(swa, in_chunk)
+        else:
+            attn = valid_q & valid_kv & swa
+        attn_mask = torch.where(attn, 1.0, 0.0).to(model.rbln_config.dtype)
+
+    return cache_seq_len, cache_offset, attn_mask
+
+
 class DecoderOnlyModel(nn.Module):
     """A modified decoder-only model implementation optimized for RBLN compilation.
 

--- a/src/optimum/rbln/transformers/models/decoderonly/decoderonly_runtime_utils.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/decoderonly_runtime_utils.py
@@ -660,10 +660,11 @@ class RBLNDecoderOnlyChunkedMultimodalPrefillMixin:
     # not waste KV-cache slots (the next chunk / decode overwrites the masked dead tail), and
     # (c) keep each chunk's KV write inside a single `kvcache_partition_len` partition.
     #
-    # Subclasses provide the runtime registry (`self.prefill`, `self.image_prefills`) and implement
-    # `_invoke_prefill_chunk` to map a chunk onto their compiled graph's exact argument order. Models
-    # without per-layer inputs (e.g. text+image only) leave `per_layer_inputs` as None and the
-    # per-layer branches below are skipped.
+    # Subclasses provide the runtime registry (`self.prefill` for text, plus `self.image_prefill` —
+    # a single bidirectional runtime by default; override `_select_image_prefill_runtime` and
+    # `_resolve_image_chunk` for multiple buckets) and implement `_invoke_prefill_chunk` to map a
+    # chunk onto their compiled graph's exact argument order. Models without per-layer inputs
+    # (e.g. text+image only) leave `per_layer_inputs` as None and the per-layer branches are skipped.
     #
     # MRO: mix in BEFORE RBLNRuntimeModel so this `prefill_forward` / `_prepare_prefill_inputs`
     # override the base text-only implementations while `super()` still resolves to RBLNRuntimeModel.
@@ -738,6 +739,29 @@ class RBLNDecoderOnlyChunkedMultimodalPrefillMixin:
             token_type_ids,
         )
 
+    def _select_image_prefill_runtime(self, chunk_size_used: int):
+        # Runtime that serves an image/video chunk. Default: a single bidirectional image-prefill
+        # runtime (`self.image_prefill`). Subclasses with multiple buckets override this to pick the
+        # runtime matching `chunk_size_used`.
+        return self.image_prefill
+
+    def _resolve_image_chunk(self, token_type_ids: torch.Tensor, step: int, start_type: int):
+        # Given an image/video run starting at `step` (token_type `start_type` > 0), return
+        # (run_len, chunk_size). Default: a single image-prefill bucket (`image_prefill_chunk_size`);
+        # the run must fit it. Subclasses with multiple buckets override this to pick the smallest
+        # bucket that fits the run.
+        bucket = self.rbln_config.image_prefill_chunk_size
+        run_len = _run_length_from(token_type_ids, step, value=start_type, cap=bucket + 1)
+        if run_len > bucket:
+            modality = "video" if start_type == 2 else "image"
+            raise ValueError(
+                f"{modality.capitalize()} run (token_type={start_type}) starting at position {step} "
+                f"is longer than the image-prefill bucket ({bucket}); no bucket can hold it. For video "
+                f"this means consecutive frames are not separated by text (each frame run must fit one "
+                f"bucket); otherwise increase `image_prefill_chunk_size`."
+            )
+        return run_len, bucket
+
     def _plan_prefill_chunks(self, token_type_ids: Optional[torch.Tensor], query_length: int):
         # Plans the chunked prefill once so the loop and block allocation stay in sync.
         # Walks the input exactly the way prefill_forward does and records, per chunk, the
@@ -754,9 +778,6 @@ class RBLNDecoderOnlyChunkedMultimodalPrefillMixin:
         #   alloc_len: highest cache slot (exclusive) touched, used to size block allocation.
         partition_len = self.rbln_config.kvcache_partition_len
         use_tt = self.rbln_config.use_image_prefill and token_type_ids is not None
-        if use_tt:
-            image_buckets = self.rbln_config.image_prefill_chunk_sizes
-            max_image_bucket = max(image_buckets)
 
         plan = []
         step = 0
@@ -770,17 +791,9 @@ class RBLNDecoderOnlyChunkedMultimodalPrefillMixin:
             start_type = int(token_type_ids[0, step].item()) if use_tt else 0
             is_image_prefill = use_tt and start_type > 0
             if is_image_prefill:
-                run_len = _run_length_from(token_type_ids, step, value=start_type, cap=max_image_bucket + 1)
-                if run_len > max_image_bucket:
-                    modality = "video" if start_type == 2 else "image"
-                    raise ValueError(
-                        f"{modality.capitalize()} run (token_type={start_type}) starting at position {step} "
-                        f"is longer than the largest image-prefill bucket ({max_image_bucket}); no bucket can "
-                        f"hold it. For video this means consecutive frames are not separated by text (each "
-                        f"frame run must fit one bucket); otherwise add a larger value to "
-                        f"`image_prefill_chunk_sizes`."
-                    )
-                chunk_size = min(b for b in image_buckets if b >= run_len)
+                # `_resolve_image_chunk` owns bucket selection: the mixin default assumes a single
+                # bucket; subclasses with multiple buckets override it.
+                run_len, chunk_size = self._resolve_image_chunk(token_type_ids, step, start_type)
             else:
                 chunk_size = self.rbln_config.prefill_chunk_size
                 run_len = _run_length_from(token_type_ids, step, value=0, cap=chunk_size) if use_tt else chunk_size
@@ -810,6 +823,100 @@ class RBLNDecoderOnlyChunkedMultimodalPrefillMixin:
             step += num_processed
 
         return plan, padded, alloc_len
+
+    def _extend_cache_position_for_alloc(
+        self,
+        cache_position: Optional[torch.Tensor],
+        token_type_ids: Optional[torch.Tensor],
+        attention_mask: Optional[torch.Tensor],
+    ) -> Optional[torch.Tensor]:
+        # During prefill, the tight-pack plan may touch cache slots past `query_length` (trailing
+        # chunk write-extent + partition-alignment padding). Extend cache_position so the page table
+        # reserves those slots. Returns cache_position unchanged for decode or non-multimodal prefill.
+        alloc_cache_position = cache_position
+        if (
+            self.phase != "decode"
+            and cache_position is not None
+            and self.rbln_config.use_image_prefill
+            and token_type_ids is not None
+        ):
+            plan_token_type_ids = token_type_ids
+            if attention_mask is not None:
+                mask_bool = attention_mask.to(dtype=torch.bool)
+                if mask_bool.dim() == 2:
+                    mask_bool = mask_bool[0]
+                plan_token_type_ids = token_type_ids[:, mask_bool]
+            query_length = cache_position.shape[-1]
+            _, _, alloc_len = self._plan_prefill_chunks(plan_token_type_ids, query_length)
+            if alloc_len > self.rbln_config.max_seq_len:
+                raise ValueError(
+                    f"Chunked prefill requires {alloc_len} KV-cache slots (input length "
+                    f"{query_length} plus {alloc_len - query_length} slots of trailing chunk_size "
+                    f"write-extent overhang and partition-alignment padding), which exceeds max_seq_len "
+                    f"({self.rbln_config.max_seq_len}). Increase max_seq_len or reduce the input length."
+                )
+            if alloc_len > query_length:
+                extra_pos = int(cache_position[0, -1].item()) + (alloc_len - query_length)
+                extra = cache_position.new_tensor([[extra_pos]])
+                alloc_cache_position = torch.cat([cache_position, extra], dim=-1)
+        return alloc_cache_position
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        cache_position: torch.Tensor = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        batch_idx: Optional[int] = None,
+        block_tables: Optional[torch.Tensor] = None,
+        position_embed: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+        token_type_ids: Optional[torch.Tensor] = None,
+        local_block_tables: Optional[torch.Tensor] = None,
+        lora_int_ids: Optional[torch.Tensor] = None,
+    ):
+        # Shared dispatch for models without per-layer inputs. Subclasses that carry per-layer
+        # inputs (e.g. Gemma4) override `forward` to thread that extra tensor through, calling
+        # `_extend_cache_position_for_alloc` for the same allocation-sizing behaviour.
+        inputs = self.inputs_embeddings_if_needed(input_ids, inputs_embeds)
+        alloc_cache_position = self._extend_cache_position_for_alloc(cache_position, token_type_ids, attention_mask)
+        block_tables, local_block_tables, is_external_block_tables = (
+            self.page_table_manager.get_block_tables_if_needed(
+                self.batch_size,
+                alloc_cache_position,
+                batch_idx=batch_idx,
+                phase=self.phase,
+                block_tables=block_tables,
+                local_block_tables=local_block_tables,
+            )
+        )
+
+        if self.phase == "decode":
+            return self.decode_forward(
+                inputs,
+                cache_position,
+                block_tables,
+                is_external_block_tables,
+                attention_mask=attention_mask,
+                position_embed=position_embed,
+                position_ids=position_ids,
+                local_block_tables=local_block_tables,
+                lora_int_ids=lora_int_ids,
+            )
+        else:
+            return self.prefill_forward(
+                inputs,
+                cache_position,
+                attention_mask,
+                batch_idx,
+                block_tables,
+                is_external_block_tables=is_external_block_tables,
+                position_ids=position_ids,
+                position_embed=position_embed,
+                token_type_ids=token_type_ids,
+                local_block_tables=local_block_tables,
+                lora_int_ids=lora_int_ids,
+            )
 
     def prefill_forward(
         self,
@@ -896,7 +1003,7 @@ class RBLNDecoderOnlyChunkedMultimodalPrefillMixin:
             chunked_attention_mask[:, mask_start : mask_start + num_processed_tokens] = 1
             query_position = torch.tensor(num_processed_tokens - 1, dtype=torch.int16)
 
-            runtime = self.image_prefills[chunk_size_used] if is_image_prefill else self.prefill
+            runtime = self._select_image_prefill_runtime(chunk_size_used) if is_image_prefill else self.prefill
             outputs = self._invoke_prefill_chunk(
                 runtime,
                 input_chunk,

--- a/src/optimum/rbln/transformers/models/gemma3/gemma3_architecture.py
+++ b/src/optimum/rbln/transformers/models/gemma3/gemma3_architecture.py
@@ -23,6 +23,7 @@ from ..decoderonly.decoderonly_architecture import (
     DecoderOnlyModel,
     DecoderOnlyWrapper,
     RotaryEmbedding,
+    build_image_prefill_swa_custom_op_args,
     slice_and_unsqueeze_cos_sin,
 )
 
@@ -51,52 +52,7 @@ class Gemma3ForCausalLMWrapper(DecoderOnlyWrapper):
 class Gemma3TextModel(DecoderOnlyModel):
     # Different from DecoderOnlyModel, this model has global and local rotary embeddings.
     def get_swa_custom_op_args(self, position_ids, query_position):
-        max_cache_len = self.config.sliding_window
-        valid_input_len = 1 if query_position is None else query_position + 1
-        cache_seq_len = torch.clamp(position_ids.to(torch.int32), max=max_cache_len)[:, :1]  # past seen tokens
-        cache_offset = (
-            torch.clamp(position_ids.to(torch.int32), max=max_cache_len)[:, :1] + valid_input_len
-        )  # cache offset for next steps
-
-        if self.phase == "decode":
-            # Causal mask for sliding window attention
-            attn_mask = torch.arange(max_cache_len)[None, :] - cache_seq_len
-            attn_mask = torch.where(attn_mask > 0, 0.0, 1.0)[:, None, None, :]
-        else:
-            # Prefill (and image_prefill) builds a 4D SWA mask of shape
-            #   (1, 1, prefill_chunk_size, max_compute_len)
-            # where max_compute_len = sliding_window + prefill_chunk_size.
-            #   - axis 2 (query):  the current prefill chunk being processed
-            #   - axis 3 (key/value): the sliding-window KV cache concatenated with the chunk's keys
-            # image_prefill additionally allows bidirectional attention within the current chunk.
-            _, prefill_chunk_size = position_ids.shape
-            max_compute_len = max_cache_len + prefill_chunk_size
-            cache_seq_len_b = torch.zeros(1, 1, 1, max_compute_len, dtype=torch.int32) + cache_seq_len
-            cache_offset_b = torch.zeros(1, 1, 1, max_compute_len, dtype=torch.int32) + cache_offset
-
-            q_idx = torch.zeros(
-                1, 1, prefill_chunk_size, max_compute_len, dtype=torch.int32, device=position_ids.device
-            )
-            q_idx = q_idx + torch.arange(prefill_chunk_size, dtype=torch.int32, device=position_ids.device).reshape(
-                1, 1, -1, 1
-            )
-
-            compute_idx = torch.arange(max_compute_len, dtype=torch.int32).reshape(1, 1, 1, -1)
-            in_chunk = (compute_idx >= cache_seq_len_b) & (compute_idx < cache_offset_b)
-            in_past = compute_idx < cache_seq_len_b
-
-            gap = cache_seq_len_b + q_idx - compute_idx
-            swa = (gap >= 0) & (gap < max_cache_len)
-
-            valid_q = q_idx < valid_input_len
-            valid_kv = torch.logical_or(in_past, in_chunk)
-            if self.phase == "image_prefill":
-                attn = valid_q & valid_kv & torch.logical_or(swa, in_chunk)
-            else:
-                attn = valid_q & valid_kv & swa
-            attn_mask = torch.where(attn, 1.0, 0.0).to(self.rbln_config.dtype)
-
-        return cache_seq_len, cache_offset, attn_mask
+        return build_image_prefill_swa_custom_op_args(self, position_ids, query_position)
 
     def forward(
         self,

--- a/src/optimum/rbln/transformers/models/gemma3/gemma3_architecture.py
+++ b/src/optimum/rbln/transformers/models/gemma3/gemma3_architecture.py
@@ -50,6 +50,54 @@ class Gemma3ForCausalLMWrapper(DecoderOnlyWrapper):
 
 class Gemma3TextModel(DecoderOnlyModel):
     # Different from DecoderOnlyModel, this model has global and local rotary embeddings.
+    def get_swa_custom_op_args(self, position_ids, query_position):
+        max_cache_len = self.config.sliding_window
+        valid_input_len = 1 if query_position is None else query_position + 1
+        cache_seq_len = torch.clamp(position_ids.to(torch.int32), max=max_cache_len)[:, :1]  # past seen tokens
+        cache_offset = (
+            torch.clamp(position_ids.to(torch.int32), max=max_cache_len)[:, :1] + valid_input_len
+        )  # cache offset for next steps
+
+        if self.phase == "decode":
+            # Causal mask for sliding window attention
+            attn_mask = torch.arange(max_cache_len)[None, :] - cache_seq_len
+            attn_mask = torch.where(attn_mask > 0, 0.0, 1.0)[:, None, None, :]
+        else:
+            # Prefill (and image_prefill) builds a 4D SWA mask of shape
+            #   (1, 1, prefill_chunk_size, max_compute_len)
+            # where max_compute_len = sliding_window + prefill_chunk_size.
+            #   - axis 2 (query):  the current prefill chunk being processed
+            #   - axis 3 (key/value): the sliding-window KV cache concatenated with the chunk's keys
+            # image_prefill additionally allows bidirectional attention within the current chunk.
+            _, prefill_chunk_size = position_ids.shape
+            max_compute_len = max_cache_len + prefill_chunk_size
+            cache_seq_len_b = torch.zeros(1, 1, 1, max_compute_len, dtype=torch.int32) + cache_seq_len
+            cache_offset_b = torch.zeros(1, 1, 1, max_compute_len, dtype=torch.int32) + cache_offset
+
+            q_idx = torch.zeros(
+                1, 1, prefill_chunk_size, max_compute_len, dtype=torch.int32, device=position_ids.device
+            )
+            q_idx = q_idx + torch.arange(prefill_chunk_size, dtype=torch.int32, device=position_ids.device).reshape(
+                1, 1, -1, 1
+            )
+
+            compute_idx = torch.arange(max_compute_len, dtype=torch.int32).reshape(1, 1, 1, -1)
+            in_chunk = (compute_idx >= cache_seq_len_b) & (compute_idx < cache_offset_b)
+            in_past = compute_idx < cache_seq_len_b
+
+            gap = cache_seq_len_b + q_idx - compute_idx
+            swa = (gap >= 0) & (gap < max_cache_len)
+
+            valid_q = q_idx < valid_input_len
+            valid_kv = torch.logical_or(in_past, in_chunk)
+            if self.phase == "image_prefill":
+                attn = valid_q & valid_kv & torch.logical_or(swa, in_chunk)
+            else:
+                attn = valid_q & valid_kv & swa
+            attn_mask = torch.where(attn, 1.0, 0.0).to(self.rbln_config.dtype)
+
+        return cache_seq_len, cache_offset, attn_mask
+
     def forward(
         self,
         input_ids: torch.Tensor = None,
@@ -102,10 +150,10 @@ class Gemma3TextModel(DecoderOnlyModel):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
             is_sliding = True if layer_idx in self.sliding_window_layers else False
-            is_sliding_decode = is_sliding and self.phase == "decode"
+            use_swa_mask = is_sliding and self.phase in ("decode", "image_prefill")
             hidden_states = layer(
                 hidden_states=hidden_states,
-                attention_mask=swa_attn_mask if is_sliding_decode else attention_mask,
+                attention_mask=swa_attn_mask if use_swa_mask else attention_mask,
                 seq_positions=sliding_cache_pos if is_sliding else seq_positions,
                 past_key_values=past_key_values,
                 cos=cos_local if is_sliding else cos_global,

--- a/src/optimum/rbln/transformers/models/gemma3/gemma3_runtime_utils.py
+++ b/src/optimum/rbln/transformers/models/gemma3/gemma3_runtime_utils.py
@@ -11,205 +11,55 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
+from typing import Any, Optional
 
 import rebel
 import torch
 
 from ...modeling_outputs import RBLNGemma3ForCausalLMOutput
-from ..decoderonly.decoderonly_runtime_utils import RBLNPytorchRuntime
+from ..decoderonly.decoderonly_runtime_utils import (
+    RBLNDecoderOnlyChunkedMultimodalPrefillMixin,
+    RBLNPytorchRuntime,
+)
 from ..decoderonly.modeling_decoderonly import RBLNRuntimeModel
 
 
-class RBLNGemma3RuntimeModel(RBLNRuntimeModel):
-    def __init__(self, *args, image_prefill: Optional[rebel.Runtime] = None, **kwargs):
+class RBLNGemma3RuntimeModel(RBLNDecoderOnlyChunkedMultimodalPrefillMixin, RBLNRuntimeModel):
+    # Gemma3 (text + image) chunked prefill. The tight-pack planning, partition alignment, and the
+    # prefill/forward loop all come from RBLNDecoderOnlyChunkedMultimodalPrefillMixin; Gemma3 only
+    # supplies the runtime registry and the per-chunk runtime argument order. Gemma3 compiles a
+    # single image-prefill bucket and has no per-layer inputs, so it relies on the mixin defaults
+    # (single `image_prefill` runtime, single-bucket `_resolve_image_chunk`, inherited `forward`).
+
+    _prefill_output_cls = RBLNGemma3ForCausalLMOutput
+
+    def __init__(self, *args: Any, image_prefill: Optional[rebel.Runtime] = None, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.image_prefill = RBLNPytorchRuntime(image_prefill)  # FIXME(taehoon)
-        self.prefill = RBLNPytorchRuntime(self.runtime) if self.phase == "prefill" else None  # FIXME
+        self.image_prefill = RBLNPytorchRuntime(image_prefill)
+        self.prefill = RBLNPytorchRuntime(self.runtime) if self.phase == "prefill" else None
 
-    def _prepare_prefill_inputs(self, *args, **kwargs):
-        (
-            inputs,
-            cache_position,
-            chunked_attention_mask,
-            position_ids,
-            position_embed,
-            padded_cache_lengths,
-            query_length,
-            token_type_ids,
-        ) = super()._prepare_prefill_inputs(*args, **kwargs)
-
-        # chunked_attention_mask shape
-        chunked_attention_mask = torch.zeros(1, chunked_attention_mask.shape[-1], dtype=torch.float32)
-
-        # In case of Gemma3ForConditionalGeneration, the loop counter may not be a prefill_chunk_size,
-        # so we cannot guarantee that the last chunk starts at a position that is a multiple of prefill_chunk_size.
-        if self.rbln_config.use_image_prefill:
-            padding_size = self.rbln_config.image_prefill_chunk_size
-            inputs = torch.nn.functional.pad(inputs, (0, 0, 0, padding_size))
-            cache_position = torch.nn.functional.pad(cache_position, (0, padding_size))
-            position_ids = torch.nn.functional.pad(position_ids, (0, padding_size))
-            token_type_ids = torch.nn.functional.pad(token_type_ids, (0, padding_size), value=-1)
-
-        return (
-            inputs,
-            cache_position,
-            chunked_attention_mask,
-            position_ids,
-            position_embed,
-            padded_cache_lengths,
-            query_length,
-            token_type_ids,
-        )
-
-    def prefill_forward(
+    def _invoke_prefill_chunk(
         self,
-        inputs: torch.Tensor,
-        cache_position: torch.Tensor = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        batch_idx: int = None,
-        block_tables: torch.Tensor = None,
-        is_external_block_tables: bool = None,
-        position_embed: Optional[torch.Tensor] = None,
-        token_type_ids: Optional[torch.Tensor] = None,
-        local_block_tables: Optional[torch.Tensor] = None,
-        lora_int_ids: Optional[torch.Tensor] = None,
-    ) -> torch.FloatTensor:
-        """
-        Performs chunked prefill for efficient KV-cache updates and memory optimization.
-        Instead of processing the entire sequence at once, the input is divided into chunks of size `prefill_chunk_size`,
-        and each chunk is processed sequentially. This allows for better memory utilization and compatibility with continuous batching.
-        """
-        if self.rbln_config.use_lora and lora_int_ids is None:
-            if self.lora_int_ids is None:
-                raise ValueError(
-                    "lora_int_id is required when using LoRA. "
-                    "You should call set_lora_int_ids() before forward() or pass lora_int_id to forward()."
-                )
-            if batch_idx is not None:
-                lora_int_ids = self.lora_int_ids[batch_idx : batch_idx + 1].clone()
-            else:
-                lora_int_ids = self.lora_int_ids.clone()
-
-        (
-            inputs,
-            cache_position,
+        runtime,
+        input_chunk: torch.Tensor,
+        per_layer_chunk: Optional[torch.Tensor],
+        cache_pos_chunk: torch.Tensor,
+        block_tables: torch.Tensor,
+        local_block_tables: Optional[torch.Tensor],
+        query_position: torch.Tensor,
+        chunked_attention_mask: torch.Tensor,
+        position_ids_chunk: Optional[torch.Tensor],
+        lora_int_ids: Optional[torch.Tensor],
+    ):
+        # Gemma3 has no per-layer inputs, so `per_layer_chunk` is ignored. Argument order mirrors
+        # Gemma3ForCausalLMWrapper.prepare_forward_args. The callee owns the `use_lora` gate.
+        return runtime(
+            input_chunk,
+            cache_pos_chunk,
+            block_tables,
+            local_block_tables,
+            query_position,
             chunked_attention_mask,
-            position_ids,
-            _,
-            padded_cache_lengths,
-            query_length,
-            token_type_ids,
-        ) = self._prepare_prefill_inputs(inputs, cache_position, attention_mask, token_type_ids=token_type_ids)
-
-        step = 0
-        output_logits = []
-        all_hidden_states = [] if self.rbln_config.output_hidden_states else None
-        while step < query_length:
-            if self.rbln_config.use_image_prefill:
-                # Check if the prefill chunk is an image prefill
-                is_image_prefill = torch.all(
-                    token_type_ids[:, step : step + self.rbln_config.image_prefill_chunk_size] == 1
-                )
-                # Check if the prefill chunk is a text prefill which have image_tokens in it.
-                is_text_prefill_with_image_tokens = not is_image_prefill and torch.any(
-                    token_type_ids[:, step : step + self.rbln_config.prefill_chunk_size] == 1
-                )
-            else:
-                is_image_prefill, is_text_prefill_with_image_tokens = False, False
-
-            # Check if the prefill chunk is the last chunk
-            is_last_chunk = step + self.rbln_config.prefill_chunk_size >= query_length
-
-            input_chunk = inputs[:, step : step + self.rbln_config.prefill_chunk_size]
-            cache_pos_chunk = (
-                cache_position[:, step : step + self.rbln_config.prefill_chunk_size] + padded_cache_lengths
-            )
-            position_ids_chunk = position_ids[:, step : step + self.rbln_config.prefill_chunk_size]
-
-            # if text_prefill end with image_tokens, we only treat the text part.
-            num_processed_tokens = self.rbln_config.prefill_chunk_size
-            current_padded_cache_lengths = 0
-            if is_text_prefill_with_image_tokens:
-                first_image_token_idx = torch.where(
-                    token_type_ids[:, step : step + self.rbln_config.prefill_chunk_size] == 1
-                )[1][0]
-                num_processed_tokens = first_image_token_idx.item()
-                current_padded_cache_lengths = self.rbln_config.prefill_chunk_size - num_processed_tokens
-            if is_last_chunk:
-                num_processed_tokens = query_length - step
-
-            chunked_attention_mask[
-                :, step + padded_cache_lengths : step + num_processed_tokens + padded_cache_lengths
-            ] = 1
-            query_position = torch.tensor(num_processed_tokens - 1, dtype=torch.int16)
-
-            if is_image_prefill:
-                outputs = self.image_prefill(
-                    input_chunk,
-                    cache_pos_chunk,
-                    block_tables,
-                    local_block_tables,
-                    query_position,
-                    chunked_attention_mask,
-                    position_ids_chunk,
-                    lora_int_ids if self.rbln_config.use_lora else None,
-                )
-            else:
-                outputs = self.prefill(
-                    input_chunk,
-                    cache_pos_chunk,
-                    block_tables,
-                    local_block_tables,
-                    query_position,
-                    chunked_attention_mask,
-                    position_ids_chunk,
-                    lora_int_ids if self.rbln_config.use_lora else None,
-                )
-
-            if self.rbln_config.output_hidden_states:
-                output_logits.append(outputs[0])
-                all_hidden_states.append(tuple(outputs[1:]))
-            else:
-                output_logits.append(outputs)
-
-            padded_cache_lengths += current_padded_cache_lengths
-            step += num_processed_tokens
-
-        if self.rbln_config.output_hidden_states:
-            num_hidden_layers = len(all_hidden_states[0]) - 1
-            concatenated_hidden_states = ()
-            for l_idx in range(num_hidden_layers + 1):
-                l_hidden_states = torch.cat([hidden_states[l_idx] for hidden_states in all_hidden_states], dim=1)
-                l_hidden_states = l_hidden_states[:, :query_length, :]
-                concatenated_hidden_states += (l_hidden_states,)
-
-            all_hidden_states = concatenated_hidden_states
-
-        # Aggregate output_logits
-        output_logits = torch.concat(output_logits, dim=-2)
-        if self.rbln_config.logits_to_keep > 0:
-            output_logits = output_logits[:, -self.rbln_config.logits_to_keep :, :]
-        else:
-            output_logits = output_logits[:, :query_length, :]
-            # index copy for masked output_logits
-            if attention_mask is not None:
-                new_output_logits = torch.full(
-                    (1, attention_mask.shape[-1], output_logits.shape[-1]),
-                    fill_value=1e-10,
-                    dtype=output_logits.dtype,
-                )
-                mask_indices = torch.nonzero(attention_mask, as_tuple=True)[0]
-                new_output_logits.index_copy_(dim=-2, index=mask_indices, source=output_logits)
-
-            output_logits = new_output_logits
-
-        if not is_external_block_tables:
-            self.dec_attn_mask[batch_idx : batch_idx + 1] = chunked_attention_mask
-
-        return RBLNGemma3ForCausalLMOutput(
-            logits=output_logits,
-            padded_cache_lengths=padded_cache_lengths,
-            attention_mask=chunked_attention_mask,
-            hidden_states=all_hidden_states,
+            position_ids_chunk,
+            lora_int_ids if self.rbln_config.use_lora else None,
         )

--- a/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
@@ -254,34 +254,6 @@ class RBLNGemma3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
 
         return inputs_embeds
 
-    def get_padded_cache_position(
-        self,
-        cache_position: torch.Tensor,  # shape: [1, seq_len]
-        token_type_ids: torch.Tensor,  # shape: [1, seq_len]
-    ) -> torch.Tensor:
-        seq_len = cache_position[0][-1].item() + 1
-
-        # Find image start positions
-        image_starts = [
-            s
-            for s in torch.where(token_type_ids == 1)[1]
-            if torch.all(token_type_ids[:, s : s + self.rbln_config.image_prefill_chunk_size] == 1)
-        ]
-
-        # Initialize padded tensors
-        padded_input_len = seq_len
-        for image_start in image_starts:
-            pad_needed = (
-                self.rbln_config.image_prefill_chunk_size
-                - (image_start + padded_input_len - seq_len) % self.rbln_config.image_prefill_chunk_size
-            ) % self.rbln_config.image_prefill_chunk_size
-            padded_input_len += pad_needed
-
-        return torch.cat(
-            [cache_position, torch.arange(seq_len, padded_input_len, dtype=torch.int32).unsqueeze(0)],
-            dim=1,
-        )
-
     def forward(
         self,
         input_ids: torch.LongTensor = None,
@@ -328,9 +300,9 @@ class RBLNGemma3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
             )
 
             for b_idx in range(batch_size):
+                # Pass the unpadded cache_position; the chunked-prefill runtime tight-packs and
+                # extends the allocation internally (see RBLNDecoderOnlyChunkedMultimodalPrefillMixin).
                 cache_position = torch.arange(0, generate_idx[b_idx].item(), dtype=torch.int32).unsqueeze(0)
-                token_type_id = token_type_ids[b_idx : b_idx + 1, attention_mask[b_idx].bool()]
-                cache_position = self.get_padded_cache_position(cache_position, token_type_id)
 
                 outputs = self.language_model.prefill_decoder(
                     inputs_embeds=inputs_embeds[b_idx : b_idx + 1],

--- a/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
+++ b/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
@@ -29,6 +29,7 @@ from ..decoderonly.decoderonly_architecture import (
     DecoderOnlyModel,
     DecoderOnlyWrapper,
     RotaryEmbedding,
+    build_image_prefill_swa_custom_op_args,
     slice_and_unsqueeze_cos_sin,
 )
 
@@ -198,58 +199,7 @@ class Gemma4TextModel(DecoderOnlyModel):
         return (per_layer_projection + per_layer_inputs) * self.per_layer_input_scale
 
     def get_swa_custom_op_args(self, position_ids, query_position):
-        max_cache_len = self.config.sliding_window
-        valid_input_len = 1 if query_position is None else query_position + 1
-        cache_seq_len = torch.clamp(position_ids.to(torch.int32), max=max_cache_len)[:, :1]  # past seen tokens []
-        cache_offset = (
-            torch.clamp(position_ids.to(torch.int32), max=max_cache_len)[:, :1] + valid_input_len  # []
-        )  # cache offset for next steps
-
-        if self.phase == "decode":
-            # Causal mask for sliding window attention
-            attn_mask = torch.arange(max_cache_len)[None, :] - cache_seq_len
-            attn_mask = torch.where(attn_mask > 0, 0.0, 1.0)[:, None, None, :]
-
-        else:
-            # Prefill (and image_prefill) builds a 4D SWA mask of shape
-            #   (1, 1, prefill_chunk_size, max_compute_len)
-            # where max_compute_len = sliding_window + prefill_chunk_size.
-            #   - axis 2 (query):  the current prefill chunk being processed
-            #   - axis 3 (key/value): the sliding-window KV cache (past tokens kept in window)
-            #                         concatenated with the current chunk's keys
-            # Example with prefill_chunk_size=512 and sliding_window=1024:
-            #   max_compute_len = 1024 + 512 = 1536 -> mask shape (1, 1, 512, 1536)
-            _, prefill_chunk_size = position_ids.shape
-            max_compute_len = max_cache_len + prefill_chunk_size
-            cache_seq_len_b = torch.zeros(1, 1, 1, max_compute_len, dtype=torch.int32) + cache_seq_len
-            cache_offset_b = torch.zeros(1, 1, 1, max_compute_len, dtype=torch.int32) + cache_offset
-
-            q_idx = torch.zeros(
-                1, 1, prefill_chunk_size, max_compute_len, dtype=torch.int32, device=position_ids.device
-            )
-            q_idx = q_idx + torch.arange(prefill_chunk_size, dtype=torch.int32, device=position_ids.device).reshape(
-                1, 1, -1, 1
-            )  # (1, 1, prefill_chunk_size, max_compute_len)
-
-            compute_idx = torch.arange(max_compute_len, dtype=torch.int32).reshape(
-                1, 1, 1, -1
-            )  # (1, 1, 1, max_compute_len)
-            in_chunk = (compute_idx >= cache_seq_len_b) & (compute_idx < cache_offset_b)  # valid idx in 4 dims
-            in_past = compute_idx < cache_seq_len_b  # valid idx in 4 dims
-
-            # (1,1,1,1) + (1,1,512,1) - (1,1,1,1536)
-            gap = cache_seq_len_b + q_idx - compute_idx
-            swa = (gap >= 0) & (gap < max_cache_len)
-
-            valid_q = q_idx < valid_input_len
-            valid_kv = torch.logical_or(in_past, in_chunk)
-            if self.phase == "image_prefill":
-                attn = valid_q & valid_kv & torch.logical_or(swa, in_chunk)
-            else:
-                attn = valid_q & valid_kv & swa
-            attn_mask = torch.where(attn, 1.0, 0.0).to(self.rbln_config.dtype)
-
-        return cache_seq_len, cache_offset, attn_mask
+        return build_image_prefill_swa_custom_op_args(self, position_ids, query_position)
 
     def forward(
         self,

--- a/src/optimum/rbln/transformers/models/gemma4/gemma4_runtime_utils.py
+++ b/src/optimum/rbln/transformers/models/gemma4/gemma4_runtime_utils.py
@@ -21,6 +21,7 @@ from ...modeling_outputs import RBLNDecoderOnlyOutput, RBLNGemma4ForCausalLMOutp
 from ..decoderonly.decoderonly_runtime_utils import (
     RBLNDecoderOnlyChunkedMultimodalPrefillMixin,
     RBLNPytorchRuntime,
+    _run_length_from,
 )
 from ..decoderonly.modeling_decoderonly import RBLNRuntimeModel
 
@@ -62,6 +63,26 @@ class RBLNGemma4RuntimeModel(RBLNDecoderOnlyChunkedMultimodalPrefillMixin, RBLNR
             *clamped_ids.shape, self.num_hidden_layers, self.hidden_size_per_layer_input
         )
         return per_layer_inputs
+
+    def _select_image_prefill_runtime(self, chunk_size_used: int):
+        # Gemma4 keeps one runtime per bucket; pick the one matching the planned chunk size.
+        return self.image_prefills[chunk_size_used]
+
+    def _resolve_image_chunk(self, token_type_ids: torch.Tensor, step: int, start_type: int):
+        # Gemma4 buckets image/video runs: pick the smallest bucket that fits the run.
+        image_buckets = self.rbln_config.image_prefill_chunk_sizes
+        max_image_bucket = max(image_buckets)
+        run_len = _run_length_from(token_type_ids, step, value=start_type, cap=max_image_bucket + 1)
+        if run_len > max_image_bucket:
+            modality = "video" if start_type == 2 else "image"
+            raise ValueError(
+                f"{modality.capitalize()} run (token_type={start_type}) starting at position {step} "
+                f"is longer than the largest image-prefill bucket ({max_image_bucket}); no bucket can "
+                f"hold it. For video this means consecutive frames are not separated by text (each "
+                f"frame run must fit one bucket); otherwise add a larger value to "
+                f"`image_prefill_chunk_sizes`."
+            )
+        return run_len, min(b for b in image_buckets if b >= run_len)
 
     def _invoke_prefill_chunk(
         self,
@@ -111,32 +132,7 @@ class RBLNGemma4RuntimeModel(RBLNDecoderOnlyChunkedMultimodalPrefillMixin, RBLNR
         if per_layer_inputs is None and input_ids is not None:
             per_layer_inputs = self.compute_per_layer_inputs(input_ids)
 
-        alloc_cache_position = cache_position
-        if (
-            self.phase != "decode"
-            and cache_position is not None
-            and self.rbln_config.use_image_prefill
-            and token_type_ids is not None
-        ):
-            plan_token_type_ids = token_type_ids
-            if attention_mask is not None:
-                mask_bool = attention_mask.to(dtype=torch.bool)
-                if mask_bool.dim() == 2:
-                    mask_bool = mask_bool[0]
-                plan_token_type_ids = token_type_ids[:, mask_bool]
-            query_length = cache_position.shape[-1]
-            _, _, alloc_len = self._plan_prefill_chunks(plan_token_type_ids, query_length)
-            if alloc_len > self.rbln_config.max_seq_len:
-                raise ValueError(
-                    f"Chunked prefill requires {alloc_len} KV-cache slots (input length "
-                    f"{query_length} plus {alloc_len - query_length} slots of trailing chunk_size "
-                    f"write-extent overhang and partition-alignment padding), which exceeds max_seq_len "
-                    f"({self.rbln_config.max_seq_len}). Increase max_seq_len or reduce the input length."
-                )
-            if alloc_len > query_length:
-                extra_pos = int(cache_position[0, -1].item()) + (alloc_len - query_length)
-                extra = cache_position.new_tensor([[extra_pos]])
-                alloc_cache_position = torch.cat([cache_position, extra], dim=-1)
+        alloc_cache_position = self._extend_cache_position_for_alloc(cache_position, token_type_ids, attention_mask)
 
         block_tables, local_block_tables, is_external_block_tables = (
             self.page_table_manager.get_block_tables_if_needed(


### PR DESCRIPTION
# Pull Request Description

> **⚠️ Important: Branch Target**
> - **New features, enhancements, and non-critical fixes**: Merge to `dev` branch
> - **Critical hotfixes only**: Merge to `main` branch (must also merge to `dev`)
> 
> Please ensure you've selected the correct base branch before submitting!

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Release (dev → main merge for production release)
- [ ] New Model Support
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

- Roll back sliding window attention mask for general support
- make Gemma3 inherit `RBLNDecoderOnlyChunkedMultimodalPrefillMixin`


## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Release
    - `release`: Merging dev to main for production release
      - ex) Release v1.2.0
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update