### PR TITLE
refactor: remove default bucketing for image_prefill_chunk_size & max_soft_tokens

### DIFF
--- a/src/optimum/rbln/transformers/models/decoderonly/decoderonly_runtime_utils.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/decoderonly_runtime_utils.py
@@ -714,11 +714,15 @@ class RBLNDecoderOnlyChunkedMultimodalPrefillMixin:
         if self.rbln_config.use_image_prefill:
             # Pad by the LARGEST chunk size any planner-dispatched chunk can use, so the last
             # chunk's `inputs[step : step + chunk_size_used]` slice always returns
-            # `chunk_size_used` rows. `image_prefill_chunk_size` (= max image bucket) and
-            # `prefill_chunk_size` (text) are independent; using only the former underruns the
-            # tail text chunk when text size exceeds the largest image bucket.
+            # `chunk_size_used` rows. `image_prefill_chunk_size` (a scalar bucket, or a list of
+            # buckets whose max is the largest) and `prefill_chunk_size` (text) are independent;
+            # using only the former underruns the tail text chunk when text size exceeds the
+            # largest image bucket.
+            image_prefill_chunk_size = self.rbln_config.image_prefill_chunk_size
+            if isinstance(image_prefill_chunk_size, (list, tuple)):
+                image_prefill_chunk_size = max(image_prefill_chunk_size)
             padding_size = max(
-                self.rbln_config.image_prefill_chunk_size,
+                image_prefill_chunk_size,
                 self.rbln_config.prefill_chunk_size,
             )
             inputs = torch.nn.functional.pad(inputs, (0, 0, 0, padding_size))

--- a/src/optimum/rbln/transformers/models/gemma4/configuration_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/configuration_gemma4.py
@@ -68,7 +68,7 @@ class RBLNGemma4ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
             prefill_chunk_size = 128
 
         if image_prefill_chunk_size is not None:
-            image_prefill_chunk_size = self._normalize_image_prefill_chunk_size(image_prefill_chunk_size)
+            image_prefill_chunk_size = self._validate_image_prefill_chunk_size(image_prefill_chunk_size)
 
         super().__init__(
             prefill_chunk_size=prefill_chunk_size,
@@ -84,10 +84,9 @@ class RBLNGemma4ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
             raise ValueError("use_attention_mask and use_position_ids must be True for RBLNGemma4ForCausalLM")
 
     @staticmethod
-    def _normalize_image_prefill_chunk_size(chunk_size: Union[int, List[int]]) -> List[int]:
-        # Single enforcement point: accepts int or list, returns a de-duplicated descending list.
-        # Each chunk must be a positive multiple of 128 (stricter than text prefill_chunk_size's
-        # 64-alignment, and independent of it).
+    def _validate_image_prefill_chunk_size(chunk_size: Union[int, List[int]]) -> List[int]:
+        # Single enforcement point: validates that every image_prefill_chunk_size (int or list) is a
+        # positive multiple of 128 and returns it in canonical form — de-duplicated and sorted descending.
         if isinstance(chunk_size, int):
             chunk_size = [chunk_size]
         chunk_size = sorted(set(chunk_size), reverse=True)
@@ -263,9 +262,9 @@ class RBLNGemma4ForConditionalGenerationConfig(RBLNModelConfig):
             pinned = getattr(lm_cfg, "image_prefill_chunk_size", None)
 
         if pinned is not None:
-            buckets = RBLNGemma4ForCausalLMConfig._normalize_image_prefill_chunk_size(pinned)
+            buckets = RBLNGemma4ForCausalLMConfig._validate_image_prefill_chunk_size(pinned)
         else:
-            buckets = RBLNGemma4ForCausalLMConfig._normalize_image_prefill_chunk_size(
+            buckets = RBLNGemma4ForCausalLMConfig._validate_image_prefill_chunk_size(
                 [ceil_to_multiple_of_128(t) for t in max_soft_tokens]
             )
             # Keep only the largest `(n + 1) // 2` buckets (descending list -> drop smallest first).

--- a/src/optimum/rbln/transformers/models/gemma4/configuration_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/configuration_gemma4.py
@@ -22,7 +22,7 @@ from ..decoderonly.configuration_decoderonly import RBLNDecoderOnlyModelForCausa
 logger = get_logger(__name__)
 
 
-DEFAULT_MAX_SOFT_TOKENS = [70, 140, 280, 560, 1120]
+DEFAULT_MAX_SOFT_TOKENS = 280
 
 
 def ceil_to_multiple_of_128(value: int) -> int:
@@ -40,8 +40,7 @@ class RBLNGemma4ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
         use_position_ids: Optional[bool] = None,
         use_attention_mask: Optional[bool] = None,
         prefill_chunk_size: Optional[int] = None,
-        image_prefill_chunk_size: Optional[int] = None,
-        image_prefill_chunk_sizes: Optional[Union[int, List[int]]] = None,
+        image_prefill_chunk_size: Optional[Union[int, List[int]]] = None,
         **kwargs: Any,
     ):
         """
@@ -49,20 +48,16 @@ class RBLNGemma4ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
             use_position_ids (Optional[bool]): Whether to use `position_ids`. Forced to `True` for Gemma4.
             use_attention_mask (Optional[bool]): Whether to use `attention_mask`. Forced to `True` for Gemma4.
             prefill_chunk_size (Optional[int]): Chunk size used during the prefill phase. Defaults to 128.
-            image_prefill_chunk_size (Optional[int]): Single chunk size used for image-prefill (multimodal
-                Gemma4). Mutually exclusive with `image_prefill_chunk_sizes`. When neither is given, the
-                image-prefill buckets are decided later in `_update_rbln_config`.
-            image_prefill_chunk_sizes (Optional[Union[int, List[int]]]): Desired bucketing shapes for the
-                image-prefill phase. When given, a separate `image_prefill` graph is compiled for every
-                value (sorted in descending order), allowing the runtime to pick the smallest bucket that
-                fits an image run. Mutually exclusive with `image_prefill_chunk_size`; when this is set,
-                `image_prefill_chunk_size` is derived as `max(image_prefill_chunk_sizes)`.
+            image_prefill_chunk_size (Optional[Union[int, List[int]]]): Chunk size(s) used for image-prefill
+                (multimodal Gemma4). A single int compiles one `image_prefill` graph; a list compiles one
+                graph per value (sorted in descending order) and the runtime picks the smallest bucket that
+                fits an image run. When not given, it is derived from the vision tower's `max_soft_tokens`
+                (the default single `max_soft_tokens=280` yields a single chunk size of 384).
             kwargs: Additional arguments passed to the parent `RBLNDecoderOnlyModelForCausalLMConfig`.
 
         Raises:
-            ValueError: If `use_attention_mask` or `use_position_ids` are False, if both
-                `image_prefill_chunk_size` and `image_prefill_chunk_sizes` are specified, or if any
-                image-prefill chunk size is not a positive integer divisible by 128.
+            ValueError: If `use_attention_mask` or `use_position_ids` are False, or if any image-prefill
+                chunk size is not a positive integer divisible by 128.
         """
         if use_attention_mask is None:
             use_attention_mask = True
@@ -72,15 +67,8 @@ class RBLNGemma4ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
         if prefill_chunk_size is None:
             prefill_chunk_size = 128
 
-        if image_prefill_chunk_size is not None and image_prefill_chunk_sizes is not None:
-            raise ValueError(
-                "Specify only one of `image_prefill_chunk_size` or `image_prefill_chunk_sizes`, not both."
-            )
-
-        if image_prefill_chunk_sizes is None and image_prefill_chunk_size is not None:
-            image_prefill_chunk_sizes = image_prefill_chunk_size
-        if image_prefill_chunk_sizes is not None:
-            image_prefill_chunk_sizes = self._normalize_image_prefill_chunk_sizes(image_prefill_chunk_sizes)
+        if image_prefill_chunk_size is not None:
+            image_prefill_chunk_size = self._normalize_image_prefill_chunk_size(image_prefill_chunk_size)
 
         super().__init__(
             prefill_chunk_size=prefill_chunk_size,
@@ -88,48 +76,41 @@ class RBLNGemma4ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
             use_position_ids=use_position_ids,
             **kwargs,
         )
-        self.image_prefill_chunk_sizes = image_prefill_chunk_sizes
+        # Always stored as a de-duplicated descending list of buckets (or None until derived from
+        # the vision tower's max_soft_tokens in RBLNGemma4ForConditionalGenerationConfig).
+        self.image_prefill_chunk_size = image_prefill_chunk_size
 
         if not (self.use_attention_mask and self.use_position_ids):
             raise ValueError("use_attention_mask and use_position_ids must be True for RBLNGemma4ForCausalLM")
 
-    @property
-    def image_prefill_chunk_size(self) -> Optional[int]:
-        # Largest image-prefill bucket, derived from image_prefill_chunk_sizes.
-        # Read-only derived value (not stored) so it is never persisted alongside image_prefill_chunk_sizes;
-        # a reloaded config carrying both would trip the "specify only one" guard in __init__.
-        if not self.image_prefill_chunk_sizes:
-            return None
-        return max(self.image_prefill_chunk_sizes)
-
     @staticmethod
-    def _normalize_image_prefill_chunk_sizes(chunk_sizes: Union[int, List[int]]) -> List[int]:
+    def _normalize_image_prefill_chunk_size(chunk_size: Union[int, List[int]]) -> List[int]:
         # Single enforcement point: accepts int or list, returns a de-duplicated descending list.
         # Each chunk must be a positive multiple of 128 (stricter than text prefill_chunk_size's
         # 64-alignment, and independent of it).
-        if isinstance(chunk_sizes, int):
-            chunk_sizes = [chunk_sizes]
-        chunk_sizes = sorted(set(chunk_sizes), reverse=True)
-        for chunk_size in chunk_sizes:
-            if chunk_size <= 0 or chunk_size % 128 != 0:
+        if isinstance(chunk_size, int):
+            chunk_size = [chunk_size]
+        chunk_size = sorted(set(chunk_size), reverse=True)
+        for size in chunk_size:
+            if size <= 0 or size % 128 != 0:
                 raise ValueError(
                     "Every image-prefill chunk size must be a positive integer divisible by 128, "
-                    f"but got image_prefill_chunk_sizes={chunk_sizes}."
+                    f"but got image_prefill_chunk_size={chunk_size}."
                 )
-        return chunk_sizes
+        return chunk_size
 
     @property
     def num_image_prefill_buckets(self) -> int:
         # Number of separate image_prefill_{chunk} graphs (0 when image-prefill is disabled).
-        if not self.use_image_prefill or not self.image_prefill_chunk_sizes:
+        if not self.use_image_prefill or not self.image_prefill_chunk_size:
             return 0
-        return len(self.image_prefill_chunk_sizes)
+        return len(self.image_prefill_chunk_size)
 
     @property
     def expected_compiled_model_names(self):
         names = ["prefill"]
-        if self.use_image_prefill and self.image_prefill_chunk_sizes:
-            names += [f"image_prefill_{chunk_size}" for chunk_size in self.image_prefill_chunk_sizes]
+        if self.use_image_prefill and self.image_prefill_chunk_size:
+            names += [f"image_prefill_{chunk_size}" for chunk_size in self.image_prefill_chunk_size]
         if self.can_generate:
             names += [f"decoder_batch_{batch_size}" for batch_size in self.decoder_batch_sizes]
         return names
@@ -150,7 +131,7 @@ class RBLNGemma4VisionModelConfig(RBLNModelConfig):
     def __init__(
         self,
         batch_size: Optional[int] = None,
-        max_soft_tokens: Optional[int] = None,
+        max_soft_tokens: Optional[Union[int, List[int]]] = None,
         pooling_kernel_size: Optional[int] = None,
         patch_size: Optional[int] = None,
         output_hidden_states: Optional[bool] = None,
@@ -159,9 +140,11 @@ class RBLNGemma4VisionModelConfig(RBLNModelConfig):
         """
         Args:
             batch_size (Optional[int]): The batch size of images (number of images, not patches). Defaults to 1.
-            max_soft_tokens (Optional[int]): The number of soft tokens emitted per image after pooling.
-                Defaults to 280 (the upstream default in `Gemma4ImageProcessor`). Must be a value
-                supported by the image processor (e.g. 70/140/280/560/1120).
+            max_soft_tokens (Optional[Union[int, List[int]]]): The number of soft tokens emitted per image
+                after pooling. Defaults to 280 (the upstream default in `Gemma4ImageProcessor`). A single int
+                compiles one vision graph; a list compiles one graph per value (sorted descending) so the
+                runtime can serve images at multiple soft-token counts. Must be a value supported by the image
+                processor (e.g. 70/140/280/560/1120).
             pooling_kernel_size (Optional[int]): Spatial pooling kernel size applied after patchification.
                 Defaults to `model_config.pooling_kernel_size` (3 by default).
             patch_size (Optional[int]): Patch height/width in pixels. Defaults to `model_config.patch_size`.
@@ -176,11 +159,12 @@ class RBLNGemma4VisionModelConfig(RBLNModelConfig):
         if not isinstance(self.batch_size, int) or self.batch_size <= 0:
             raise ValueError(f"batch_size must be a positive integer, got {self.batch_size}")
 
-        if max_soft_tokens is not None:
-            if isinstance(max_soft_tokens, int):
-                max_soft_tokens = [max_soft_tokens]
-            elif isinstance(max_soft_tokens, list):
-                max_soft_tokens.sort(reverse=True)
+        if max_soft_tokens is None:
+            max_soft_tokens = DEFAULT_MAX_SOFT_TOKENS
+        if isinstance(max_soft_tokens, int):
+            max_soft_tokens = [max_soft_tokens]
+        else:
+            max_soft_tokens = sorted(max_soft_tokens, reverse=True)
 
         self.max_soft_tokens = max_soft_tokens
         self.pooling_kernel_size = pooling_kernel_size
@@ -239,7 +223,7 @@ class RBLNGemma4ForConditionalGenerationConfig(RBLNModelConfig):
             use_inputs_embeds=True,
         )
 
-        self._update_image_prefill_chunk_sizes()
+        self._update_image_prefill_chunk_size()
 
     def _get_vision_max_soft_tokens(self) -> List[int]:
         # Per-image soft-token counts the vision tower emits, sorted in descending order.
@@ -257,55 +241,64 @@ class RBLNGemma4ForConditionalGenerationConfig(RBLNModelConfig):
             max_soft_tokens = [max_soft_tokens]
         return sorted(max_soft_tokens, reverse=True)
 
-    def _update_image_prefill_chunk_sizes(self) -> None:
-        # Derives or validates the language model's image-prefill buckets against the vision tower's
-        # soft-token counts.
-        # When neither image_prefill_chunk_size nor image_prefill_chunk_sizes is pinned: map each
-        # max_soft_tokens to the smallest multiple of 128 that holds it, then keep only the largest
+    def _update_image_prefill_chunk_size(self) -> None:
+        # Resolves the language model's image-prefill chunk size(s) against the vision tower's
+        # max_soft_tokens.
+        # When image_prefill_chunk_size is not pinned: derive it from max_soft_tokens by mapping each
+        # count to the smallest multiple of 128 that holds it, then keeping only the largest
         # (n + 1) // 2 buckets — dropped smallest-first so the largest count keeps its own bucket and
-        # smaller images route to the smallest kept bucket >= their length at runtime.
-        # When the user did pin the buckets: verify the largest can hold the vision tower's largest
-        # max_soft_tokens; otherwise some image run would have no bucket (detected here, not at runtime).
-        # Note: these buckets are independent of the language model's text prefill_chunk_size.
+        # smaller images route to the smallest kept bucket >= their length at runtime. With the default
+        # single max_soft_tokens (280) this derives a single chunk size of 384.
+        # When the user did pin it: use it as-is.
+        # Either way the resolved buckets are validated against max_soft_tokens below (asserted here, not
+        # at runtime); these buckets are independent of the text prefill_chunk_size.
         lm_cfg = self.language_model
-        soft_tokens = self._get_vision_max_soft_tokens()
-        max_soft_token = max(soft_tokens)
+        # max_soft_tokens follows HF's single-int convention but is normalized to a descending list here
+        # to support multiple vision buckets; min/max are computed inline where needed.
+        max_soft_tokens = self._get_vision_max_soft_tokens()
 
         if isinstance(lm_cfg, dict):
-            pinned = lm_cfg.get("image_prefill_chunk_sizes", lm_cfg.get("image_prefill_chunk_size", None))
+            pinned = lm_cfg.get("image_prefill_chunk_size", None)
         else:
-            pinned = getattr(lm_cfg, "image_prefill_chunk_sizes", None)
+            pinned = getattr(lm_cfg, "image_prefill_chunk_size", None)
 
         if pinned is not None:
-            pinned_buckets = RBLNGemma4ForCausalLMConfig._normalize_image_prefill_chunk_sizes(pinned)
-            if max(pinned_buckets) < max_soft_token:
-                raise ValueError(
-                    f"The largest image-prefill chunk size ({max(pinned_buckets)}) is smaller than the "
-                    f"vision tower's largest max_soft_tokens ({max_soft_token}); some images would have no "
-                    f"bucket able to hold them. Provide an image-prefill chunk size of at least "
-                    f"{ceil_to_multiple_of_128(max_soft_token)}."
-                )
-            return
-
-        buckets = RBLNGemma4ForCausalLMConfig._normalize_image_prefill_chunk_sizes(
-            [ceil_to_multiple_of_128(t) for t in soft_tokens]
-        )
-        # Keep only the largest `(n + 1) // 2` buckets (descending list -> drop smallest first).
-        num_keep = (len(soft_tokens) + 1) // 2
-        buckets = buckets[:num_keep]
-
-        if isinstance(lm_cfg, dict):
-            lm_cfg["image_prefill_chunk_sizes"] = buckets
+            buckets = RBLNGemma4ForCausalLMConfig._normalize_image_prefill_chunk_size(pinned)
         else:
-            lm_cfg.image_prefill_chunk_sizes = buckets
+            buckets = RBLNGemma4ForCausalLMConfig._normalize_image_prefill_chunk_size(
+                [ceil_to_multiple_of_128(t) for t in max_soft_tokens]
+            )
+            # Keep only the largest `(n + 1) // 2` buckets (descending list -> drop smallest first).
+            num_keep = (len(max_soft_tokens) + 1) // 2
+            buckets = buckets[:num_keep]
+            if isinstance(lm_cfg, dict):
+                lm_cfg["image_prefill_chunk_size"] = buckets
+            else:
+                lm_cfg.image_prefill_chunk_size = buckets
+
+        # (1) The largest image-prefill bucket must hold the largest max_soft_tokens; otherwise those
+        # images cannot be image-prefilled by any bucket.
+        if max(buckets) < max(max_soft_tokens):
+            raise ValueError(
+                f"The largest image-prefill chunk size ({max(buckets)}) is smaller than the vision "
+                f"tower's largest max_soft_tokens ({max(max_soft_tokens)}); those images cannot be "
+                f"image-prefilled by any bucket. Provide an image-prefill chunk size of at least "
+                f"{ceil_to_multiple_of_128(max(max_soft_tokens))}."
+            )
+
+        # (2) Any image-prefill bucket smaller than the smallest max_soft_tokens is never selected at
+        # runtime (every image run is >= min(max_soft_tokens) and the runtime picks the smallest bucket
+        # that fits), so it would be compiled but unused.
+        if min(buckets) < min(max_soft_tokens):
+            raise ValueError(
+                f"The smallest image-prefill chunk size ({min(buckets)}) is smaller than the vision "
+                f"tower's smallest max_soft_tokens ({min(max_soft_tokens)}); image-prefill chunk sizes "
+                f"below {min(max_soft_tokens)} are never used at runtime. Remove them."
+            )
 
     @property
     def image_prefill_chunk_size(self):
         return self.language_model.image_prefill_chunk_size
-
-    @property
-    def image_prefill_chunk_sizes(self):
-        return self.language_model.image_prefill_chunk_sizes
 
     @property
     def prefill_chunk_size(self):

--- a/src/optimum/rbln/transformers/models/gemma4/configuration_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/configuration_gemma4.py
@@ -244,10 +244,8 @@ class RBLNGemma4ForConditionalGenerationConfig(RBLNModelConfig):
         # Resolves the language model's image-prefill chunk size(s) against the vision tower's
         # max_soft_tokens.
         # When image_prefill_chunk_size is not pinned: derive it from max_soft_tokens by mapping each
-        # count to the smallest multiple of 128 that holds it, then keeping only the largest
-        # (n + 1) // 2 buckets — dropped smallest-first so the largest count keeps its own bucket and
-        # smaller images route to the smallest kept bucket >= their length at runtime. With the default
-        # single max_soft_tokens (280) this derives a single chunk size of 384.
+        # count to the smallest multiple of 128 that holds it — one bucket per distinct soft-token count.
+        # With the default single max_soft_tokens (280) this derives a single chunk size of 384.
         # When the user did pin it: use it as-is.
         # Either way the resolved buckets are validated against max_soft_tokens below (asserted here, not
         # at runtime); these buckets are independent of the text prefill_chunk_size.
@@ -267,9 +265,6 @@ class RBLNGemma4ForConditionalGenerationConfig(RBLNModelConfig):
             buckets = RBLNGemma4ForCausalLMConfig._validate_image_prefill_chunk_size(
                 [ceil_to_multiple_of_128(t) for t in max_soft_tokens]
             )
-            # Keep only the largest `(n + 1) // 2` buckets (descending list -> drop smallest first).
-            num_keep = (len(max_soft_tokens) + 1) // 2
-            buckets = buckets[:num_keep]
             if isinstance(lm_cfg, dict):
                 lm_cfg["image_prefill_chunk_size"] = buckets
             else:
@@ -285,14 +280,18 @@ class RBLNGemma4ForConditionalGenerationConfig(RBLNModelConfig):
                 f"{ceil_to_multiple_of_128(max(max_soft_tokens))}."
             )
 
-        # (2) Any image-prefill bucket smaller than the smallest max_soft_tokens is never selected at
-        # runtime (every image run is >= min(max_soft_tokens) and the runtime picks the smallest bucket
-        # that fits), so it would be compiled but unused.
-        if min(buckets) < min(max_soft_tokens):
+        # (2) Every compiled bucket must serve at least one max_soft_tokens count. At runtime an image
+        # of t soft tokens is dispatched to the smallest bucket >= t; buckets that no count routes to
+        # (too small to fit any, or shadowed by a smaller bucket that already covers every count) are
+        # compiled but never selected. `max(buckets) >= max(max_soft_tokens)` (checked above) guarantees
+        # every count has at least one fitting bucket here.
+        used_buckets = {min(b for b in buckets if b >= t) for t in max_soft_tokens}
+        unused_buckets = [b for b in buckets if b not in used_buckets]
+        if unused_buckets:
             raise ValueError(
-                f"The smallest image-prefill chunk size ({min(buckets)}) is smaller than the vision "
-                f"tower's smallest max_soft_tokens ({min(max_soft_tokens)}); image-prefill chunk sizes "
-                f"below {min(max_soft_tokens)} are never used at runtime. Remove them."
+                f"Image-prefill chunk sizes {unused_buckets} are never used at runtime: no vision tower "
+                f"max_soft_tokens ({max_soft_tokens}) routes to them (each image is dispatched to the "
+                f"smallest image-prefill chunk size >= its soft-token count). Remove them."
             )
 
     @property

--- a/src/optimum/rbln/transformers/models/gemma4/gemma4_runtime_utils.py
+++ b/src/optimum/rbln/transformers/models/gemma4/gemma4_runtime_utils.py
@@ -70,7 +70,7 @@ class RBLNGemma4RuntimeModel(RBLNDecoderOnlyChunkedMultimodalPrefillMixin, RBLNR
 
     def _resolve_image_chunk(self, token_type_ids: torch.Tensor, step: int, start_type: int):
         # Gemma4 buckets image/video runs: pick the smallest bucket that fits the run.
-        image_buckets = self.rbln_config.image_prefill_chunk_sizes
+        image_buckets = self.rbln_config.image_prefill_chunk_size
         max_image_bucket = max(image_buckets)
         run_len = _run_length_from(token_type_ids, step, value=start_type, cap=max_image_bucket + 1)
         if run_len > max_image_bucket:
@@ -80,7 +80,7 @@ class RBLNGemma4RuntimeModel(RBLNDecoderOnlyChunkedMultimodalPrefillMixin, RBLNR
                 f"is longer than the largest image-prefill bucket ({max_image_bucket}); no bucket can "
                 f"hold it. For video this means consecutive frames are not separated by text (each "
                 f"frame run must fit one bucket); otherwise add a larger value to "
-                f"`image_prefill_chunk_sizes`."
+                f"`image_prefill_chunk_size`."
             )
         return run_len, min(b for b in image_buckets if b >= run_len)
 

--- a/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
@@ -136,8 +136,6 @@ class RBLNGemma4VisionModel(RBLNModel):
             rbln_config.pooling_kernel_size = model_config.pooling_kernel_size
         if rbln_config.patch_size is None:
             rbln_config.patch_size = model_config.patch_size
-        if rbln_config.max_soft_tokens is None:
-            rbln_config.max_soft_tokens = list(DEFAULT_MAX_SOFT_TOKENS)
 
         max_patches_list = rbln_config.get_max_patches()
         hidden_size = model_config.hidden_size
@@ -316,10 +314,10 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         compile_cfgs = [prefill_compile_config]
 
         if rbln_config.use_image_prefill:
-            if rbln_config.image_prefill_chunk_sizes is None:
-                rbln_config.image_prefill_chunk_sizes = [rbln_config.prefill_chunk_size]
+            if rbln_config.image_prefill_chunk_size is None:
+                rbln_config.image_prefill_chunk_size = [rbln_config.prefill_chunk_size]
 
-            for chunk_size in rbln_config.image_prefill_chunk_sizes:
+            for chunk_size in rbln_config.image_prefill_chunk_size:
                 image_prefill_input_info = cls.get_input_info(
                     batch_size=1,
                     query_length=chunk_size,
@@ -373,7 +371,7 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             ip_start = rbln_config.image_prefill_runtime_idx
             ip_compile_configs = rbln_config.compile_cfgs[ip_start : ip_start + rbln_config.num_image_prefill_buckets]
             for chunk_size, ip_compile_config in zip(
-                rbln_config.image_prefill_chunk_sizes, ip_compile_configs, strict=True
+                rbln_config.image_prefill_chunk_size, ip_compile_configs, strict=True
             ):
                 ip_example_inputs = ip_compile_config.get_dummy_inputs(fill=0, static_tensors=static_tensors)
                 compiled_models[f"image_prefill_{chunk_size}"] = cls._compile_model(
@@ -480,7 +478,7 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         image_prefills = {}
         if self.rbln_config.use_image_prefill:
             ip_start = self.rbln_config.image_prefill_runtime_idx
-            for i, chunk_size in enumerate(self.rbln_config.image_prefill_chunk_sizes):
+            for i, chunk_size in enumerate(self.rbln_config.image_prefill_chunk_size):
                 image_prefills[chunk_size] = self.model[ip_start + i]
 
         self.prefill_decoder = RBLNGemma4RuntimeModel(
@@ -578,8 +576,8 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         rbln_config: RBLNModelConfig,
         preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
     ):
-        if rbln_config.image_prefill_chunk_sizes is None:
-            rbln_config.image_prefill_chunk_sizes = [rbln_config.prefill_chunk_size]
+        if rbln_config.image_prefill_chunk_size is None:
+            rbln_config.image_prefill_chunk_size = [rbln_config.prefill_chunk_size]
 
         if "image_prefill" not in rbln_config.phases:
             rbln_config.phases = ["prefill", "image_prefill", "decode"]
@@ -699,7 +697,7 @@ class RBLNGemma4ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
         max_soft_tokens_list = getattr(vt_cfg, "max_soft_tokens", None) if vt_cfg is not None else None
         if isinstance(vt_cfg, dict):
             max_soft_tokens_list = vt_cfg.get("max_soft_tokens", None)
-        max_soft_tokens_list = max_soft_tokens_list or list(DEFAULT_MAX_SOFT_TOKENS)
+        max_soft_tokens_list = max_soft_tokens_list or [DEFAULT_MAX_SOFT_TOKENS]
         if isinstance(max_soft_tokens_list, int):
             max_soft_tokens_list = [max_soft_tokens_list]
         elif isinstance(max_soft_tokens_list, list):


### PR DESCRIPTION
# Pull Request Description

> **⚠️ Important: Branch Target**
> - **New features, enhancements, and non-critical fixes**: Merge to `dev` branch
> - **Critical hotfixes only**: Merge to `main` branch (must also merge to `dev`)
> 
> Please ensure you've selected the correct base branch before submitting!

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Release (dev → main merge for production release)
- [ ] New Model Support
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

1. remove default bucketing logic
2. set a single integer value for image_prefill_chunk_size and max_soft_tokens by default


## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Release
    - `release`: Merging dev to main for production release
      - ex) Release v1.2.0
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update