### PR TITLE
other(deprecation): apply cutoff to pre-, post-, and dev-releases

### DIFF
--- a/src/optimum/rbln/utils/deprecation.py
+++ b/src/optimum/rbln/utils/deprecation.py
@@ -51,12 +51,7 @@ class Action(Enum):
 
 
 def _at_or_past_deprecation(current: str, deprecated: str) -> bool:
-    """Whether ``current`` belongs to a release line at or past ``deprecated``.
-
-    Compares PEP 440 base versions so pre-release (``aN``, ``bN``, ``rcN``),
-    dev-release (``.devN``), and post-release (``.postN``) suffixes share
-    the cutoff with their final ``X.Y.Z`` tag.
-    """
+    """Compare PEP 440 base versions so pre/post/dev-release suffixes share the cutoff."""
     current_base = packaging.version.Version(packaging.version.Version(current).base_version)
     return current_base >= packaging.version.Version(deprecated)
 

--- a/src/optimum/rbln/utils/deprecation.py
+++ b/src/optimum/rbln/utils/deprecation.py
@@ -51,14 +51,11 @@ class Action(Enum):
 
 
 def _at_or_past_deprecation(current: str, deprecated: str) -> bool:
-    """Whether the running release line is at or past the deprecation cutoff.
+    """Whether ``current`` belongs to a release line at or past ``deprecated``.
 
-    Compares PEP 440 base versions, so pre-/post-/dev-releases on the
-    same X.Y.Z line — e.g. 0.11.0a1, 0.11.0rc2, 0.11.0.post1, 0.11.0.dev3 —
-    trigger the raise-after-cutoff behavior consistently with the final
-    0.11.0 tag. Without this normalization, packaging.version treats
-    0.11.0a1 < 0.11.0, so deprecated calls only blow up at final-release
-    time rather than on the alpha/RC builds CI actually runs against.
+    Compares PEP 440 base versions so pre-, post-, and dev-releases of the
+    same ``X.Y.Z`` line (e.g. ``0.11.0a1``, ``0.11.0rc1``, ``0.11.0.post1``)
+    share the cutoff with the final ``0.11.0`` tag.
     """
     current_base = packaging.version.Version(packaging.version.Version(current).base_version)
     return current_base >= packaging.version.Version(deprecated)

--- a/src/optimum/rbln/utils/deprecation.py
+++ b/src/optimum/rbln/utils/deprecation.py
@@ -50,6 +50,20 @@ class Action(Enum):
     RAISE = "raise"
 
 
+def _at_or_past_deprecation(current: str, deprecated: str) -> bool:
+    """Whether the running release line is at or past the deprecation cutoff.
+
+    Compares PEP 440 base versions, so pre-/post-/dev-releases on the
+    same X.Y.Z line — e.g. 0.11.0a1, 0.11.0rc2, 0.11.0.post1, 0.11.0.dev3 —
+    trigger the raise-after-cutoff behavior consistently with the final
+    0.11.0 tag. Without this normalization, packaging.version treats
+    0.11.0a1 < 0.11.0, so deprecated calls only blow up at final-release
+    time rather than on the alpha/RC builds CI actually runs against.
+    """
+    current_base = packaging.version.Version(packaging.version.Version(current).base_version)
+    return current_base >= packaging.version.Version(deprecated)
+
+
 # Scenario Table for Deprecation Strategy Example
 # Assume that current version is v0.9.6 and the deprecated version is v0.10.0
 # |--------------------|----------------|----------------|---------------------------------------------|--------------------------------------------------------------------------------------|----------------------------------------------------------------------|
@@ -121,9 +135,7 @@ def deprecate_kwarg(
             A wrapped function that handles the deprecated keyword arguments according to the specified parameters.
     """
 
-    deprecated_version = packaging.version.parse(version)
-    current_version = packaging.version.parse(__version__)
-    is_greater_or_equal_version = current_version >= deprecated_version
+    is_greater_or_equal_version = _at_or_past_deprecation(__version__, version)
 
     if is_greater_or_equal_version:
         version_message = f"and removed starting from version {version}"
@@ -244,9 +256,7 @@ def deprecate_method(
         ...         return self.from_pretrained(path)
     """
 
-    deprecated_version = packaging.version.parse(version)
-    current_version = packaging.version.parse(__version__)
-    is_greater_or_equal_version = current_version >= deprecated_version
+    is_greater_or_equal_version = _at_or_past_deprecation(__version__, version)
 
     if is_greater_or_equal_version:
         version_message = f"and removed starting from version {version}"

--- a/src/optimum/rbln/utils/deprecation.py
+++ b/src/optimum/rbln/utils/deprecation.py
@@ -53,9 +53,9 @@ class Action(Enum):
 def _at_or_past_deprecation(current: str, deprecated: str) -> bool:
     """Whether ``current`` belongs to a release line at or past ``deprecated``.
 
-    Compares PEP 440 base versions so pre-, post-, and dev-releases of the
-    same ``X.Y.Z`` line (e.g. ``0.11.0a1``, ``0.11.0rc1``, ``0.11.0.post1``)
-    share the cutoff with the final ``0.11.0`` tag.
+    Compares PEP 440 base versions so pre-release (``aN``, ``bN``, ``rcN``),
+    dev-release (``.devN``), and post-release (``.postN``) suffixes share
+    the cutoff with their final ``X.Y.Z`` tag.
     """
     current_base = packaging.version.Version(packaging.version.Version(current).base_version)
     return current_base >= packaging.version.Version(deprecated)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -41,6 +41,7 @@ def test_deprecate_method_raises_at_or_past_cutoff(current_version, expect_raise
     expectation = pytest.raises(ValueError, match="deprecated") if expect_raise else does_not_raise()
 
     with patch("optimum.rbln.utils.deprecation.__version__", current_version):
+
         @deprecate_method(version="1.0.0", new_method="from_pretrained")
         def stub():
             pass

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -20,9 +20,7 @@ def test_version_is_str():
 
 
 def test_at_or_past_deprecation_normalizes_prerelease_to_base_version():
-    # Pre-/post-/dev-releases on the same X.Y.Z line should count as
-    # "at the cutoff" so deprecated paths blow up on alphas/RCs that CI
-    # runs, not only on the final tag.
+    """Pre-, post-, and dev-releases share the cutoff with the final tag."""
     from optimum.rbln.utils.deprecation import _at_or_past_deprecation
 
     assert _at_or_past_deprecation("0.11.0a1", "0.11.0")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -38,16 +38,15 @@ def test_version_is_str():
 )
 def test_deprecate_method_raises_at_or_past_cutoff(current_version, expect_raise):
     with patch("optimum.rbln.utils.deprecation.__version__", current_version):
-
         @deprecate_method(version="1.0.0", new_method="from_pretrained")
         def stub():
-            return "ok"
+            pass
 
     if expect_raise:
         with pytest.raises(ValueError, match="deprecated"):
             stub()
     else:
-        assert stub() == "ok"
+        stub()
 
 
 DUMMY_DEVICE_CODE = -1

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -21,9 +21,12 @@ def test_version_is_str():
 
 
 @pytest.mark.parametrize(
-    "current, expected",
+    "current_version, expect_raise",
     [
-        # Same X.Y.Z line — any PEP 440 suffix shares the cutoff.
+        # Earlier release lines stay below the cutoff — warn only.
+        pytest.param("0.9.5", False, id="below"),
+        pytest.param("0.9.9.post2", False, id="below-post"),
+        # Same X.Y.Z line — any PEP 440 suffix shares the cutoff and raises.
         pytest.param("1.0.0.dev0", True, id="dev"),
         pytest.param("1.0.0a1", True, id="alpha"),
         pytest.param("1.0.0b2", True, id="beta"),
@@ -31,16 +34,25 @@ def test_version_is_str():
         pytest.param("1.0.0", True, id="final"),
         pytest.param("1.0.0.post1", True, id="post"),
         pytest.param("1.0.1", True, id="patch-above"),
-        # Earlier release lines stay below the cutoff.
-        pytest.param("0.9.5", False, id="minor-below"),
-        pytest.param("0.9.9.post2", False, id="minor-below-post"),
     ],
 )
-def test_at_or_past_deprecation_normalizes_prerelease_to_base_version(current, expected):
-    """Pre-, post-, and dev-releases share the cutoff with the final tag."""
-    from optimum.rbln.utils.deprecation import _at_or_past_deprecation
+def test_deprecate_method_raises_at_or_past_cutoff(current_version, expect_raise):
+    """@deprecate_method raises starting from the cutoff X.Y.Z line, including any PEP 440 suffix."""
+    from unittest.mock import patch
 
-    assert _at_or_past_deprecation(current, "1.0.0") is expected
+    from optimum.rbln.utils.deprecation import deprecate_method
+
+    with patch("optimum.rbln.utils.deprecation.__version__", current_version):
+
+        @deprecate_method(version="1.0.0", new_method="from_pretrained")
+        def stub():
+            return "ok"
+
+    if expect_raise:
+        with pytest.raises(ValueError, match="deprecated"):
+            stub()
+    else:
+        assert stub() == "ok"
 
 
 DUMMY_DEVICE_CODE = -1

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -23,10 +23,8 @@ def test_version_is_str():
 @pytest.mark.parametrize(
     "current_version, expect_raise",
     [
-        # Earlier release lines stay below the cutoff — warn only.
         pytest.param("0.9.5", False, id="below"),
         pytest.param("0.9.9.post2", False, id="below-post"),
-        # Same X.Y.Z line — any PEP 440 suffix shares the cutoff and raises.
         pytest.param("1.0.0.dev0", True, id="dev"),
         pytest.param("1.0.0a1", True, id="alpha"),
         pytest.param("1.0.0b2", True, id="beta"),

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -26,15 +26,15 @@ def test_version_is_str():
 @pytest.mark.parametrize(
     "current_version, expect_raise",
     [
-        pytest.param("0.9.5", False, id="below"),
-        pytest.param("0.9.9.post2", False, id="below-post"),
-        pytest.param("1.0.0.dev0", True, id="dev"),
-        pytest.param("1.0.0a1", True, id="alpha"),
-        pytest.param("1.0.0b2", True, id="beta"),
-        pytest.param("1.0.0rc1", True, id="rc"),
-        pytest.param("1.0.0", True, id="final"),
-        pytest.param("1.0.0.post1", True, id="post"),
-        pytest.param("1.0.1", True, id="patch-above"),
+        pytest.param("1.9.5", False, id="below"),
+        pytest.param("1.9.99.post1", False, id="below-post"),
+        pytest.param("1.10.0.dev0", True, id="dev"),
+        pytest.param("1.10.0a1", True, id="alpha"),
+        pytest.param("1.10.0b2", True, id="beta"),
+        pytest.param("1.10.0rc1", True, id="rc"),
+        pytest.param("1.10.0", True, id="final"),
+        pytest.param("1.10.0.post1", True, id="post"),
+        pytest.param("1.10.1", True, id="patch-above"),
     ],
 )
 def test_deprecate_method_raises_at_or_past_cutoff(current_version, expect_raise):
@@ -42,7 +42,7 @@ def test_deprecate_method_raises_at_or_past_cutoff(current_version, expect_raise
 
     with patch("optimum.rbln.utils.deprecation.__version__", current_version):
 
-        @deprecate_method(version="1.0.0", new_method="from_pretrained")
+        @deprecate_method(version="1.10.0", new_method="from_pretrained")
         def stub():
             pass
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -7,6 +7,7 @@ import unittest
 from enum import Enum
 from typing import Iterable
 
+import pytest
 import transformers
 from diffusers import DiffusionPipeline
 from transformers import AutoConfig, CLIPConfig
@@ -19,20 +20,27 @@ def test_version_is_str():
     assert isinstance(__version__, str)
 
 
-def test_at_or_past_deprecation_normalizes_prerelease_to_base_version():
+@pytest.mark.parametrize(
+    "current, expected",
+    [
+        # Same X.Y.Z line — any PEP 440 suffix shares the cutoff.
+        pytest.param("1.0.0.dev0", True, id="dev"),
+        pytest.param("1.0.0a1", True, id="alpha"),
+        pytest.param("1.0.0b2", True, id="beta"),
+        pytest.param("1.0.0rc1", True, id="rc"),
+        pytest.param("1.0.0", True, id="final"),
+        pytest.param("1.0.0.post1", True, id="post"),
+        pytest.param("1.0.1", True, id="patch-above"),
+        # Earlier release lines stay below the cutoff.
+        pytest.param("0.9.5", False, id="minor-below"),
+        pytest.param("0.9.9.post2", False, id="minor-below-post"),
+    ],
+)
+def test_at_or_past_deprecation_normalizes_prerelease_to_base_version(current, expected):
     """Pre-, post-, and dev-releases share the cutoff with the final tag."""
     from optimum.rbln.utils.deprecation import _at_or_past_deprecation
 
-    assert _at_or_past_deprecation("0.11.0a1", "0.11.0")
-    assert _at_or_past_deprecation("0.11.0b2", "0.11.0")
-    assert _at_or_past_deprecation("0.11.0rc1", "0.11.0")
-    assert _at_or_past_deprecation("0.11.0.dev3", "0.11.0")
-    assert _at_or_past_deprecation("0.11.0", "0.11.0")
-    assert _at_or_past_deprecation("0.11.0.post1", "0.11.0")
-    assert _at_or_past_deprecation("0.11.1", "0.11.0")
-
-    assert not _at_or_past_deprecation("0.10.5", "0.11.0")
-    assert not _at_or_past_deprecation("0.10.9.post2", "0.11.0")
+    assert _at_or_past_deprecation(current, "1.0.0") is expected
 
 
 DUMMY_DEVICE_CODE = -1

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -19,6 +19,24 @@ def test_version_is_str():
     assert isinstance(__version__, str)
 
 
+def test_at_or_past_deprecation_normalizes_prerelease_to_base_version():
+    # Pre-/post-/dev-releases on the same X.Y.Z line should count as
+    # "at the cutoff" so deprecated paths blow up on alphas/RCs that CI
+    # runs, not only on the final tag.
+    from optimum.rbln.utils.deprecation import _at_or_past_deprecation
+
+    assert _at_or_past_deprecation("0.11.0a1", "0.11.0")
+    assert _at_or_past_deprecation("0.11.0b2", "0.11.0")
+    assert _at_or_past_deprecation("0.11.0rc1", "0.11.0")
+    assert _at_or_past_deprecation("0.11.0.dev3", "0.11.0")
+    assert _at_or_past_deprecation("0.11.0", "0.11.0")
+    assert _at_or_past_deprecation("0.11.0.post1", "0.11.0")
+    assert _at_or_past_deprecation("0.11.1", "0.11.0")
+
+    assert not _at_or_past_deprecation("0.10.5", "0.11.0")
+    assert not _at_or_past_deprecation("0.10.9.post2", "0.11.0")
+
+
 DUMMY_DEVICE_CODE = -1
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 from enum import Enum
 from typing import Iterable
+from unittest.mock import patch
 
 import pytest
 import transformers
@@ -14,6 +15,7 @@ from transformers import AutoConfig, CLIPConfig
 
 from optimum.rbln import __version__
 from optimum.rbln.configuration_utils import ContextRblnConfig
+from optimum.rbln.utils.deprecation import deprecate_method
 
 
 def test_version_is_str():
@@ -35,11 +37,6 @@ def test_version_is_str():
     ],
 )
 def test_deprecate_method_raises_at_or_past_cutoff(current_version, expect_raise):
-    """@deprecate_method raises starting from the cutoff X.Y.Z line, including any PEP 440 suffix."""
-    from unittest.mock import patch
-
-    from optimum.rbln.utils.deprecation import deprecate_method
-
     with patch("optimum.rbln.utils.deprecation.__version__", current_version):
 
         @deprecate_method(version="1.0.0", new_method="from_pretrained")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -4,6 +4,7 @@ import random
 import shutil
 import tempfile
 import unittest
+from contextlib import nullcontext as does_not_raise
 from enum import Enum
 from typing import Iterable
 from unittest.mock import patch
@@ -37,15 +38,14 @@ def test_version_is_str():
     ],
 )
 def test_deprecate_method_raises_at_or_past_cutoff(current_version, expect_raise):
+    expectation = pytest.raises(ValueError, match="deprecated") if expect_raise else does_not_raise()
+
     with patch("optimum.rbln.utils.deprecation.__version__", current_version):
         @deprecate_method(version="1.0.0", new_method="from_pretrained")
         def stub():
             pass
 
-    if expect_raise:
-        with pytest.raises(ValueError, match="deprecated"):
-            stub()
-    else:
+    with expectation:
         stub()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -168,22 +168,24 @@ def test_load_config_object(model_id, tmp_path):
     base_config.save(str(config_path))
 
     # Subtest 1: Plain load
-    loaded_config = RBLNResNetForImageClassificationConfig.load(str(config_path))
+    loaded_config = RBLNResNetForImageClassificationConfig.from_pretrained(str(config_path))
     assert loaded_config.image_size == 128, "Plain load: image_size mismatch"
 
     # Subtest 2: Load with rbln_config dict
-    loaded_config = RBLNResNetForImageClassificationConfig.load(
+    loaded_config = RBLNResNetForImageClassificationConfig.from_pretrained(
         str(config_path), rbln_config={"create_runtimes": False}
     )
     assert not loaded_config.create_runtimes, "Load with rbln_config: create_runtimes mismatch"
 
     # Subtest 3: Load with rbln_ prefix
-    loaded_config = RBLNResNetForImageClassificationConfig.load(str(config_path), rbln_create_runtimes=False)
+    loaded_config = RBLNResNetForImageClassificationConfig.from_pretrained(
+        str(config_path), rbln_create_runtimes=False
+    )
     assert not loaded_config.create_runtimes, "Load with rbln_ prefix: create_runtimes mismatch"
 
     # Subtest 4: Load with rbln_ prefix
     with pytest.raises(ValueError, match="Cannot set the following arguments: ['image_size']*"):
-        loaded_config = RBLNResNetForImageClassificationConfig.load(
+        loaded_config = RBLNResNetForImageClassificationConfig.from_pretrained(
             str(config_path), rbln_create_runtimes=False, rbln_config={"image_size": 256}
         )
         assert not loaded_config.create_runtimes, "Load with rbln_ prefix: create_runtimes mismatch"


### PR DESCRIPTION
## Summary

`@deprecate_method` / `@deprecate_kwarg` raise after `__version__ >= cutoff`. Because `packaging.version` orders `X.Y.Za1 < X.Y.Z < X.Y.Z.post1`, **pre-/post-/dev-releases never trigger the raise** — deprecated calls only blow up at the final tag.

This PR normalizes the comparison through `Version(...).base_version` so any release on the same `X.Y.Z` line — `dev`, `aN`, `bN`, `rcN`, `final`, `.postN` — hits the cutoff together.

## Behavior change

| current | before | after |
|---|---|---|
| `X.Y.Z.dev0` / `aN` / `bN` / `rcN` | warn | **raise** |
| `X.Y.Z` | raise | raise |
| `X.Y.Z.postN` / `X.Y.(Z+1)` | raise | raise |
| `< X.Y.Z` | warn | warn (unchanged) |

## Tests

- `tests/test_base.py::test_deprecate_method_raises_at_or_past_cutoff` — parametrized integration test that mocks `__version__`, decorates a stub with `@deprecate_method(version="1.0.0")`, and asserts the raise outcome across 9 PEP 440 suffix variants.
- `tests/test_config.py::test_load_config_object` — switched from `.load(...)` (deprecated) to `.from_pretrained(...)`. The test no longer triggers the raise it's now subject to.

## Related

[235075e4](https://github.com/RBLN-SW/optimum-rbln/commit/235075e4e9991bcdae9a89897bf0f0a2f3c6d92f) — a stale `.load()` call that survived all `0.11.0a*` builds and only raised at the `0.11.0` tag. Exactly the pattern this PR catches earlier.
