### PR TITLE
model(seq2seq): raise instead of silently truncating over-long encoder input

### DIFF
--- a/src/optimum/rbln/transformers/models/seq2seq/modeling_seq2seq.py
+++ b/src/optimum/rbln/transformers/models/seq2seq/modeling_seq2seq.py
@@ -436,9 +436,7 @@ class RBLNModelForSeq2SeqLM(RBLNModel, GenerationMixin, ABC):
             (0, pad_len),
             value=self.config.pad_token_id,
         )
-        model_kwargs["attention_mask"] = torch.nn.functional.pad(
-            model_kwargs["attention_mask"], (0, pad_len)
-        )
+        model_kwargs["attention_mask"] = torch.nn.functional.pad(model_kwargs["attention_mask"], (0, pad_len))
 
         # 3. make sure that encoder returns `ModelOutput`
         model_input_name = model_input_name if model_input_name is not None else self.main_input_name

--- a/src/optimum/rbln/transformers/models/seq2seq/modeling_seq2seq.py
+++ b/src/optimum/rbln/transformers/models/seq2seq/modeling_seq2seq.py
@@ -424,13 +424,20 @@ class RBLNModelForSeq2SeqLM(RBLNModel, GenerationMixin, ABC):
             }
 
         batch_size, input_len = inputs_tensor.shape
+        pad_len = self.rbln_config.enc_max_seq_len - input_len
+        if pad_len < 0:
+            raise ValueError(
+                f"Encoder input length ({input_len}) exceeds the compiled `enc_max_seq_len` "
+                f"({self.rbln_config.enc_max_seq_len}); the input would be silently truncated. "
+                f"Recompile the model with a larger `rbln_enc_max_seq_len`."
+            )
         inputs_tensor = torch.nn.functional.pad(
             inputs_tensor,
-            (0, self.rbln_config.enc_max_seq_len - input_len),
+            (0, pad_len),
             value=self.config.pad_token_id,
         )
         model_kwargs["attention_mask"] = torch.nn.functional.pad(
-            model_kwargs["attention_mask"], (0, self.rbln_config.enc_max_seq_len - input_len)
+            model_kwargs["attention_mask"], (0, pad_len)
         )
 
         # 3. make sure that encoder returns `ModelOutput`


### PR DESCRIPTION
# Pull Request Description

> **⚠️ Important: Branch Target**
> - **New features, enhancements, and non-critical fixes**: Merge to `dev` branch
> - **Critical hotfixes only**: Merge to `main` branch (must also merge to `dev`)
>
> Please ensure you've selected the correct base branch before submitting!

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Release (dev → main merge for production release)
- [ ] New Model Support
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Changes Overview
In `RBLNModelForSeq2SeqLM._prepare_encoder_decoder_kwargs_for_generation`, raise a
clear `ValueError` when the encoder input is longer than the compiled
`enc_max_seq_len`, instead of silently truncating it.

## Motivation and Context
The encoder input is padded to `enc_max_seq_len` with:

```python
inputs_tensor = torch.nn.functional.pad(
    inputs_tensor, (0, self.rbln_config.enc_max_seq_len - input_len), value=self.config.pad_token_id
)
```

When `input_len > enc_max_seq_len`, the pad amount becomes negative.
`torch.nn.functional.pad` interprets a negative pad as a **crop**, so it silently
drops the trailing tokens (and the same happens to `attention_mask`) — no warning,
no error. The model then runs on truncated input and produces degraded output that
is hard to diagnose, because nothing signals that part of the input was discarded.

This guard makes the failure explicit and actionable: the user is told the input
length, the compiled limit, and that they should recompile with a larger
`rbln_enc_max_seq_len`.

```python
pad_len = self.rbln_config.enc_max_seq_len - input_len
if pad_len < 0:
    raise ValueError(
        f"Encoder input length ({input_len}) exceeds the compiled `enc_max_seq_len` "
        f"({self.rbln_config.enc_max_seq_len}); the input would be silently truncated. "
        f"Recompile the model with a larger `rbln_enc_max_seq_len`."
    )
```

Note on compatibility: inputs that already fit within `enc_max_seq_len` are
unaffected. Only inputs that were previously being silently truncated now raise —
i.e. cases that were already producing incorrect output.

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->


----
# Conventional commit
```
fix(seq2seq): raise instead of silently truncating over-long encoder input
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
