### PR TITLE
performance: allow user-adjustable kvcache_num_blocks estimation

### DIFF
--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -1,7 +1,7 @@
 import math
 import os
 from collections import defaultdict
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Callable, Optional, Tuple
 
 import rebel
 
@@ -175,18 +175,28 @@ def format_byte_size(nbytes: int) -> str:
 class RBLNDecoderOnlyFlashAttentionMixin:
     @classmethod
     def set_kvcache_num_blocks_after_compilation(
-        cls, compiled_models: dict[str, rebel.RBLNCompiledModel], rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig"
+        cls,
+        compiled_models: dict[str, rebel.RBLNCompiledModel],
+        rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
+        adjuster: "Optional[Callable[[int, 'RBLNDecoderOnlyModelForCausalLMConfig'], int]]" = None,
     ):
-        rbln_config.kvcache_num_blocks = cls.estimate_num_kvcache_blocks(
-            compiled_models=compiled_models, rbln_config=rbln_config
-        )
-        if rbln_config.kvcache_num_blocks < rbln_config.num_min_blocks:
+        estimated = cls.estimate_num_kvcache_blocks(compiled_models=compiled_models, rbln_config=rbln_config)
+        num_blocks = adjuster(estimated, rbln_config) if adjuster is not None else estimated
+        if not isinstance(num_blocks, int) or isinstance(num_blocks, bool) or num_blocks <= 0:
+            raise ValueError(f"`kvcache_num_blocks_adjuster` must return a positive int, got {num_blocks!r}.")
+        if num_blocks > estimated:
+            logger.warning(
+                f"`kvcache_num_blocks_adjuster` returned {num_blocks}, which exceeds the "
+                f"estimated maximum {estimated}. This may cause OOM at compile or runtime."
+            )
+        if num_blocks < rbln_config.num_min_blocks:
             raise ValueError(
                 "Memory is not enough for full sequence length. "
                 "Please consider decreasing `max_seq_len` to reduce the number of blocks."
             )
+        rbln_config.kvcache_num_blocks = num_blocks
         cls.multiply_kv_cache_num_blocks(
-            compiled_models=compiled_models, rbln_config=rbln_config, multiplier=rbln_config.kvcache_num_blocks
+            compiled_models=compiled_models, rbln_config=rbln_config, multiplier=num_blocks
         )
 
     @classmethod

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import asdict, dataclass
-from typing import Any, Dict, List, Literal, Optional, Union, get_args
+from typing import Any, Callable, Dict, List, Literal, Optional, Union, get_args
 
 from ....configuration_utils import RBLNModelConfig, RBLNSerializableConfigProtocol
 from ....utils.logging import get_logger
@@ -38,6 +38,7 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
 
     _default_phases = ["prefill"]
     _default_logits_to_keep = 0
+    subclass_non_save_attributes = ["kvcache_num_blocks_adjuster"]
 
     def __init__(
         self,
@@ -53,6 +54,7 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
         lora_config: Optional[Union[Dict[str, Any], RBLNLoRAConfig]] = None,
         prefill_chunk_size: Optional[int] = None,
         kvcache_num_blocks: Optional[int] = None,
+        kvcache_num_blocks_adjuster: Optional[Callable[[int, "RBLNModelConfig"], int]] = None,
         decoder_batch_sizes: Optional[List[int]] = None,
         cache_impl: Optional[CacheImplType] = None,
         sliding_window: Optional[int] = None,
@@ -97,6 +99,14 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
             kvcache_num_blocks (Optional[int]): The total number of blocks to allocate for the
                 PagedAttention KV cache at compile time. Defaults to 0 (automatically determined).
                 See the "KV Cache Number of Blocks (`kvcache_num_blocks`)" section below for details.
+            kvcache_num_blocks_adjuster (Optional[Callable[[int, RBLNModelConfig], int]]): A callable
+                invoked at compile time with the auto-estimated number of blocks and the
+                `RBLNModelConfig` instance, returning the number of blocks to actually allocate.
+                Only used when `kvcache_num_blocks` is `0` (auto). The default estimator assumes
+                the model owns all available DRAM, so pass an adjuster when some memory must be
+                reserved for other uses. The returned value must be a positive int; values below
+                `num_min_blocks` raise an error, and values above the estimate emit a warning.
+                Not serialized into `rbln_config.json` and ignored when loading a precompiled artifact.
             decoder_batch_sizes (Optional[List[int]]): A list of batch sizes for which separate decoder models will be compiled.
                 This allows the model to handle varying batch sizes efficiently during generation. If not specified,
                 defaults to a list containing only the model's main batch size. When specifying multiple batch sizes:
@@ -225,6 +235,7 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
             raise ValueError("`prefill_chunk_size` must be a positive integer divisible by 64.")
 
         self.kvcache_num_blocks = kvcache_num_blocks if kvcache_num_blocks is not None else 0
+        self.kvcache_num_blocks_adjuster = kvcache_num_blocks_adjuster
         self.cache_impl = cache_impl or "static"
         self.sliding_window = sliding_window
         self.sliding_window_layers = sliding_window_layers or []

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -330,7 +330,9 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
         if rbln_config.is_auto_num_blocks:
             if not is_compiler_supports_buffer_resize():
                 raise RuntimeError("`kvcache_num_blocks` must be set.")
-            cls.set_kvcache_num_blocks_after_compilation(compiled_models, rbln_config)
+            cls.set_kvcache_num_blocks_after_compilation(
+                compiled_models, rbln_config, adjuster=rbln_config.kvcache_num_blocks_adjuster
+            )
 
         return compiled_models
 

--- a/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
@@ -407,7 +407,9 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         if rbln_config.is_auto_num_blocks:
             if not is_compiler_supports_buffer_resize():
                 raise RuntimeError("`kvcache_num_blocks` must be set.")
-            cls.set_kvcache_num_blocks_after_compilation(compiled_models, rbln_config)
+            cls.set_kvcache_num_blocks_after_compilation(
+                compiled_models, rbln_config, adjuster=rbln_config.kvcache_num_blocks_adjuster
+            )
 
         return compiled_models
 

--- a/src/optimum/rbln/transformers/models/qwen3_vl/configuration_qwen3_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/configuration_qwen3_vl.py
@@ -29,7 +29,7 @@ class RBLNQwen3VLForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausalLMC
     """
 
     submodules = ["visual"]
-    subclass_non_save_attributes = ["_load_visual_runtime"]
+    subclass_non_save_attributes = ["_load_visual_runtime", "kvcache_num_blocks_adjuster"]
 
     def __init__(
         self,
@@ -66,7 +66,7 @@ class RBLNQwen3VLForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausalLMC
 
 class RBLNQwen3VLModelConfig(RBLNDecoderOnlyModelConfig):
     submodules = ["visual"]
-    subclass_non_save_attributes = ["_load_visual_runtime"]
+    subclass_non_save_attributes = ["_load_visual_runtime", "kvcache_num_blocks_adjuster"]
 
     def __init__(self, visual: Optional[RBLNModelConfig] = None, _load_visual_runtime: bool = True, **kwargs: Any):
         super().__init__(**kwargs)


### PR DESCRIPTION
# Pull Request Description

> **⚠️ Important: Branch Target**
> - **New features, enhancements, and non-critical fixes**: Merge to `dev` branch
> - **Critical hotfixes only**: Merge to `main` branch (must also merge to `dev`)
>
> Please ensure you've selected the correct base branch before submitting!

## Type of Change
- [ ] Release (dev → main merge for production release)
- [ ] New Model Support
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Changes Overview

Add an optional `kvcache_num_blocks_adjuster` callable that lets users override the auto-estimated `kvcache_num_blocks` at compile time.

- `RBLNDecoderOnlyModelConfig` gains a `kvcache_num_blocks_adjuster: Optional[Callable[[int, RBLNModelConfig], int]]` field (defaults to `None`). It is registered in `subclass_non_save_attributes` so it is **not** serialized into `rbln_config.json`.
- `RBLNDecoderOnlyFlashAttentionMixin.set_kvcache_num_blocks_after_compilation` accepts an optional `adjuster` argument. When provided, it is called as `adjuster(estimated, rbln_config)` and the return value replaces the estimate.
- The decoder-only and Gemma4 compile paths forward `rbln_config.kvcache_num_blocks_adjuster` into that argument.
- `RBLNQwen3VLForConditionalGenerationConfig` and `RBLNQwen3VLModelConfig` override `subclass_non_save_attributes`; their lists are extended with `"kvcache_num_blocks_adjuster"` so the inherited exclusion is not shadowed.

Validation policy for the adjusted value:
- A non-positive or non-`int` return value raises `ValueError`.
- A value below `num_min_blocks` raises the existing "Memory is not enough" `ValueError`.
- A value above the estimate emits a warning but is honored (the upper bound is the caller's responsibility).

## Motivation and Context

The current `estimate_num_kvcache_blocks` logic assumes the model owns all available DRAM on the NPU. In deployments where some memory must be reserved for other processes or components, the auto-estimated block count can be too high and lead to OOM at compile or runtime. Users currently have no way to influence the auto-estimated value other than fully overriding `kvcache_num_blocks` with a manual constant, which loses the benefit of DRAM-based estimation.

The adjuster gives users a hook to scale the estimate to their actual memory budget while still relying on the compiler's DRAM-based estimate as the starting point. It is a compile-time-only knob: when loading a precompiled artifact, the estimation path does not run, so the adjuster is ignored and the persisted `kvcache_num_blocks` is used.

### Note for reviewers / future maintainers

`subclass_non_save_attributes` is a plain class attribute that is shadowed (not merged) when a subclass redefines it. Any future subclass of `RBLNDecoderOnlyModelConfig` that overrides `subclass_non_save_attributes` must also include `"kvcache_num_blocks_adjuster"`, otherwise a callable passed by the user would be serialized into `rbln_config.json` and crash `json.dump`.

## Related Issues

N/A

## Usage Example

```python
def reserve_half(estimated: int, rbln_config) -> int:
    return estimated // 2

model = RBLNLlamaForCausalLM.from_pretrained(
    "meta-llama/Llama-3-8B",
    rbln_config={"kvcache_num_blocks": 0, "kvcache_num_blocks_adjuster": reserve_half},
)
```

## Test Plan

- [ ] CPU-side: construct `RBLNDecoderOnlyModelConfig(kvcache_num_blocks_adjuster=fn)` and confirm the field is stored but absent from `_prepare_for_serialization()`.
- [ ] NPU: compile a decoder-only model with `kvcache_num_blocks=0` and a reducing adjuster; confirm the resulting `rbln_config.kvcache_num_blocks` matches the adjuster output and the model runs.
- [ ] NPU: compile with an adjuster returning a value above the estimate; confirm a warning is logged and compilation still succeeds when memory allows.
- [ ] NPU: compile with an adjuster returning a value below `num_min_blocks`; confirm the expected `ValueError` is raised.

Made with [Cursor](https://cursor.com)