### PR TITLE
other(release-v0.11.0): use RBLNAutoConfig.from_pretrained instead of removed .load

### DIFF
--- a/src/optimum/rbln/configuration_utils.py
+++ b/src/optimum/rbln/configuration_utils.py
@@ -417,7 +417,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
         config.save("/path/to/model")
 
         # Using AutoConfig
-        loaded_config = RBLNAutoConfig.load("/path/to/model")
+        loaded_config = RBLNAutoConfig.from_pretrained("/path/to/model")
         ```
 
 

--- a/src/optimum/rbln/transformers/models/auto/auto_factory.py
+++ b/src/optimum/rbln/transformers/models/auto/auto_factory.py
@@ -174,7 +174,7 @@ class _BaseAutoModelClass:
         model_path_subfolder = RBLNBaseModel._load_compiled_model_dir(
             model_id=pretrained_model_name_or_path, **filtered_kwargs
         )
-        rbln_config = RBLNAutoConfig.load(model_path_subfolder)
+        rbln_config = RBLNAutoConfig.from_pretrained(model_path_subfolder)
 
         return rbln_config.rbln_model_cls_name
 


### PR DESCRIPTION
Hotfix into `release-v0.11.0`. Same fix as #612 (targets `dev`).

## Problem

On 0.11.0, loading any compiled model through an `RBLNAutoModelFor*` class (`export=False`) crashes:

```
File ".../auto/auto_factory.py", line 177, in get_rbln_model_cls_name
    rbln_config = RBLNAutoConfig.load(model_path_subfolder)
ValueError: `RBLNAutoConfig.load` is deprecated and removed starting from version 0.11.0. Use `from_pretrained` instead.
```

`RBLNAutoConfig.load` is `@deprecate_method(version="0.11.0", new_method="from_pretrained")` and hard-raises, yet `AutoFactory.get_rbln_model_cls_name` still calls it internally. Compile (`export=True`) is unaffected; only loading a compiled model (`export=False`) hits this path. Affects every `RBLNAutoModelFor*` (Whisper `SpeechSeq2Seq`, BGE `TextEncoding`, reranker `SequenceClassification`, …).

Surfaced by the rbln-deploy nightly suite (ko-reranker): compile RC 0, inference RC 1.

## Fix

```diff
- rbln_config = RBLNAutoConfig.load(model_path_subfolder)
+ rbln_config = RBLNAutoConfig.from_pretrained(model_path_subfolder)
```

Drop-in (same signature/return type; `load` is the deprecated alias). Also updates a stale docstring example; the `load()` method's own deprecation example is left as-is.

## Related
- `dev` branch fix: #612
