### PR TITLE
refactor: resolve shape mismatch when extending cache_position on vLLM

### DIFF
--- a/src/optimum/rbln/transformers/models/decoderonly/decoderonly_runtime_utils.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/decoderonly_runtime_utils.py
@@ -841,12 +841,13 @@ class RBLNDecoderOnlyChunkedMultimodalPrefillMixin:
             and token_type_ids is not None
         ):
             plan_token_type_ids = token_type_ids
+            query_length = cache_position.shape[-1]
             if attention_mask is not None:
                 mask_bool = attention_mask.to(dtype=torch.bool)
                 if mask_bool.dim() == 2:
                     mask_bool = mask_bool[0]
                 plan_token_type_ids = token_type_ids[:, mask_bool]
-            query_length = cache_position.shape[-1]
+                query_length = int(mask_bool.sum().item())
             _, _, alloc_len = self._plan_prefill_chunks(plan_token_type_ids, query_length)
             if alloc_len > self.rbln_config.max_seq_len:
                 raise ValueError(

--- a/src/optimum/rbln/transformers/models/decoderonly/decoderonly_runtime_utils.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/decoderonly_runtime_utils.py
@@ -841,13 +841,12 @@ class RBLNDecoderOnlyChunkedMultimodalPrefillMixin:
             and token_type_ids is not None
         ):
             plan_token_type_ids = token_type_ids
-            query_length = cache_position.shape[-1]
             if attention_mask is not None:
                 mask_bool = attention_mask.to(dtype=torch.bool)
                 if mask_bool.dim() == 2:
                     mask_bool = mask_bool[0]
                 plan_token_type_ids = token_type_ids[:, mask_bool]
-                query_length = int(mask_bool.sum().item())
+            query_length = plan_token_type_ids.shape[-1]
             _, _, alloc_len = self._plan_prefill_chunks(plan_token_type_ids, query_length)
             if alloc_len > self.rbln_config.max_seq_len:
                 raise ValueError(

--- a/src/optimum/rbln/transformers/models/gemma4/configuration_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/configuration_gemma4.py
@@ -234,7 +234,7 @@ class RBLNGemma4ForConditionalGenerationConfig(RBLNModelConfig):
         )
         self.language_model = self.initialize_submodule_config(
             submodule_config=language_model,
-            batch_size=batch_size,
+            batch_size=self.batch_size,
             force_kwargs=True,
             use_inputs_embeds=True,
         )


### PR DESCRIPTION
# Pull Request Description

> **⚠️ Important: Branch Target**
> - **New features, enhancements, and non-critical fixes**: Merge to `dev` branch
> - **Critical hotfixes only**: Merge to `main` branch (must also merge to `dev`)
> 
> Please ensure you've selected the correct base branch before submitting!

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Release (dev → main merge for production release)
- [ ] New Model Support
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

Derive `query_length` from attention mask to prevent index out of range error.

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

When Gemma3 / Gemma4 is served with vLLM, the input prompt is left-padded, so `cache_position` is longer than the real (unpadded) input length.

In contrast, `plan_token_type_ids` is sliced down to the real input length with the attention mask, so the padding is removed.

Since `query_length` is derived from the shape of `cache_position`, it does not match the length of `plan_token_type_ids`.

As a result, `plan_token_type_ids` is indexed up to `query_length`, which can exceed its length and raise an index out of range error.

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->


----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Release
    - `release`: Merging dev to main for production release
      - ex) Release v1.2.0
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update