### PR TITLE
release: v0.11.0.post1 (rebuilt on v0.11.0 base)

### DIFF
--- a/src/optimum/rbln/configuration_utils.py
+++ b/src/optimum/rbln/configuration_utils.py
@@ -417,7 +417,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
         config.save("/path/to/model")
 
         # Using AutoConfig
-        loaded_config = RBLNAutoConfig.load("/path/to/model")
+        loaded_config = RBLNAutoConfig.from_pretrained("/path/to/model")
         ```
 
 

--- a/src/optimum/rbln/transformers/models/auto/auto_factory.py
+++ b/src/optimum/rbln/transformers/models/auto/auto_factory.py
@@ -174,7 +174,7 @@ class _BaseAutoModelClass:
         model_path_subfolder = RBLNBaseModel._load_compiled_model_dir(
             model_id=pretrained_model_name_or_path, **filtered_kwargs
         )
-        rbln_config = RBLNAutoConfig.load(model_path_subfolder)
+        rbln_config = RBLNAutoConfig.from_pretrained(model_path_subfolder)
 
         return rbln_config.rbln_model_cls_name
 


### PR DESCRIPTION
## Summary

Re-build `v0.11.0.post1` on top of the `v0.11.0` tag the way it should have been done originally.

The hotfix [`235075e4`](https://github.com/RBLN-SW/optimum-rbln/commit/235075e4) (`use RBLNAutoConfig.from_pretrained instead of removed .load`, #612) was originally landed on `dev` tip rather than on the `v0.11.0` line, so `v0.11.0.post1` ended up as a sibling of `v0.11.0` in the git graph instead of a direct descendant. This PR rebuilds the fix on top of `v0.11.0` so the post-release becomes a proper child of the release line.

## What's in this PR

`Files changed: 2, +2/-2` — exactly the v0.11.0.post1 hotfix, cherry-picked from `235075e4` (original author preserved).

```
src/optimum/rbln/configuration_utils.py                   | 2 +-
src/optimum/rbln/transformers/models/auto/auto_factory.py | 2 +-
```

## Tag plan after merge

The git tag `v0.11.0.post1` will be **moved** from `235075e4` (dev tip) to the new main merge SHA so the tag finally points to a direct descendant of `v0.11.0`. The PyPI wheel `optimum-rbln==0.11.0.post1` is treated as immutable and stays as-is — only the git tag is being repositioned. (The wheel's code is byte-identical to the new SHA's tree.)

## Follow-up after this PR merges

1. Delete the old git tag `v0.11.0.post1` (currently on `235075e4`).
2. Re-tag `v0.11.0.post1` on the new main SHA.
3. Sync `release-v0.11.0` branch to the new main tip so future v0.11.0.x hotfixes start from a correct base.
4. Revert `235075e4` on `dev` (it's now redundant — the same fix is on main via this PR).
5. Back-merge main into dev to reconverge.

## Merge instructions

**"Create a merge commit"** mode. This produces a clean merge commit whose first parent is `v0.11.0` and whose second parent is the new hotfix commit — exactly the topology a normal post-release would have.

## Replaces

- Closes #616 (the previous forward-merge approach, which would have kept `v0.11.0.post1` in its sibling position).
