### PR TITLE
release: bring v0.11.0.post1 hotfix onto main

### DIFF
--- a/src/optimum/rbln/configuration_utils.py
+++ b/src/optimum/rbln/configuration_utils.py
@@ -417,7 +417,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
         config.save("/path/to/model")
 
         # Using AutoConfig
-        loaded_config = RBLNAutoConfig.load("/path/to/model")
+        loaded_config = RBLNAutoConfig.from_pretrained("/path/to/model")
         ```
 
 

--- a/src/optimum/rbln/transformers/models/auto/auto_factory.py
+++ b/src/optimum/rbln/transformers/models/auto/auto_factory.py
@@ -174,7 +174,7 @@ class _BaseAutoModelClass:
         model_path_subfolder = RBLNBaseModel._load_compiled_model_dir(
             model_id=pretrained_model_name_or_path, **filtered_kwargs
         )
-        rbln_config = RBLNAutoConfig.load(model_path_subfolder)
+        rbln_config = RBLNAutoConfig.from_pretrained(model_path_subfolder)
 
         return rbln_config.rbln_model_cls_name
 


### PR DESCRIPTION
## Summary

**Forward-merge `dev` (v0.11.0.post1) into `main`** so the hotfix that landed on v0.11.0.post1 — [`235075e4`](https://github.com/RBLN-SW/optimum-rbln/commit/235075e4) (`use RBLNAutoConfig.from_pretrained instead of removed .load`, #612) — is reflected on the main release line.

Without this, `v0.11.0.post1`'s 2-line fix lives only on `dev`. `main` (= `v0.11.0`) still contains the stale `RBLNAutoConfig.load(...)` call, and `git tag --contains v0.11.0.post1 main` would never report the tag.

## What changes on main

```
2 files changed, 2 insertions(+), 2 deletions(-)
src/optimum/rbln/configuration_utils.py                   | 2 +-
src/optimum/rbln/transformers/models/auto/auto_factory.py | 2 +-
```

Exactly the v0.11.0.post1 hotfix — nothing else.

## After this PR

- `main` HEAD = merge commit with parents `(3ffeb8f6, 235075e4)`
- Both `v0.11.0` and `v0.11.0.post1` become ancestors of `main`
- A follow-up PR will back-merge `main` into `dev` so the graph reconverges

## Merge instructions

⚠️ **Must be merged with "Create a merge commit"** (not Squash, not Rebase). Squash flattens the multi-parent merge into a single linear commit and destroys the topology this PR exists to restore.
