### PR TITLE
refactor: modernize type annotations to Python 3.10+ syntax

### DIFF
--- a/examples/advanced/custom_class.py
+++ b/examples/advanced/custom_class.py
@@ -26,7 +26,7 @@ for completely custom architectures without a corresponding HuggingFace implemen
 This example demonstrates creating a custom RBLN class for the ResNet model from transformers.
 """
 
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import torch
 from transformers import ResNetModel  # noqa: F401
@@ -58,7 +58,7 @@ class RBLNResNetModel(RBLNModel):
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]] = None,
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None = None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
         rbln_config: Optional["RBLNResNetModelConfig"] = None,
@@ -85,7 +85,7 @@ class RBLNResNetModel(RBLNModel):
         rbln_config.set_compile_cfgs([RBLNCompileConfig(input_info=input_info)])
         return rbln_config
 
-    def forward(self, pixel_values, return_dict: Optional[bool] = None, **kwargs):
+    def forward(self, pixel_values, return_dict: bool | None = None, **kwargs):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         # self.model is a list of rebel.Runtime objects
@@ -109,7 +109,7 @@ class RBLNResNetModel(RBLNModel):
 # - batch_size: Batch size for inference
 # - image_size: Input image dimensions (height, width)
 class RBLNResNetModelConfig(RBLNModelConfig):
-    def __init__(self, batch_size: int = None, image_size: Optional[Tuple[int, int]] = None, **kwargs):
+    def __init__(self, batch_size: int = None, image_size: tuple[int, int] | None = None, **kwargs):
         super().__init__(**kwargs)
         self.batch_size = batch_size or 1
         self.image_size = image_size or (224, 224)

--- a/examples/image-to-text/run_idefics3.py
+++ b/examples/image-to-text/run_idefics3.py
@@ -1,5 +1,4 @@
 import os
-import typing
 
 import fire
 from datasets import load_dataset
@@ -12,9 +11,9 @@ def main(
     model_id: str = "HuggingFaceM4/Idefics3-8B-Llama3",
     batch_size: int = 1,
     from_transformers: bool = False,
-    prompt: typing.Optional[str] = None,
-    max_seq_len: typing.Optional[int] = None,
-    num_devices: typing.Optional[int] = 4,
+    prompt: str | None = None,
+    max_seq_len: int | None = None,
+    num_devices: int | None = 4,
 ):
     processor = AutoProcessor.from_pretrained(model_id)
 

--- a/examples/image-to-text/run_llava_next_image_to_text.py
+++ b/examples/image-to-text/run_llava_next_image_to_text.py
@@ -1,5 +1,4 @@
 import os
-import typing
 
 import fire
 from datasets import load_dataset
@@ -12,10 +11,10 @@ def main(
     model_id: str = "llava-hf/llava-v1.6-mistral-7b-hf",
     batch_size: int = 1,
     from_transformers: bool = False,
-    prompt: typing.Optional[str] = None,
-    max_seq_len: typing.Optional[int] = None,
-    num_devices: typing.Optional[int] = 4,
-    num_text_only: typing.Optional[int] = None,
+    prompt: str | None = None,
+    max_seq_len: int | None = None,
+    num_devices: int | None = 4,
+    num_text_only: int | None = None,
 ):
     if from_transformers:
         processor = LlavaNextProcessor.from_pretrained(model_id)

--- a/examples/stable-diffusion/run_stable_diffusion_multicontrolnet.py
+++ b/examples/stable-diffusion/run_stable_diffusion_multicontrolnet.py
@@ -1,5 +1,4 @@
 import os
-from typing import List, Optional
 
 import cv2
 import fire
@@ -16,7 +15,7 @@ from optimum.rbln import RBLNStableDiffusionControlNetPipeline
 def main(
     diffusion_model_id: str = "runwayml/stable-diffusion-v1-5",
     from_diffusers: bool = False,
-    controlnet_model_id: Optional[List[str]] = None,
+    controlnet_model_id: list[str] | None = None,
     prompt: str = "a giant standing in a fantasy landscape, best quality",
     negative_prompt: str = "monochrome, lowres, bad anatomy, worst quality, low quality",
 ):

--- a/examples/text-classification/run_t5_classification.py
+++ b/examples/text-classification/run_t5_classification.py
@@ -1,5 +1,4 @@
 import os
-import typing
 
 import fire
 from transformers import AutoTokenizer, T5EncoderModel
@@ -11,7 +10,7 @@ def main(
     model_id: str = "google-t5/t5-small",
     batch_size: int = 1,
     from_transformers: bool = False,
-    prompt: typing.Optional[str] = "Studies have been shown that owning a dog is good for you",
+    prompt: str | None = "Studies have been shown that owning a dog is good for you",
 ):
     tokenizer = AutoTokenizer.from_pretrained(model_id)
 

--- a/examples/text2text-generation/run_llama_peft.py
+++ b/examples/text2text-generation/run_llama_peft.py
@@ -1,5 +1,4 @@
 import os
-import typing
 
 import fire
 from peft import PeftModel
@@ -12,8 +11,8 @@ def main(
     model_id: str = "meta-llama/Meta-Llama-3-8B",
     batch_size: int = 1,
     from_transformers: bool = False,
-    max_seq_len: typing.Optional[int] = None,
-    num_devices: typing.Optional[int] = 4,
+    max_seq_len: int | None = None,
+    num_devices: int | None = 4,
     use_inputs_embeds: bool = None,
 ):
     if from_transformers:

--- a/examples/text2text-generation/run_llama_text2text_generation.py
+++ b/examples/text2text-generation/run_llama_text2text_generation.py
@@ -1,5 +1,4 @@
 import os
-import typing
 
 import fire
 from transformers import AutoTokenizer
@@ -11,8 +10,8 @@ def main(
     model_id: str = "meta-llama/Llama-2-7b-chat-hf",
     batch_size: int = 1,
     from_transformers: bool = False,
-    max_seq_len: typing.Optional[int] = None,
-    num_devices: typing.Optional[int] = 4,
+    max_seq_len: int | None = None,
+    num_devices: int | None = 4,
 ):
     # Example input sentences for the model
     sentences = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,8 +138,8 @@ line-length = 119
 
 [tool.ruff.lint]
 # Never enforce `E501` (line length violations).
-ignore = ["C901", "E501", "E741", "W605"]
-select = ["C", "E", "F", "I", "W", "B"]
+ignore = ["C901", "E501", "E741", "W605", "UP037"]
+select = ["C", "E", "F", "I", "W", "B", "UP"]
 
 [tool.ruff.lint.isort]
 lines-after-imports = 2

--- a/src/optimum/rbln/cli.py
+++ b/src/optimum/rbln/cli.py
@@ -18,7 +18,6 @@ import inspect
 import json
 import sys
 from pathlib import Path
-from typing import Optional
 
 from huggingface_hub import hf_hub_download
 
@@ -325,12 +324,12 @@ def _read_json_from_model_id(
     model_id: str,
     filename: str,
     *,
-    hf_token: Optional[str] = None,
-    hf_revision: Optional[str] = None,
-    hf_cache_dir: Optional[str] = None,
+    hf_token: str | None = None,
+    hf_revision: str | None = None,
+    hf_cache_dir: str | None = None,
     hf_force_download: bool = False,
     hf_local_files_only: bool = False,
-) -> Optional[dict]:
+) -> dict | None:
     """Read a JSON file (e.g., config.json or model_index.json) from a local path or the HuggingFace Hub.
 
     Args:
@@ -375,12 +374,12 @@ def _read_json_from_model_id(
 def _infer_rbln_class_from_model_id(
     model_id: str,
     *,
-    hf_token: Optional[str] = None,
-    hf_revision: Optional[str] = None,
-    hf_cache_dir: Optional[str] = None,
+    hf_token: str | None = None,
+    hf_revision: str | None = None,
+    hf_cache_dir: str | None = None,
     hf_force_download: bool = False,
     hf_local_files_only: bool = False,
-) -> Optional[str]:
+) -> str | None:
     """Infer RBLN class name from model files by prefixing discovered class with 'RBLN'.
 
     Order of precedence:
@@ -576,7 +575,7 @@ def main():
 
     try:
         # Resolve or infer model class for compilation
-        resolved_class_name: Optional[str] = args.model_class
+        resolved_class_name: str | None = args.model_class
         if not resolved_class_name:
             resolved_class_name = _infer_rbln_class_from_model_id(
                 args.model_id,

--- a/src/optimum/rbln/configuration_utils.py
+++ b/src/optimum/rbln/configuration_utils.py
@@ -17,7 +17,7 @@ import inspect
 import json
 from dataclasses import asdict, dataclass, fields
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Protocol, Tuple, Type, Union, runtime_checkable
+from typing import Any, Protocol, Union, runtime_checkable
 
 import numpy as np
 import torch
@@ -33,10 +33,10 @@ logger = get_logger(__name__)
 
 
 DEFAULT_COMPILED_MODEL_NAME = "compiled_model"
-TypeInputInfo = List[Tuple[str, Tuple[int], str]]
+TypeInputInfo = list[tuple[str, tuple[int], str]]
 
 
-def nested_update(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+def nested_update(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
     """
     Recursively merge override dict into base dict.
     For nested dicts, values are merged recursively instead of being replaced.
@@ -62,7 +62,7 @@ def nested_update(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, A
 
 @runtime_checkable
 class RBLNSerializableConfigProtocol(Protocol):
-    def _prepare_for_serialization(self) -> Dict[str, Any]: ...
+    def _prepare_for_serialization(self) -> dict[str, Any]: ...
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self._prepare_for_serialization()})"
@@ -81,12 +81,12 @@ class RBLNCompileConfig:
     """
 
     compiled_model_name: str = DEFAULT_COMPILED_MODEL_NAME
-    input_info: Union[List[TypeInputInfo], TypeInputInfo] = None
-    npu: Optional[str] = None
-    num_devices: Optional[int] = None
+    input_info: list[TypeInputInfo] | TypeInputInfo = None
+    npu: str | None = None
+    num_devices: int | None = None
 
     @staticmethod
-    def normalize_dtype(dtype: Union[str, torch.dtype, np.dtype]) -> str:
+    def normalize_dtype(dtype: str | torch.dtype | np.dtype) -> str:
         """
         Convert framework-specific dtype to string representation.
         i.e. torch.float32 -> "float32"
@@ -133,7 +133,7 @@ class RBLNCompileConfig:
         else:
             self.input_info = normalize_input_info(self.input_info)
 
-    def update(self, kwargs: Dict[str, Any]):
+    def update(self, kwargs: dict[str, Any]):
         self.compiled_model_name = kwargs.get("compiled_model_name", self.compiled_model_name)
         self.input_info = kwargs.get("input_info", self.input_info)
         self.npu = kwargs.get("npu", self.npu)
@@ -143,8 +143,8 @@ class RBLNCompileConfig:
     def get_dummy_inputs(
         self,
         fill=0,
-        static_tensors: Optional[Dict[str, torch.Tensor]] = None,
-        meta_tensor_names: Optional[List[str]] = None,
+        static_tensors: dict[str, torch.Tensor] | None = None,
+        meta_tensor_names: list[str] | None = None,
     ):
         dummy = []
         static_tensors = static_tensors if static_tensors is not None else {}
@@ -175,10 +175,10 @@ class RBLNCompileConfig:
 
 
 RUNTIME_KEYWORDS = ["create_runtimes", "device", "device_map", "activate_profiler", "timeout"]
-CONFIG_MAPPING: Dict[str, Type["RBLNModelConfig"]] = {}
+CONFIG_MAPPING: dict[str, type["RBLNModelConfig"]] = {}
 
 
-def get_rbln_config_class(rbln_config_class_name: str) -> Type["RBLNModelConfig"]:
+def get_rbln_config_class(rbln_config_class_name: str) -> type["RBLNModelConfig"]:
     cls = getattr(importlib.import_module("optimum.rbln"), rbln_config_class_name, None)
     if cls is None:
         if rbln_config_class_name in CONFIG_MAPPING:
@@ -188,12 +188,12 @@ def get_rbln_config_class(rbln_config_class_name: str) -> Type["RBLNModelConfig"
     return cls
 
 
-def load_config(path: str) -> Tuple[Type["RBLNModelConfig"], Dict[str, Any]]:
+def load_config(path: str) -> tuple[type["RBLNModelConfig"], dict[str, Any]]:
     path = Path(path)
     if path.is_dir():
         path = path / "rbln_config.json"
 
-    with open(path, "r") as jsonf:
+    with open(path) as jsonf:
         config_file = json.load(jsonf)
 
     if "_meta" in config_file:
@@ -227,7 +227,7 @@ class RBLNAutoConfig:
         return cls(**kwargs)
 
     @staticmethod
-    def load_from_dict(config_dict: Dict[str, Any]) -> "RBLNModelConfig":
+    def load_from_dict(config_dict: dict[str, Any]) -> "RBLNModelConfig":
         """
         Build a `RBLNModelConfig` from a plain dictionary.
 
@@ -261,7 +261,7 @@ class RBLNAutoConfig:
         return cls(**config_dict)
 
     @staticmethod
-    def register(config: Type["RBLNModelConfig"], exist_ok=False):
+    def register(config: type["RBLNModelConfig"], exist_ok=False):
         """
         Register a new configuration for this class.
 
@@ -283,10 +283,10 @@ class RBLNAutoConfig:
     def from_pretrained(
         cls,
         path: str,
-        rbln_config: Optional[Union[Dict[str, Any], "RBLNModelConfig"]] = None,
+        rbln_config: Union[dict[str, Any], "RBLNModelConfig"] | None = None,
         return_unused_kwargs: bool = False,
-        **kwargs: Optional[Dict[str, Any]],
-    ) -> Union["RBLNModelConfig", Tuple["RBLNModelConfig", Dict[str, Any]]]:
+        **kwargs: dict[str, Any] | None,
+    ) -> Union["RBLNModelConfig", tuple["RBLNModelConfig", dict[str, Any]]]:
         """
         Load RBLNModelConfig from a path.
         Class name is automatically inferred from the `rbln_config.json` file.
@@ -315,10 +315,10 @@ class RBLNAutoConfig:
     def load(
         cls,
         path: str,
-        rbln_config: Optional[Union[Dict[str, Any], "RBLNModelConfig"]] = None,
+        rbln_config: Union[dict[str, Any], "RBLNModelConfig"] | None = None,
         return_unused_kwargs: bool = False,
-        **kwargs: Optional[Dict[str, Any]],
-    ) -> Union["RBLNModelConfig", Tuple["RBLNModelConfig", Dict[str, Any]]]:
+        **kwargs: dict[str, Any] | None,
+    ) -> Union["RBLNModelConfig", tuple["RBLNModelConfig", dict[str, Any]]]:
         """
         Load RBLNModelConfig from a path.
         Class name is automatically inferred from the `rbln_config.json` file.
@@ -562,13 +562,13 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
         "activate_profiler",
         "timeout",
     ]
-    submodules: List[str] = []
+    submodules: list[str] = []
     subclass_non_save_attributes = []
     _allow_no_compile_cfgs = False
 
     def initialize_submodule_config(
         self,
-        submodule_config: Optional[Union[Dict[str, Any], "RBLNModelConfig"]] = None,
+        submodule_config: Union[dict[str, Any], "RBLNModelConfig"] | None = None,
         force_kwargs: bool = False,
         **kwargs: Any,
     ) -> "RBLNModelConfig":
@@ -620,7 +620,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
 
         return submodule_config
 
-    def filter_parameters(self, config_cls: Type["RBLNModelConfig"], parameters: Dict[str, Any]) -> Dict[str, Any]:
+    def filter_parameters(self, config_cls: type["RBLNModelConfig"], parameters: dict[str, Any]) -> dict[str, Any]:
         import importlib
 
         model_cls_name = config_cls.__name__.replace("Config", "")
@@ -701,19 +701,19 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
     )
     def __init__(
         self,
-        cls_name: Optional[str] = None,
-        create_runtimes: Optional[bool] = None,
-        device: Optional[Union[int, List[int]]] = None,
-        device_map: Optional[Dict[str, Union[int, List[int]]]] = None,
-        activate_profiler: Optional[bool] = None,
-        npu: Optional[str] = None,
-        num_devices: Optional[int] = None,
-        timeout: Optional[int] = None,
-        optimum_rbln_version: Optional[str] = None,
-        dtype: Optional[Union[str, torch.dtype]] = None,
-        _compile_cfgs: Optional[List[RBLNCompileConfig]] = None,
+        cls_name: str | None = None,
+        create_runtimes: bool | None = None,
+        device: int | list[int] | None = None,
+        device_map: dict[str, int | list[int]] | None = None,
+        activate_profiler: bool | None = None,
+        npu: str | None = None,
+        num_devices: int | None = None,
+        timeout: int | None = None,
+        optimum_rbln_version: str | None = None,
+        dtype: str | torch.dtype | None = None,
+        _compile_cfgs: list[RBLNCompileConfig] | None = None,
         *,
-        optimize_host_memory: Optional[bool] = None,
+        optimize_host_memory: bool | None = None,
         **kwargs: Any,
     ):
         """
@@ -767,7 +767,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
             self.optimum_rbln_version = __version__
 
         compile_cfgs = _compile_cfgs if _compile_cfgs is not None else []
-        self._compile_cfgs: List[RBLNCompileConfig] = compile_cfgs
+        self._compile_cfgs: list[RBLNCompileConfig] = compile_cfgs
 
         if not isinstance(self._compile_cfgs, list):
             raise ValueError("`compile_cfgs` must be a list of `RBLNCompileConfig`.")
@@ -804,7 +804,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
         return self.dtype
 
     @torch_dtype.setter
-    def torch_dtype(self, torch_dtype: Union[str, torch.dtype]):
+    def torch_dtype(self, torch_dtype: str | torch.dtype):
         logger.warning_once("`torch_dtype` is deprecated. Use `dtype` instead.")
         self.dtype = torch_dtype
 
@@ -813,7 +813,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
         return getattr(torch, self._dtype)
 
     @dtype.setter
-    def dtype(self, dtype: Union[str, torch.dtype]):
+    def dtype(self, dtype: str | torch.dtype):
         if isinstance(dtype, torch.dtype):
             dtype = RBLNCompileConfig.normalize_dtype(dtype)
 
@@ -824,7 +824,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
         return self.__class__.__name__[:-6]
 
     @property
-    def rbln_model_cls(self) -> Type:
+    def rbln_model_cls(self) -> type:
         rbln_model_cls = getattr(importlib.import_module("optimum.rbln"), self.rbln_model_cls_name, None)
         if rbln_model_cls is None:
             raise ValueError(
@@ -833,7 +833,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
             )
         return rbln_model_cls
 
-    def _prepare_for_serialization(self) -> Dict[str, Any]:
+    def _prepare_for_serialization(self) -> dict[str, Any]:
         # Prepare the attributes map for serialization by converting nested RBLNModelConfig
         # objects to their serializable form.
         serializable_map = {}
@@ -861,10 +861,10 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
         return self._compile_cfgs
 
     @compile_cfgs.setter
-    def compile_cfgs(self, compile_cfgs: List[RBLNCompileConfig]):
+    def compile_cfgs(self, compile_cfgs: list[RBLNCompileConfig]):
         raise RuntimeError("`compile_cfgs` cannot be set directly. Please use `set_compile_cfgs` instead.")
 
-    def set_compile_cfgs(self, compile_cfgs: List[RBLNCompileConfig]):
+    def set_compile_cfgs(self, compile_cfgs: list[RBLNCompileConfig]):
         if not isinstance(compile_cfgs, list):
             raise ValueError("`compile_cfgs` must be a list of `RBLNCompileConfig`.")
         if len(compile_cfgs) == 0:
@@ -916,10 +916,10 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
     def from_pretrained(
         cls,
         path: str,
-        rbln_config: Optional[Union[Dict[str, Any], "RBLNModelConfig"]] = None,
+        rbln_config: Union[dict[str, Any], "RBLNModelConfig"] | None = None,
         return_unused_kwargs: bool = False,
-        **kwargs: Optional[Dict[str, Any]],
-    ) -> Union["RBLNModelConfig", Tuple["RBLNModelConfig", Dict[str, Any]]]:
+        **kwargs: dict[str, Any] | None,
+    ) -> Union["RBLNModelConfig", tuple["RBLNModelConfig", dict[str, Any]]]:
         """
         Load a RBLNModelConfig from a path.
 
@@ -1008,10 +1008,10 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
     def load(
         cls,
         path: str,
-        rbln_config: Optional[Union[Dict[str, Any], "RBLNModelConfig"]] = None,
+        rbln_config: Union[dict[str, Any], "RBLNModelConfig"] | None = None,
         return_unused_kwargs: bool = False,
-        **kwargs: Optional[Dict[str, Any]],
-    ) -> Union["RBLNModelConfig", Tuple["RBLNModelConfig", Dict[str, Any]]]:
+        **kwargs: dict[str, Any] | None,
+    ) -> Union["RBLNModelConfig", tuple["RBLNModelConfig", dict[str, Any]]]:
         """
         Load a RBLNModelConfig from a path.
 
@@ -1047,10 +1047,10 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
 
     @classmethod
     def initialize_from_kwargs(
-        cls: Type["RBLNModelConfig"],
-        rbln_config: Optional[Union[Dict[str, Any], "RBLNModelConfig"]] = None,
+        cls: type["RBLNModelConfig"],
+        rbln_config: Union[dict[str, Any], "RBLNModelConfig"] | None = None,
         **kwargs: Any,
-    ) -> Tuple["RBLNModelConfig", Dict[str, Any]]:
+    ) -> tuple["RBLNModelConfig", dict[str, Any]]:
         # Initialize RBLNModelConfig from kwargs.
         kwargs_keys = list(kwargs.keys())
         rbln_kwargs = {key[5:]: kwargs.pop(key) for key in kwargs_keys if key.startswith("rbln_")}
@@ -1068,7 +1068,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
 
         return rbln_config, kwargs
 
-    def get_default_values_for_original_cls(self, func_name: str, keys: List[str]) -> Dict[str, Any]:
+    def get_default_values_for_original_cls(self, func_name: str, keys: list[str]) -> dict[str, Any]:
         # Get default values for original class attributes from RBLNModelConfig.
         model_cls = self.rbln_model_cls.get_hf_class()
         func = getattr(model_cls, func_name)
@@ -1102,7 +1102,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
         return self._runtime_options["device"]
 
     @device.setter
-    def device(self, device: Union[int, List[int]]):
+    def device(self, device: int | list[int]):
         self._runtime_options["device"] = device
 
     @property
@@ -1119,7 +1119,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
         return self._runtime_options["device_map"]
 
     @device_map.setter
-    def device_map(self, device_map: Dict[str, Union[int, List[int]]]):
+    def device_map(self, device_map: dict[str, int | list[int]]):
         self._runtime_options["device_map"] = device_map
 
     @property
@@ -1146,8 +1146,8 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
 
 
 def convert_rbln_config_dict(
-    rbln_config: Optional[Union[Dict[str, Any], RBLNModelConfig]] = None, **kwargs
-) -> Tuple[Optional[Union[Dict[str, Any], RBLNModelConfig]], Dict[str, Any]]:
+    rbln_config: dict[str, Any] | RBLNModelConfig | None = None, **kwargs
+) -> tuple[dict[str, Any] | RBLNModelConfig | None, dict[str, Any]]:
     # Validate and merge rbln_ prefixed kwargs into rbln_config
     kwargs_keys = list(kwargs.keys())
     rbln_kwargs = {key[5:]: kwargs.pop(key) for key in kwargs_keys if key.startswith("rbln_")}

--- a/src/optimum/rbln/configuration_utils.py
+++ b/src/optimum/rbln/configuration_utils.py
@@ -75,9 +75,9 @@ class RBLNCompileConfig:
 
     Attributes:
         compiled_model_name (str): Name of the compiled model.
-        input_info (Union[List[TypeInputInfo], TypeInputInfo]): Information about input tensors.
-        npu (Optional[str]): NPU configuration.
-        num_devices (Optional[int]): Number of devices to distribute the model across.
+        input_info (list[TypeInputInfo] | TypeInputInfo): Information about input tensors.
+        npu (str | None): NPU configuration.
+        num_devices (int | None): Number of devices to distribute the model across.
     """
 
     compiled_model_name: str = DEFAULT_COMPILED_MODEL_NAME
@@ -293,7 +293,7 @@ class RBLNAutoConfig:
 
         Args:
             path (str): Path to the RBLNModelConfig.
-            rbln_config (Optional[Dict[str, Any]]): Additional configuration to override.
+            rbln_config (dict[str, Any] | None): Additional configuration to override.
             return_unused_kwargs (bool): Whether to return unused kwargs.
             kwargs: Additional keyword arguments to override configuration values.
 
@@ -329,7 +329,7 @@ class RBLNAutoConfig:
 
         Args:
             path (str): Path to the RBLNModelConfig file or directory.
-            rbln_config (Optional[Dict[str, Any]]): Additional configuration to override.
+            rbln_config (dict[str, Any] | None): Additional configuration to override.
             return_unused_kwargs (bool): Whether to return unused kwargs.
             kwargs: Additional keyword arguments to override configuration values.
 
@@ -720,17 +720,17 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
         Initialize a RBLN model configuration with runtime options and compile configurations.
 
         Args:
-            cls_name (Optional[str]): The class name of the configuration. Defaults to the current class name.
-            create_runtimes (Optional[bool]): Whether to create RBLN runtimes. Defaults to True.
-            device (Optional[Union[int, List[int]]]): The device(s) to load the model onto. Can be a single device ID or a list.
-            device_map (Optional[Dict[str, Union[int, List[int]]]]): Mapping from compiled model names to device IDs.
-            activate_profiler (Optional[bool]): Whether to activate the profiler for performance analysis.
-            npu (Optional[str]): The NPU device name to use for compilation.
-            num_devices (Optional[int]): Number of devices to distribute the model across.
-            timeout (Optional[int]): The timeout for the runtime in seconds. If it isn't provided, it will be set to 60 by default.
-            optimum_rbln_version (Optional[str]): The optimum-rbln version used for this configuration.
-            dtype (Optional[Union[str, torch.dtype]]): The data type to use for the model.
-            _compile_cfgs (List[RBLNCompileConfig]): List of compilation configurations for the model.
+            cls_name (str | None): The class name of the configuration. Defaults to the current class name.
+            create_runtimes (bool | None): Whether to create RBLN runtimes. Defaults to True.
+            device (int | list[int] | None): The device(s) to load the model onto. Can be a single device ID or a list.
+            device_map (dict[str, int | list[int]] | None): Mapping from compiled model names to device IDs.
+            activate_profiler (bool | None): Whether to activate the profiler for performance analysis.
+            npu (str | None): The NPU device name to use for compilation.
+            num_devices (int | None): Number of devices to distribute the model across.
+            timeout (int | None): The timeout for the runtime in seconds. If it isn't provided, it will be set to 60 by default.
+            optimum_rbln_version (str | None): The optimum-rbln version used for this configuration.
+            dtype (str | torch.dtype | None): The data type to use for the model.
+            _compile_cfgs (list[RBLNCompileConfig]): List of compilation configurations for the model.
             kwargs: Additional keyword arguments.
 
         Raises:
@@ -925,7 +925,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
 
         Args:
             path (str): Path to the RBLNModelConfig file or directory containing the config file.
-            rbln_config (Optional[Dict[str, Any]]): Additional configuration to override.
+            rbln_config (dict[str, Any] | None): Additional configuration to override.
             return_unused_kwargs (bool): Whether to return unused kwargs.
             kwargs: Additional keyword arguments to override configuration values.
                     Keys starting with 'rbln_' will have the prefix removed and be used
@@ -1021,7 +1021,7 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
 
         Args:
             path (str): Path to the RBLNModelConfig file or directory containing the config file.
-            rbln_config (Optional[Dict[str, Any]]): Additional configuration to override.
+            rbln_config (dict[str, Any] | None): Additional configuration to override.
             return_unused_kwargs (bool): Whether to return unused kwargs.
             kwargs: Additional keyword arguments to override configuration values.
                     Keys starting with 'rbln_' will have the prefix removed and be used

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_autoencoder_kl.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_autoencoder_kl.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Tuple
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 
@@ -27,12 +27,12 @@ class RBLNAutoencoderKLConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        sample_size: Optional[Tuple[int, int]] = None,
-        uses_encoder: Optional[bool] = None,
-        vae_scale_factor: Optional[float] = None,  # TODO: rename to scaling_factor
-        in_channels: Optional[int] = None,
-        latent_channels: Optional[int] = None,
+        batch_size: int | None = None,
+        sample_size: tuple[int, int] | None = None,
+        uses_encoder: bool | None = None,
+        vae_scale_factor: float | None = None,  # TODO: rename to scaling_factor
+        in_channels: int | None = None,
+        latent_channels: int | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_autoencoder_kl.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_autoencoder_kl.py
@@ -37,15 +37,15 @@ class RBLNAutoencoderKLConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            sample_size (Optional[Tuple[int, int]]): The spatial dimensions (height, width) of the input/output images.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            sample_size (tuple[int, int] | None): The spatial dimensions (height, width) of the input/output images.
                 If an integer is provided, it's used for both height and width.
-            uses_encoder (Optional[bool]): Whether to include the encoder part of the VAE in the model.
+            uses_encoder (bool | None): Whether to include the encoder part of the VAE in the model.
                 When False, only the decoder is used (for latent-to-image conversion).
-            vae_scale_factor (Optional[float]): The scaling factor between pixel space and latent space.
+            vae_scale_factor (float | None): The scaling factor between pixel space and latent space.
                 Determines how much smaller the latent representations are compared to the original images.
-            in_channels (Optional[int]): Number of input channels for the model.
-            latent_channels (Optional[int]): Number of channels in the latent space.
+            in_channels (int | None): Number of input channels for the model.
+            latent_channels (int | None): Number of channels in the latent space.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_autoencoder_kl_cosmos.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_autoencoder_kl_cosmos.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....utils.logging import get_logger
@@ -26,16 +26,16 @@ class RBLNAutoencoderKLCosmosConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        uses_encoder: Optional[bool] = None,
-        num_frames: Optional[int] = None,
-        height: Optional[int] = None,
-        width: Optional[int] = None,
-        num_channels_latents: Optional[int] = None,
-        vae_scale_factor_temporal: Optional[int] = None,
-        vae_scale_factor_spatial: Optional[int] = None,
-        use_slicing: Optional[bool] = None,
-        **kwargs: Dict[str, Any],
+        batch_size: int | None = None,
+        uses_encoder: bool | None = None,
+        num_frames: int | None = None,
+        height: int | None = None,
+        width: int | None = None,
+        num_channels_latents: int | None = None,
+        vae_scale_factor_temporal: int | None = None,
+        vae_scale_factor_spatial: int | None = None,
+        use_slicing: bool | None = None,
+        **kwargs: dict[str, Any],
     ):
         """
         Args:

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_autoencoder_kl_cosmos.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_autoencoder_kl_cosmos.py
@@ -39,18 +39,18 @@ class RBLNAutoencoderKLCosmosConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            uses_encoder (Optional[bool]): Whether to include the encoder part of the VAE in the model.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            uses_encoder (bool | None): Whether to include the encoder part of the VAE in the model.
                 When False, only the decoder is used (for latent-to-video conversion).
-            num_frames (Optional[int]): The number of frames in the generated video. Defaults to 121.
-            height (Optional[int]): The height in pixels of the generated video. Defaults to 704.
-            width (Optional[int]): The width in pixels of the generated video. Defaults to 1280.
-            num_channels_latents (Optional[int]): The number of channels in latent space.
-            vae_scale_factor_temporal (Optional[int]): The scaling factor between time space and latent space.
+            num_frames (int | None): The number of frames in the generated video. Defaults to 121.
+            height (int | None): The height in pixels of the generated video. Defaults to 704.
+            width (int | None): The width in pixels of the generated video. Defaults to 1280.
+            num_channels_latents (int | None): The number of channels in latent space.
+            vae_scale_factor_temporal (int | None): The scaling factor between time space and latent space.
                 Determines how much shorter the latent representations are compared to the original videos.
-            vae_scale_factor_spatial (Optional[int]): The scaling factor between pixel space and latent space.
+            vae_scale_factor_spatial (int | None): The scaling factor between pixel space and latent space.
                 Determines how much smaller the latent representations are compared to the original videos.
-            use_slicing (Optional[bool]): Enable sliced VAE encoding and decoding.
+            use_slicing (bool | None): Enable sliced VAE encoding and decoding.
                 If True, the VAE will split the input tensor in slices to compute encoding or decoding in several steps.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_autoencoder_kl_temporal_decoder.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_autoencoder_kl_temporal_decoder.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Tuple
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 
@@ -20,12 +20,12 @@ from ....configuration_utils import RBLNModelConfig
 class RBLNAutoencoderKLTemporalDecoderConfig(RBLNModelConfig):
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        sample_size: Optional[Tuple[int, int]] = None,
-        uses_encoder: Optional[bool] = None,
-        num_frames: Optional[int] = None,
-        decode_chunk_size: Optional[int] = None,
-        vae_scale_factor: Optional[float] = None,
+        batch_size: int | None = None,
+        sample_size: tuple[int, int] | None = None,
+        uses_encoder: bool | None = None,
+        num_frames: int | None = None,
+        decode_chunk_size: int | None = None,
+        vae_scale_factor: float | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_autoencoder_kl_temporal_decoder.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_autoencoder_kl_temporal_decoder.py
@@ -30,15 +30,15 @@ class RBLNAutoencoderKLTemporalDecoderConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            sample_size (Optional[Tuple[int, int]]): The spatial dimensions (height, width) of the input/output images.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            sample_size (tuple[int, int] | None): The spatial dimensions (height, width) of the input/output images.
                 If an integer is provided, it's used for both height and width.
-            uses_encoder (Optional[bool]): Whether to include the encoder part of the VAE in the model.
+            uses_encoder (bool | None): Whether to include the encoder part of the VAE in the model.
                 When False, only the decoder is used (for latent-to-image conversion).
-            num_frames (Optional[int]): The number of frames in the generated video.
-            decode_chunk_size (Optional[int]): The number of frames to decode at once during VAE decoding.
+            num_frames (int | None): The number of frames in the generated video.
+            decode_chunk_size (int | None): The number of frames to decode at once during VAE decoding.
                 Useful for managing memory usage during video generation.
-            vae_scale_factor (Optional[float]): The scaling factor between pixel space and latent space.
+            vae_scale_factor (float | None): The scaling factor between pixel space and latent space.
                 Determines how much smaller the latent representations are compared to the original images.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_controlnet.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_controlnet.py
@@ -33,14 +33,14 @@ class RBLNControlNetModelConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            max_seq_len (Optional[int]): Maximum sequence length for text inputs when used
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            max_seq_len (int | None): Maximum sequence length for text inputs when used
                 with cross-attention.
-            unet_sample_size (Optional[Tuple[int, int]]): The spatial dimensions (height, width)
+            unet_sample_size (tuple[int, int] | None): The spatial dimensions (height, width)
                 of the UNet output samples.
-            vae_sample_size (Optional[Tuple[int, int]]): The spatial dimensions (height, width)
+            vae_sample_size (tuple[int, int] | None): The spatial dimensions (height, width)
                 of the VAE input/output images.
-            text_model_hidden_size (Optional[int]): Hidden size of the text encoder model used
+            text_model_hidden_size (int | None): Hidden size of the text encoder model used
                 for conditioning.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_controlnet.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_controlnet.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Tuple
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 
@@ -24,11 +24,11 @@ class RBLNControlNetModelConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        max_seq_len: Optional[int] = None,
-        unet_sample_size: Optional[Tuple[int, int]] = None,
-        vae_sample_size: Optional[Tuple[int, int]] = None,
-        text_model_hidden_size: Optional[int] = None,
+        batch_size: int | None = None,
+        max_seq_len: int | None = None,
+        unet_sample_size: tuple[int, int] | None = None,
+        vae_sample_size: tuple[int, int] | None = None,
+        text_model_hidden_size: int | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_prior_transformer.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_prior_transformer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 
@@ -29,9 +29,9 @@ class RBLNPriorTransformerConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        embedding_dim: Optional[int] = None,
-        num_embeddings: Optional[int] = None,
+        batch_size: int | None = None,
+        embedding_dim: int | None = None,
+        num_embeddings: int | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_prior_transformer.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_prior_transformer.py
@@ -36,9 +36,9 @@ class RBLNPriorTransformerConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            embedding_dim (Optional[int]): Dimension of the embedding vectors in the model.
-            num_embeddings (Optional[int]): Number of discrete embeddings in the codebook.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            embedding_dim (int | None): Dimension of the embedding vectors in the model.
+            num_embeddings (int | None): Number of discrete embeddings in the codebook.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_transformer_cosmos.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_transformer_cosmos.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 
@@ -27,17 +27,17 @@ class RBLNCosmosTransformer3DModelConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        num_frames: Optional[int] = None,
-        height: Optional[int] = None,
-        width: Optional[int] = None,
-        fps: Optional[int] = None,
-        max_seq_len: Optional[int] = None,
-        embedding_dim: Optional[int] = None,
-        num_channels_latents: Optional[int] = None,
-        num_latent_frames: Optional[int] = None,
-        latent_height: Optional[int] = None,
-        latent_width: Optional[int] = None,
+        batch_size: int | None = None,
+        num_frames: int | None = None,
+        height: int | None = None,
+        width: int | None = None,
+        fps: int | None = None,
+        max_seq_len: int | None = None,
+        embedding_dim: int | None = None,
+        num_channels_latents: int | None = None,
+        num_latent_frames: int | None = None,
+        latent_height: int | None = None,
+        latent_width: int | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_transformer_cosmos.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_transformer_cosmos.py
@@ -42,16 +42,16 @@ class RBLNCosmosTransformer3DModelConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            num_frames (Optional[int]): The number of frames in the generated video. Defaults to 121.
-            height (Optional[int]): The height in pixels of the generated video. Defaults to 704.
-            width (Optional[int]): The width in pixels of the generated video. Defaults to 1280.
-            fps (Optional[int]): The frames per second of the generated video.  Defaults to 30.
-            max_seq_len (Optional[int]): Maximum sequence length of prompt embeds.
-            embedding_dim (Optional[int]): Embedding vector dimension of prompt embeds.
-            num_channels_latents (Optional[int]): The number of channels in latent space.
-            latent_height (Optional[int]): The height in pixels in latent space.
-            latent_width (Optional[int]): The width in pixels in latent space.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            num_frames (int | None): The number of frames in the generated video. Defaults to 121.
+            height (int | None): The height in pixels of the generated video. Defaults to 704.
+            width (int | None): The width in pixels of the generated video. Defaults to 1280.
+            fps (int | None): The frames per second of the generated video.  Defaults to 30.
+            max_seq_len (int | None): Maximum sequence length of prompt embeds.
+            embedding_dim (int | None): Embedding vector dimension of prompt embeds.
+            num_channels_latents (int | None): The number of channels in latent space.
+            latent_height (int | None): The height in pixels in latent space.
+            latent_width (int | None): The width in pixels in latent space.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_transformer_sd3.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_transformer_sd3.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Tuple, Union
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 
@@ -29,9 +29,9 @@ class RBLNSD3Transformer2DModelConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        sample_size: Optional[Union[int, Tuple[int, int]]] = None,
-        prompt_embed_length: Optional[int] = None,
+        batch_size: int | None = None,
+        sample_size: int | tuple[int, int] | None = None,
+        prompt_embed_length: int | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_transformer_sd3.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_transformer_sd3.py
@@ -36,10 +36,10 @@ class RBLNSD3Transformer2DModelConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            sample_size (Optional[Union[int, Tuple[int, int]]]): The spatial dimensions (height, width)
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            sample_size (int | tuple[int, int] | None): The spatial dimensions (height, width)
                 of the generated samples. If an integer is provided, it's used for both height and width.
-            prompt_embed_length (Optional[int]): The length of the embedded prompt vectors that
+            prompt_embed_length (int | None): The length of the embedded prompt vectors that
                 will be used to condition the transformer model.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_unet_2d_condition.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_unet_2d_condition.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Tuple
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 
@@ -29,15 +29,15 @@ class RBLNUNet2DConditionModelConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        sample_size: Optional[Tuple[int, int]] = None,
-        in_channels: Optional[int] = None,
-        cross_attention_dim: Optional[int] = None,
-        use_additional_residuals: Optional[bool] = None,
-        max_seq_len: Optional[int] = None,
-        in_features: Optional[int] = None,
-        text_model_hidden_size: Optional[int] = None,
-        image_model_hidden_size: Optional[int] = None,
+        batch_size: int | None = None,
+        sample_size: tuple[int, int] | None = None,
+        in_channels: int | None = None,
+        cross_attention_dim: int | None = None,
+        use_additional_residuals: bool | None = None,
+        max_seq_len: int | None = None,
+        in_features: int | None = None,
+        text_model_hidden_size: int | None = None,
+        image_model_hidden_size: int | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_unet_2d_condition.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_unet_2d_condition.py
@@ -42,16 +42,16 @@ class RBLNUNet2DConditionModelConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            sample_size (Optional[Tuple[int, int]]): The spatial dimensions (height, width) of the generated samples.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            sample_size (tuple[int, int] | None): The spatial dimensions (height, width) of the generated samples.
                 If an integer is provided, it's used for both height and width.
-            in_channels (Optional[int]): Number of input channels for the UNet.
-            cross_attention_dim (Optional[int]): Dimension of the cross-attention features.
-            use_additional_residuals (Optional[bool]): Whether to use additional residual connections in the model.
-            max_seq_len (Optional[int]): Maximum sequence length for text inputs when used with cross-attention.
-            in_features (Optional[int]): Number of input features for the model.
-            text_model_hidden_size (Optional[int]): Hidden size of the text encoder model.
-            image_model_hidden_size (Optional[int]): Hidden size of the image encoder model.
+            in_channels (int | None): Number of input channels for the UNet.
+            cross_attention_dim (int | None): Dimension of the cross-attention features.
+            use_additional_residuals (bool | None): Whether to use additional residual connections in the model.
+            max_seq_len (int | None): Maximum sequence length for text inputs when used with cross-attention.
+            in_features (int | None): Number of input features for the model.
+            text_model_hidden_size (int | None): Hidden size of the text encoder model.
+            image_model_hidden_size (int | None): Hidden size of the image encoder model.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_unet_spatio_temporal_condition.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_unet_spatio_temporal_condition.py
@@ -30,11 +30,11 @@ class RBLNUNetSpatioTemporalConditionModelConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            sample_size (Optional[Tuple[int, int]]): The spatial dimensions (height, width) of the generated samples.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            sample_size (tuple[int, int] | None): The spatial dimensions (height, width) of the generated samples.
                 If an integer is provided, it's used for both height and width.
-            in_features (Optional[int]): Number of input features for the model.
-            num_frames (Optional[int]): The number of frames in the generated video.
+            in_features (int | None): Number of input features for the model.
+            num_frames (int | None): The number of frames in the generated video.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_unet_spatio_temporal_condition.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_unet_spatio_temporal_condition.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Tuple
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 
@@ -22,10 +22,10 @@ class RBLNUNetSpatioTemporalConditionModelConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        sample_size: Optional[Tuple[int, int]] = None,
-        in_features: Optional[int] = None,
-        num_frames: Optional[int] = None,
+        batch_size: int | None = None,
+        sample_size: tuple[int, int] | None = None,
+        in_features: int | None = None,
+        num_frames: int | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_vq_model.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_vq_model.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Tuple
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 
@@ -27,12 +27,12 @@ class RBLNVQModelConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        sample_size: Optional[Tuple[int, int]] = None,
-        uses_encoder: Optional[bool] = None,
-        vqmodel_scale_factor: Optional[float] = None,  # TODO: rename to scaling_factor
-        in_channels: Optional[int] = None,
-        latent_channels: Optional[int] = None,
+        batch_size: int | None = None,
+        sample_size: tuple[int, int] | None = None,
+        uses_encoder: bool | None = None,
+        vqmodel_scale_factor: float | None = None,  # TODO: rename to scaling_factor
+        in_channels: int | None = None,
+        latent_channels: int | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/diffusers/configurations/models/configuration_vq_model.py
+++ b/src/optimum/rbln/diffusers/configurations/models/configuration_vq_model.py
@@ -37,15 +37,15 @@ class RBLNVQModelConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            sample_size (Optional[Tuple[int, int]]): The spatial dimensions (height, width) of the input/output images.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            sample_size (tuple[int, int] | None): The spatial dimensions (height, width) of the input/output images.
                 If an integer is provided, it's used for both height and width.
-            uses_encoder (Optional[bool]): Whether to include the encoder part of the VAE in the model.
+            uses_encoder (bool | None): Whether to include the encoder part of the VAE in the model.
                 When False, only the decoder is used (for latent-to-image conversion).
-            vqmodel_scale_factor (Optional[float]): The scaling factor between pixel space and latent space.
+            vqmodel_scale_factor (float | None): The scaling factor between pixel space and latent space.
                 Determines the downsampling ratio between original images and latent representations.
-            in_channels (Optional[int]): Number of input channels for the model.
-            latent_channels (Optional[int]): Number of channels in the latent space.
+            in_channels (int | None): Number of input channels for the model.
+            latent_channels (int | None): Number of channels in the latent space.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_controlnet.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_controlnet.py
@@ -42,23 +42,23 @@ class RBLNStableDiffusionControlNetPipelineBaseConfig(RBLNModelConfig):
     ):
         """
         Args:
-            text_encoder (Optional[RBLNCLIPTextModelConfig]): Configuration for the text encoder component.
+            text_encoder (RBLNCLIPTextModelConfig | None): Configuration for the text encoder component.
                 Initialized as RBLNCLIPTextModelConfig if not provided.
-            unet (Optional[RBLNUNet2DConditionModelConfig]): Configuration for the UNet model component.
+            unet (RBLNUNet2DConditionModelConfig | None): Configuration for the UNet model component.
                 Initialized as RBLNUNet2DConditionModelConfig if not provided.
-            vae (Optional[RBLNAutoencoderKLConfig]): Configuration for the VAE model component.
+            vae (RBLNAutoencoderKLConfig | None): Configuration for the VAE model component.
                 Initialized as RBLNAutoencoderKLConfig if not provided.
-            controlnet (Optional[RBLNControlNetModelConfig]): Configuration for the ControlNet model component.
+            controlnet (RBLNControlNetModelConfig | None): Configuration for the ControlNet model component.
                 Initialized as RBLNControlNetModelConfig if not provided.
-            batch_size (Optional[int]): Batch size for inference, applied to all submodules.
-            img_height (Optional[int]): Height of the generated images.
-            img_width (Optional[int]): Width of the generated images.
-            height (Optional[int]): Height of the generated images.
-            width (Optional[int]): Width of the generated images.
-            sample_size (Optional[Tuple[int, int]]): Spatial dimensions for the UNet model.
-            image_size (Optional[Tuple[int, int]]): Alternative way to specify image dimensions.
+            batch_size (int | None): Batch size for inference, applied to all submodules.
+            img_height (int | None): Height of the generated images.
+            img_width (int | None): Width of the generated images.
+            height (int | None): Height of the generated images.
+            width (int | None): Width of the generated images.
+            sample_size (tuple[int, int] | None): Spatial dimensions for the UNet model.
+            image_size (tuple[int, int] | None): Alternative way to specify image dimensions.
                 Cannot be used together with img_height/img_width.
-            guidance_scale (Optional[float]): Scale for classifier-free guidance.
+            guidance_scale (float | None): Scale for classifier-free guidance.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:
@@ -189,25 +189,25 @@ class RBLNStableDiffusionXLControlNetPipelineBaseConfig(RBLNModelConfig):
     ):
         """
         Args:
-            text_encoder (Optional[RBLNCLIPTextModelConfig]): Configuration for the primary text encoder.
+            text_encoder (RBLNCLIPTextModelConfig | None): Configuration for the primary text encoder.
                 Initialized as RBLNCLIPTextModelConfig if not provided.
-            text_encoder_2 (Optional[RBLNCLIPTextModelWithProjectionConfig]): Configuration for the secondary text encoder.
+            text_encoder_2 (RBLNCLIPTextModelWithProjectionConfig | None): Configuration for the secondary text encoder.
                 Initialized as RBLNCLIPTextModelWithProjectionConfig if not provided.
-            unet (Optional[RBLNUNet2DConditionModelConfig]): Configuration for the UNet model component.
+            unet (RBLNUNet2DConditionModelConfig | None): Configuration for the UNet model component.
                 Initialized as RBLNUNet2DConditionModelConfig if not provided.
-            vae (Optional[RBLNAutoencoderKLConfig]): Configuration for the VAE model component.
+            vae (RBLNAutoencoderKLConfig | None): Configuration for the VAE model component.
                 Initialized as RBLNAutoencoderKLConfig if not provided.
-            controlnet (Optional[RBLNControlNetModelConfig]): Configuration for the ControlNet model component.
+            controlnet (RBLNControlNetModelConfig | None): Configuration for the ControlNet model component.
                 Initialized as RBLNControlNetModelConfig if not provided.
-            batch_size (Optional[int]): Batch size for inference, applied to all submodules.
-            img_height (Optional[int]): Height of the generated images.
-            img_width (Optional[int]): Width of the generated images.
-            height (Optional[int]): Height of the generated images.
-            width (Optional[int]): Width of the generated images.
-            sample_size (Optional[Tuple[int, int]]): Spatial dimensions for the UNet model.
-            image_size (Optional[Tuple[int, int]]): Alternative way to specify image dimensions.
+            batch_size (int | None): Batch size for inference, applied to all submodules.
+            img_height (int | None): Height of the generated images.
+            img_width (int | None): Width of the generated images.
+            height (int | None): Height of the generated images.
+            width (int | None): Width of the generated images.
+            sample_size (tuple[int, int] | None): Spatial dimensions for the UNet model.
+            image_size (tuple[int, int] | None): Alternative way to specify image dimensions.
                 Cannot be used together with img_height/img_width.
-            guidance_scale (Optional[float]): Scale for classifier-free guidance.
+            guidance_scale (float | None): Scale for classifier-free guidance.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_controlnet.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_controlnet.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Tuple
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....transformers import RBLNCLIPTextModelConfig, RBLNCLIPTextModelWithProjectionConfig
@@ -25,19 +25,19 @@ class RBLNStableDiffusionControlNetPipelineBaseConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        text_encoder: Optional[RBLNCLIPTextModelConfig] = None,
-        unet: Optional[RBLNUNet2DConditionModelConfig] = None,
-        vae: Optional[RBLNAutoencoderKLConfig] = None,
-        controlnet: Optional[RBLNControlNetModelConfig] = None,
+        text_encoder: RBLNCLIPTextModelConfig | None = None,
+        unet: RBLNUNet2DConditionModelConfig | None = None,
+        vae: RBLNAutoencoderKLConfig | None = None,
+        controlnet: RBLNControlNetModelConfig | None = None,
         *,
-        batch_size: Optional[int] = None,
-        img_height: Optional[int] = None,
-        img_width: Optional[int] = None,
-        height: Optional[int] = None,
-        width: Optional[int] = None,
-        sample_size: Optional[Tuple[int, int]] = None,
-        image_size: Optional[Tuple[int, int]] = None,
-        guidance_scale: Optional[float] = None,
+        batch_size: int | None = None,
+        img_height: int | None = None,
+        img_width: int | None = None,
+        height: int | None = None,
+        width: int | None = None,
+        sample_size: tuple[int, int] | None = None,
+        image_size: tuple[int, int] | None = None,
+        guidance_scale: float | None = None,
         **kwargs: Any,
     ):
         """
@@ -171,20 +171,20 @@ class RBLNStableDiffusionXLControlNetPipelineBaseConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        text_encoder: Optional[RBLNCLIPTextModelConfig] = None,
-        text_encoder_2: Optional[RBLNCLIPTextModelWithProjectionConfig] = None,
-        unet: Optional[RBLNUNet2DConditionModelConfig] = None,
-        vae: Optional[RBLNAutoencoderKLConfig] = None,
-        controlnet: Optional[RBLNControlNetModelConfig] = None,
+        text_encoder: RBLNCLIPTextModelConfig | None = None,
+        text_encoder_2: RBLNCLIPTextModelWithProjectionConfig | None = None,
+        unet: RBLNUNet2DConditionModelConfig | None = None,
+        vae: RBLNAutoencoderKLConfig | None = None,
+        controlnet: RBLNControlNetModelConfig | None = None,
         *,
-        batch_size: Optional[int] = None,
-        img_height: Optional[int] = None,
-        img_width: Optional[int] = None,
-        height: Optional[int] = None,
-        width: Optional[int] = None,
-        sample_size: Optional[Tuple[int, int]] = None,
-        image_size: Optional[Tuple[int, int]] = None,
-        guidance_scale: Optional[float] = None,
+        batch_size: int | None = None,
+        img_height: int | None = None,
+        img_width: int | None = None,
+        height: int | None = None,
+        width: int | None = None,
+        sample_size: tuple[int, int] | None = None,
+        image_size: tuple[int, int] | None = None,
+        guidance_scale: float | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_cosmos.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_cosmos.py
@@ -45,20 +45,20 @@ class RBLNCosmosPipelineBaseConfig(RBLNModelConfig):
     ):
         """
         Args:
-            text_encoder (Optional[RBLNT5EncoderModelConfig]): Configuration for the text encoder component.
+            text_encoder (RBLNT5EncoderModelConfig | None): Configuration for the text encoder component.
                 Initialized as RBLNT5EncoderModelConfig if not provided.
-            transformer (Optional[RBLNCosmosTransformer3DModelConfig]): Configuration for the Transformer model component.
+            transformer (RBLNCosmosTransformer3DModelConfig | None): Configuration for the Transformer model component.
                 Initialized as RBLNCosmosTransformer3DModelConfig if not provided.
-            vae (Optional[RBLNAutoencoderKLCosmosConfig]): Configuration for the VAE model component.
+            vae (RBLNAutoencoderKLCosmosConfig | None): Configuration for the VAE model component.
                 Initialized as RBLNAutoencoderKLCosmosConfig if not provided.
-            safety_checker (Optional[RBLNCosmosSafetyCheckerConfig]): Configuration for the safety checker component.
+            safety_checker (RBLNCosmosSafetyCheckerConfig | None): Configuration for the safety checker component.
                 Initialized as RBLNCosmosSafetyCheckerConfig if not provided.
-            batch_size (Optional[int]): Batch size for inference, applied to all submodules.
-            height (Optional[int]): Height of the generated videos.
-            width (Optional[int]): Width of the generated videos.
-            num_frames (Optional[int]): The number of frames in the generated video.
-            fps (Optional[int]): The frames per second of the generated video.
-            max_seq_len (Optional[int]): Maximum sequence length supported by the model.
+            batch_size (int | None): Batch size for inference, applied to all submodules.
+            height (int | None): Height of the generated videos.
+            width (int | None): Width of the generated videos.
+            num_frames (int | None): The number of frames in the generated video.
+            fps (int | None): The frames per second of the generated video.
+            max_seq_len (int | None): Maximum sequence length supported by the model.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
         """
         super().__init__(**kwargs)

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_cosmos.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_cosmos.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....transformers import RBLNT5EncoderModelConfig
@@ -30,17 +30,17 @@ class RBLNCosmosPipelineBaseConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        text_encoder: Optional[RBLNT5EncoderModelConfig] = None,
-        transformer: Optional[RBLNCosmosTransformer3DModelConfig] = None,
-        vae: Optional[RBLNAutoencoderKLCosmosConfig] = None,
-        safety_checker: Optional[RBLNCosmosSafetyCheckerConfig] = None,
+        text_encoder: RBLNT5EncoderModelConfig | None = None,
+        transformer: RBLNCosmosTransformer3DModelConfig | None = None,
+        vae: RBLNAutoencoderKLCosmosConfig | None = None,
+        safety_checker: RBLNCosmosSafetyCheckerConfig | None = None,
         *,
-        batch_size: Optional[int] = None,
-        height: Optional[int] = None,
-        width: Optional[int] = None,
-        num_frames: Optional[int] = None,
-        fps: Optional[int] = None,
-        max_seq_len: Optional[int] = None,
+        batch_size: int | None = None,
+        height: int | None = None,
+        width: int | None = None,
+        num_frames: int | None = None,
+        fps: int | None = None,
+        max_seq_len: int | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_kandinsky2_2.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_kandinsky2_2.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Tuple
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....transformers import RBLNCLIPTextModelWithProjectionConfig, RBLNCLIPVisionModelWithProjectionConfig
@@ -26,17 +26,17 @@ class RBLNKandinskyV22PipelineBaseConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        unet: Optional[RBLNUNet2DConditionModelConfig] = None,
-        movq: Optional[RBLNVQModelConfig] = None,
+        unet: RBLNUNet2DConditionModelConfig | None = None,
+        movq: RBLNVQModelConfig | None = None,
         *,
-        sample_size: Optional[Tuple[int, int]] = None,
-        batch_size: Optional[int] = None,
-        guidance_scale: Optional[float] = None,
-        image_size: Optional[Tuple[int, int]] = None,
-        img_height: Optional[int] = None,
-        img_width: Optional[int] = None,
-        height: Optional[int] = None,
-        width: Optional[int] = None,
+        sample_size: tuple[int, int] | None = None,
+        batch_size: int | None = None,
+        guidance_scale: float | None = None,
+        image_size: tuple[int, int] | None = None,
+        img_height: int | None = None,
+        img_width: int | None = None,
+        height: int | None = None,
+        width: int | None = None,
         **kwargs: Any,
     ):
         """
@@ -146,12 +146,12 @@ class RBLNKandinskyV22PriorPipelineConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        text_encoder: Optional[RBLNCLIPTextModelWithProjectionConfig] = None,
-        image_encoder: Optional[RBLNCLIPVisionModelWithProjectionConfig] = None,
-        prior: Optional[RBLNPriorTransformerConfig] = None,
+        text_encoder: RBLNCLIPTextModelWithProjectionConfig | None = None,
+        image_encoder: RBLNCLIPVisionModelWithProjectionConfig | None = None,
+        prior: RBLNPriorTransformerConfig | None = None,
         *,
-        batch_size: Optional[int] = None,
-        guidance_scale: Optional[float] = None,
+        batch_size: int | None = None,
+        guidance_scale: float | None = None,
         **kwargs: Any,
     ):
         """
@@ -220,22 +220,22 @@ class RBLNKandinskyV22CombinedPipelineBaseConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        prior_pipe: Optional[RBLNKandinskyV22PriorPipelineConfig] = None,
-        decoder_pipe: Optional[RBLNKandinskyV22PipelineConfig] = None,
+        prior_pipe: RBLNKandinskyV22PriorPipelineConfig | None = None,
+        decoder_pipe: RBLNKandinskyV22PipelineConfig | None = None,
         *,
-        sample_size: Optional[Tuple[int, int]] = None,
-        image_size: Optional[Tuple[int, int]] = None,
-        batch_size: Optional[int] = None,
-        img_height: Optional[int] = None,
-        img_width: Optional[int] = None,
-        height: Optional[int] = None,
-        width: Optional[int] = None,
-        guidance_scale: Optional[float] = None,
-        prior_prior: Optional[RBLNPriorTransformerConfig] = None,
-        prior_image_encoder: Optional[RBLNCLIPVisionModelWithProjectionConfig] = None,
-        prior_text_encoder: Optional[RBLNCLIPTextModelWithProjectionConfig] = None,
-        unet: Optional[RBLNUNet2DConditionModelConfig] = None,
-        movq: Optional[RBLNVQModelConfig] = None,
+        sample_size: tuple[int, int] | None = None,
+        image_size: tuple[int, int] | None = None,
+        batch_size: int | None = None,
+        img_height: int | None = None,
+        img_width: int | None = None,
+        height: int | None = None,
+        width: int | None = None,
+        guidance_scale: float | None = None,
+        prior_prior: RBLNPriorTransformerConfig | None = None,
+        prior_image_encoder: RBLNCLIPVisionModelWithProjectionConfig | None = None,
+        prior_text_encoder: RBLNCLIPTextModelWithProjectionConfig | None = None,
+        unet: RBLNUNet2DConditionModelConfig | None = None,
+        movq: RBLNVQModelConfig | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_kandinsky2_2.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_kandinsky2_2.py
@@ -41,19 +41,19 @@ class RBLNKandinskyV22PipelineBaseConfig(RBLNModelConfig):
     ):
         """
         Args:
-            unet (Optional[RBLNUNet2DConditionModelConfig]): Configuration for the UNet model component.
+            unet (RBLNUNet2DConditionModelConfig | None): Configuration for the UNet model component.
                 Initialized as RBLNUNet2DConditionModelConfig if not provided.
-            movq (Optional[RBLNVQModelConfig]): Configuration for the MoVQ (VQ-GAN) model component.
+            movq (RBLNVQModelConfig | None): Configuration for the MoVQ (VQ-GAN) model component.
                 Initialized as RBLNVQModelConfig if not provided.
-            sample_size (Optional[Tuple[int, int]]): Spatial dimensions for the UNet model.
-            batch_size (Optional[int]): Batch size for inference, applied to all submodules.
-            guidance_scale (Optional[float]): Scale for classifier-free guidance.
-            image_size (Optional[Tuple[int, int]]): Dimensions for the generated images.
+            sample_size (tuple[int, int] | None): Spatial dimensions for the UNet model.
+            batch_size (int | None): Batch size for inference, applied to all submodules.
+            guidance_scale (float | None): Scale for classifier-free guidance.
+            image_size (tuple[int, int] | None): Dimensions for the generated images.
                 Cannot be used together with img_height/img_width.
-            img_height (Optional[int]): Height of the generated images.
-            img_width (Optional[int]): Width of the generated images.
-            height (Optional[int]): Height of the generated images.
-            width (Optional[int]): Width of the generated images.
+            img_height (int | None): Height of the generated images.
+            img_width (int | None): Width of the generated images.
+            height (int | None): Height of the generated images.
+            width (int | None): Width of the generated images.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:
@@ -162,14 +162,14 @@ class RBLNKandinskyV22PriorPipelineConfig(RBLNModelConfig):
         latent representations used to condition the diffusion process.
 
         Args:
-            text_encoder (Optional[RBLNCLIPTextModelWithProjectionConfig]): Configuration for the text encoder component.
+            text_encoder (RBLNCLIPTextModelWithProjectionConfig | None): Configuration for the text encoder component.
                 Initialized as RBLNCLIPTextModelWithProjectionConfig if not provided.
-            image_encoder (Optional[RBLNCLIPVisionModelWithProjectionConfig]): Configuration for the image encoder component.
+            image_encoder (RBLNCLIPVisionModelWithProjectionConfig | None): Configuration for the image encoder component.
                 Initialized as RBLNCLIPVisionModelWithProjectionConfig if not provided.
-            prior (Optional[RBLNPriorTransformerConfig]): Configuration for the prior transformer component.
+            prior (RBLNPriorTransformerConfig | None): Configuration for the prior transformer component.
                 Initialized as RBLNPriorTransformerConfig if not provided.
-            batch_size (Optional[int]): Batch size for inference, applied to all submodules.
-            guidance_scale (Optional[float]): Scale for classifier-free guidance.
+            batch_size (int | None): Batch size for inference, applied to all submodules.
+            guidance_scale (float | None): Scale for classifier-free guidance.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Note:
@@ -246,28 +246,28 @@ class RBLNKandinskyV22CombinedPipelineBaseConfig(RBLNModelConfig):
         It combines the text/image encoding, prior mapping, and diffusion steps together.
 
         Args:
-            prior_pipe (Optional[RBLNKandinskyV22PriorPipelineConfig]): Configuration for the prior pipeline.
+            prior_pipe (RBLNKandinskyV22PriorPipelineConfig | None): Configuration for the prior pipeline.
                 Initialized as RBLNKandinskyV22PriorPipelineConfig if not provided.
-            decoder_pipe (Optional[RBLNKandinskyV22PipelineConfig]): Configuration for the decoder pipeline.
+            decoder_pipe (RBLNKandinskyV22PipelineConfig | None): Configuration for the decoder pipeline.
                 Initialized as RBLNKandinskyV22PipelineConfig if not provided.
-            sample_size (Optional[Tuple[int, int]]): Spatial dimensions for the UNet model.
-            image_size (Optional[Tuple[int, int]]): Dimensions for the generated images.
+            sample_size (tuple[int, int] | None): Spatial dimensions for the UNet model.
+            image_size (tuple[int, int] | None): Dimensions for the generated images.
                 Cannot be used together with img_height/img_width.
-            batch_size (Optional[int]): Batch size for inference, applied to all submodules.
-            img_height (Optional[int]): Height of the generated images.
-            img_width (Optional[int]): Width of the generated images.
-            height (Optional[int]): Height of the generated images.
-            width (Optional[int]): Width of the generated images.
-            guidance_scale (Optional[float]): Scale for classifier-free guidance.
-            prior_prior (Optional[RBLNPriorTransformerConfig]): Direct configuration for the prior transformer.
+            batch_size (int | None): Batch size for inference, applied to all submodules.
+            img_height (int | None): Height of the generated images.
+            img_width (int | None): Width of the generated images.
+            height (int | None): Height of the generated images.
+            width (int | None): Width of the generated images.
+            guidance_scale (float | None): Scale for classifier-free guidance.
+            prior_prior (RBLNPriorTransformerConfig | None): Direct configuration for the prior transformer.
                 Used if prior_pipe is not provided.
-            prior_image_encoder (Optional[RBLNCLIPVisionModelWithProjectionConfig]): Direct configuration for the image encoder.
+            prior_image_encoder (RBLNCLIPVisionModelWithProjectionConfig | None): Direct configuration for the image encoder.
                 Used if prior_pipe is not provided.
-            prior_text_encoder (Optional[RBLNCLIPTextModelWithProjectionConfig]): Direct configuration for the text encoder.
+            prior_text_encoder (RBLNCLIPTextModelWithProjectionConfig | None): Direct configuration for the text encoder.
                 Used if prior_pipe is not provided.
-            unet (Optional[RBLNUNet2DConditionModelConfig]): Direct configuration for the UNet.
+            unet (RBLNUNet2DConditionModelConfig | None): Direct configuration for the UNet.
                 Used if decoder_pipe is not provided.
-            movq (Optional[RBLNVQModelConfig]): Direct configuration for the MoVQ (VQ-GAN) model.
+            movq (RBLNVQModelConfig | None): Direct configuration for the MoVQ (VQ-GAN) model.
                 Used if decoder_pipe is not provided.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
         """

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion.py
@@ -41,21 +41,21 @@ class RBLNStableDiffusionPipelineBaseConfig(RBLNModelConfig):
     ):
         """
         Args:
-            text_encoder (Optional[RBLNCLIPTextModelConfig]): Configuration for the text encoder component.
+            text_encoder (RBLNCLIPTextModelConfig | None): Configuration for the text encoder component.
                 Initialized as RBLNCLIPTextModelConfig if not provided.
-            unet (Optional[RBLNUNet2DConditionModelConfig]): Configuration for the UNet model component.
+            unet (RBLNUNet2DConditionModelConfig | None): Configuration for the UNet model component.
                 Initialized as RBLNUNet2DConditionModelConfig if not provided.
-            vae (Optional[RBLNAutoencoderKLConfig]): Configuration for the VAE model component.
+            vae (RBLNAutoencoderKLConfig | None): Configuration for the VAE model component.
                 Initialized as RBLNAutoencoderKLConfig if not provided.
-            batch_size (Optional[int]): Batch size for inference, applied to all submodules.
-            img_height (Optional[int]): Height of the generated images.
-            img_width (Optional[int]): Width of the generated images.
-            height (Optional[int]): Height of the generated images.
-            width (Optional[int]): Width of the generated images.
-            sample_size (Optional[Tuple[int, int]]): Spatial dimensions for the UNet model.
-            image_size (Optional[Tuple[int, int]]): Alternative way to specify image dimensions.
+            batch_size (int | None): Batch size for inference, applied to all submodules.
+            img_height (int | None): Height of the generated images.
+            img_width (int | None): Width of the generated images.
+            height (int | None): Height of the generated images.
+            width (int | None): Width of the generated images.
+            sample_size (tuple[int, int] | None): Spatial dimensions for the UNet model.
+            image_size (tuple[int, int] | None): Alternative way to specify image dimensions.
                 Cannot be used together with img_height/img_width.
-            guidance_scale (Optional[float]): Scale for classifier-free guidance.
+            guidance_scale (float | None): Scale for classifier-free guidance.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Tuple
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....transformers import RBLNCLIPTextModelConfig
@@ -25,18 +25,18 @@ class RBLNStableDiffusionPipelineBaseConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        text_encoder: Optional[RBLNCLIPTextModelConfig] = None,
-        unet: Optional[RBLNUNet2DConditionModelConfig] = None,
-        vae: Optional[RBLNAutoencoderKLConfig] = None,
+        text_encoder: RBLNCLIPTextModelConfig | None = None,
+        unet: RBLNUNet2DConditionModelConfig | None = None,
+        vae: RBLNAutoencoderKLConfig | None = None,
         *,
-        batch_size: Optional[int] = None,
-        img_height: Optional[int] = None,
-        img_width: Optional[int] = None,
-        height: Optional[int] = None,
-        width: Optional[int] = None,
-        sample_size: Optional[Tuple[int, int]] = None,
-        image_size: Optional[Tuple[int, int]] = None,
-        guidance_scale: Optional[float] = None,
+        batch_size: int | None = None,
+        img_height: int | None = None,
+        img_width: int | None = None,
+        height: int | None = None,
+        width: int | None = None,
+        sample_size: tuple[int, int] | None = None,
+        image_size: tuple[int, int] | None = None,
+        guidance_scale: float | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_3.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_3.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Tuple
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....transformers import RBLNCLIPTextModelWithProjectionConfig, RBLNT5EncoderModelConfig
@@ -25,21 +25,21 @@ class RBLNStableDiffusion3PipelineBaseConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        transformer: Optional[RBLNSD3Transformer2DModelConfig] = None,
-        text_encoder: Optional[RBLNCLIPTextModelWithProjectionConfig] = None,
-        text_encoder_2: Optional[RBLNCLIPTextModelWithProjectionConfig] = None,
-        text_encoder_3: Optional[RBLNT5EncoderModelConfig] = None,
-        vae: Optional[RBLNAutoencoderKLConfig] = None,
+        transformer: RBLNSD3Transformer2DModelConfig | None = None,
+        text_encoder: RBLNCLIPTextModelWithProjectionConfig | None = None,
+        text_encoder_2: RBLNCLIPTextModelWithProjectionConfig | None = None,
+        text_encoder_3: RBLNT5EncoderModelConfig | None = None,
+        vae: RBLNAutoencoderKLConfig | None = None,
         *,
-        max_seq_len: Optional[int] = None,
-        sample_size: Optional[Tuple[int, int]] = None,
-        image_size: Optional[Tuple[int, int]] = None,
-        batch_size: Optional[int] = None,
-        img_height: Optional[int] = None,
-        img_width: Optional[int] = None,
-        height: Optional[int] = None,
-        width: Optional[int] = None,
-        guidance_scale: Optional[float] = None,
+        max_seq_len: int | None = None,
+        sample_size: tuple[int, int] | None = None,
+        image_size: tuple[int, int] | None = None,
+        batch_size: int | None = None,
+        img_height: int | None = None,
+        img_width: int | None = None,
+        height: int | None = None,
+        width: int | None = None,
+        guidance_scale: float | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_3.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_3.py
@@ -44,26 +44,26 @@ class RBLNStableDiffusion3PipelineBaseConfig(RBLNModelConfig):
     ):
         """
         Args:
-            transformer (Optional[RBLNSD3Transformer2DModelConfig]): Configuration for the transformer model component.
+            transformer (RBLNSD3Transformer2DModelConfig | None): Configuration for the transformer model component.
                 Initialized as RBLNSD3Transformer2DModelConfig if not provided.
-            text_encoder (Optional[RBLNCLIPTextModelWithProjectionConfig]): Configuration for the primary text encoder.
+            text_encoder (RBLNCLIPTextModelWithProjectionConfig | None): Configuration for the primary text encoder.
                 Initialized as RBLNCLIPTextModelWithProjectionConfig if not provided.
-            text_encoder_2 (Optional[RBLNCLIPTextModelWithProjectionConfig]): Configuration for the secondary text encoder.
+            text_encoder_2 (RBLNCLIPTextModelWithProjectionConfig | None): Configuration for the secondary text encoder.
                 Initialized as RBLNCLIPTextModelWithProjectionConfig if not provided.
-            text_encoder_3 (Optional[RBLNT5EncoderModelConfig]): Configuration for the tertiary text encoder.
+            text_encoder_3 (RBLNT5EncoderModelConfig | None): Configuration for the tertiary text encoder.
                 Initialized as RBLNT5EncoderModelConfig if not provided.
-            vae (Optional[RBLNAutoencoderKLConfig]): Configuration for the VAE model component.
+            vae (RBLNAutoencoderKLConfig | None): Configuration for the VAE model component.
                 Initialized as RBLNAutoencoderKLConfig if not provided.
-            max_seq_len (Optional[int]): Maximum sequence length for text inputs. Defaults to 256.
-            sample_size (Optional[Tuple[int, int]]): Spatial dimensions for the transformer model.
-            image_size (Optional[Tuple[int, int]]): Dimensions for the generated images.
+            max_seq_len (int | None): Maximum sequence length for text inputs. Defaults to 256.
+            sample_size (tuple[int, int] | None): Spatial dimensions for the transformer model.
+            image_size (tuple[int, int] | None): Dimensions for the generated images.
                 Cannot be used together with img_height/img_width.
-            batch_size (Optional[int]): Batch size for inference, applied to all submodules.
-            img_height (Optional[int]): Height of the generated images.
-            img_width (Optional[int]): Width of the generated images.
-            height (Optional[int]): Height of the generated images.
-            width (Optional[int]): Width of the generated images.
-            guidance_scale (Optional[float]): Scale for classifier-free guidance.
+            batch_size (int | None): Batch size for inference, applied to all submodules.
+            img_height (int | None): Height of the generated images.
+            img_width (int | None): Width of the generated images.
+            height (int | None): Height of the generated images.
+            width (int | None): Width of the generated images.
+            guidance_scale (float | None): Scale for classifier-free guidance.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_xl.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_xl.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Tuple
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....transformers import RBLNCLIPTextModelConfig, RBLNCLIPTextModelWithProjectionConfig
@@ -25,19 +25,19 @@ class RBLNStableDiffusionXLPipelineBaseConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        text_encoder: Optional[RBLNCLIPTextModelConfig] = None,
-        text_encoder_2: Optional[RBLNCLIPTextModelWithProjectionConfig] = None,
-        unet: Optional[RBLNUNet2DConditionModelConfig] = None,
-        vae: Optional[RBLNAutoencoderKLConfig] = None,
+        text_encoder: RBLNCLIPTextModelConfig | None = None,
+        text_encoder_2: RBLNCLIPTextModelWithProjectionConfig | None = None,
+        unet: RBLNUNet2DConditionModelConfig | None = None,
+        vae: RBLNAutoencoderKLConfig | None = None,
         *,
-        batch_size: Optional[int] = None,
-        img_height: Optional[int] = None,
-        img_width: Optional[int] = None,
-        height: Optional[int] = None,
-        width: Optional[int] = None,
-        sample_size: Optional[Tuple[int, int]] = None,
-        image_size: Optional[Tuple[int, int]] = None,
-        guidance_scale: Optional[float] = None,
+        batch_size: int | None = None,
+        img_height: int | None = None,
+        img_width: int | None = None,
+        height: int | None = None,
+        width: int | None = None,
+        sample_size: tuple[int, int] | None = None,
+        image_size: tuple[int, int] | None = None,
+        guidance_scale: float | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_xl.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_diffusion_xl.py
@@ -42,23 +42,23 @@ class RBLNStableDiffusionXLPipelineBaseConfig(RBLNModelConfig):
     ):
         """
         Args:
-            text_encoder (Optional[RBLNCLIPTextModelConfig]): Configuration for the primary text encoder component.
+            text_encoder (RBLNCLIPTextModelConfig | None): Configuration for the primary text encoder component.
                 Initialized as RBLNCLIPTextModelConfig if not provided.
-            text_encoder_2 (Optional[RBLNCLIPTextModelWithProjectionConfig]): Configuration for the secondary text encoder component.
+            text_encoder_2 (RBLNCLIPTextModelWithProjectionConfig | None): Configuration for the secondary text encoder component.
                 Initialized as RBLNCLIPTextModelWithProjectionConfig if not provided.
-            unet (Optional[RBLNUNet2DConditionModelConfig]): Configuration for the UNet model component.
+            unet (RBLNUNet2DConditionModelConfig | None): Configuration for the UNet model component.
                 Initialized as RBLNUNet2DConditionModelConfig if not provided.
-            vae (Optional[RBLNAutoencoderKLConfig]): Configuration for the VAE model component.
+            vae (RBLNAutoencoderKLConfig | None): Configuration for the VAE model component.
                 Initialized as RBLNAutoencoderKLConfig if not provided.
-            batch_size (Optional[int]): Batch size for inference, applied to all submodules.
-            img_height (Optional[int]): Height of the generated images.
-            img_width (Optional[int]): Width of the generated images.
-            height (Optional[int]): Height of the generated images.
-            width (Optional[int]): Width of the generated images.
-            sample_size (Optional[Tuple[int, int]]): Spatial dimensions for the UNet model.
-            image_size (Optional[Tuple[int, int]]): Alternative way to specify image dimensions.
+            batch_size (int | None): Batch size for inference, applied to all submodules.
+            img_height (int | None): Height of the generated images.
+            img_width (int | None): Width of the generated images.
+            height (int | None): Height of the generated images.
+            width (int | None): Width of the generated images.
+            sample_size (tuple[int, int] | None): Spatial dimensions for the UNet model.
+            image_size (tuple[int, int] | None): Alternative way to specify image dimensions.
                 Cannot be used together with img_height/img_width.
-            guidance_scale (Optional[float]): Scale for classifier-free guidance.
+            guidance_scale (float | None): Scale for classifier-free guidance.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_video_diffusion.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_video_diffusion.py
@@ -39,19 +39,19 @@ class RBLNStableVideoDiffusionPipelineConfig(RBLNModelConfig):
     ):
         """
         Args:
-            image_encoder (Optional[RBLNCLIPVisionModelWithProjectionConfig]): Configuration for the image encoder component.
+            image_encoder (RBLNCLIPVisionModelWithProjectionConfig | None): Configuration for the image encoder component.
                 Initialized as RBLNCLIPVisionModelWithProjectionConfig if not provided.
-            unet (Optional[RBLNUNetSpatioTemporalConditionModelConfig]): Configuration for the UNet model component.
+            unet (RBLNUNetSpatioTemporalConditionModelConfig | None): Configuration for the UNet model component.
                 Initialized as RBLNUNetSpatioTemporalConditionModelConfig if not provided.
-            vae (Optional[RBLNAutoencoderKLTemporalDecoderConfig]): Configuration for the VAE model component.
+            vae (RBLNAutoencoderKLTemporalDecoderConfig | None): Configuration for the VAE model component.
                 Initialized as RBLNAutoencoderKLTemporalDecoderConfig if not provided.
-            batch_size (Optional[int]): Batch size for inference, applied to all submodules.
-            height (Optional[int]): Height of the generated images.
-            width (Optional[int]): Width of the generated images.
-            num_frames (Optional[int]): The number of frames in the generated video.
-            decode_chunk_size (Optional[int]): The number of frames to decode at once during VAE decoding.
+            batch_size (int | None): Batch size for inference, applied to all submodules.
+            height (int | None): Height of the generated images.
+            width (int | None): Width of the generated images.
+            num_frames (int | None): The number of frames in the generated video.
+            decode_chunk_size (int | None): The number of frames to decode at once during VAE decoding.
                 Useful for managing memory usage during video generation.
-            guidance_scale (Optional[float]): Scale for classifier-free guidance.
+            guidance_scale (float | None): Scale for classifier-free guidance.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_video_diffusion.py
+++ b/src/optimum/rbln/diffusers/configurations/pipelines/configuration_stable_video_diffusion.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....transformers import RBLNCLIPVisionModelWithProjectionConfig
@@ -25,16 +25,16 @@ class RBLNStableVideoDiffusionPipelineConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        image_encoder: Optional[RBLNCLIPVisionModelWithProjectionConfig] = None,
-        unet: Optional[RBLNUNetSpatioTemporalConditionModelConfig] = None,
-        vae: Optional[RBLNAutoencoderKLTemporalDecoderConfig] = None,
+        image_encoder: RBLNCLIPVisionModelWithProjectionConfig | None = None,
+        unet: RBLNUNetSpatioTemporalConditionModelConfig | None = None,
+        vae: RBLNAutoencoderKLTemporalDecoderConfig | None = None,
         *,
-        batch_size: Optional[int] = None,
-        height: Optional[int] = None,
-        width: Optional[int] = None,
-        num_frames: Optional[int] = None,
-        decode_chunk_size: Optional[int] = None,
-        guidance_scale: Optional[float] = None,
+        batch_size: int | None = None,
+        height: int | None = None,
+        width: int | None = None,
+        num_frames: int | None = None,
+        decode_chunk_size: int | None = None,
+        guidance_scale: float | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/diffusers/modeling_diffusers.py
+++ b/src/optimum/rbln/diffusers/modeling_diffusers.py
@@ -15,7 +15,7 @@
 import copy
 import importlib
 from os import PathLike
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Any
 
 import torch
 
@@ -78,9 +78,9 @@ class RBLNDiffusionMixin:
     @staticmethod
     def _maybe_apply_and_fuse_lora(
         model: torch.nn.Module,
-        lora_ids: Optional[Union[str, List[str]]] = None,
-        lora_weights_names: Optional[Union[str, List[str]]] = None,
-        lora_scales: Optional[Union[float, List[float]]] = None,
+        lora_ids: str | list[str] | None = None,
+        lora_weights_names: str | list[str] | None = None,
+        lora_scales: float | list[float] | None = None,
     ) -> torch.nn.Module:
         lora_ids = [lora_ids] if isinstance(lora_ids, str) else lora_ids
         lora_weights_names = [lora_weights_names] if isinstance(lora_weights_names, str) else lora_weights_names
@@ -116,7 +116,7 @@ class RBLNDiffusionMixin:
         return model
 
     @classmethod
-    def get_rbln_config_class(cls) -> Type[RBLNModelConfig]:
+    def get_rbln_config_class(cls) -> type[RBLNModelConfig]:
         # Lazily loads and caches the corresponding RBLN model config class.
         if "_rbln_config_class" not in cls.__dict__ or cls._rbln_config_class is None:
             rbln_config_class_name = cls.__name__ + "Config"
@@ -137,11 +137,11 @@ class RBLNDiffusionMixin:
         model_id: str,
         *,
         export: bool = None,
-        model_save_dir: Optional[PathLike] = None,
-        rbln_config: Optional[Dict[str, Any]] = None,
-        lora_ids: Optional[Union[str, List[str]]] = None,
-        lora_weights_names: Optional[Union[str, List[str]]] = None,
-        lora_scales: Optional[Union[float, List[float]]] = None,
+        model_save_dir: PathLike | None = None,
+        rbln_config: dict[str, Any] | None = None,
+        lora_ids: str | list[str] | None = None,
+        lora_weights_names: str | list[str] | None = None,
+        lora_scales: float | list[float] | None = None,
         **kwargs: Any,
     ) -> "RBLNDiffusionMixin":
         """
@@ -277,10 +277,10 @@ class RBLNDiffusionMixin:
     def _compile_pipelines(
         cls,
         model: torch.nn.Module,
-        passed_submodules: Dict[str, RBLNModel],
-        model_save_dir: Optional[PathLike],
+        passed_submodules: dict[str, RBLNModel],
+        model_save_dir: PathLike | None,
         rbln_config: "RBLNDiffusionMixinConfig",
-    ) -> Dict[str, RBLNModel]:
+    ) -> dict[str, RBLNModel]:
         compiled_submodules = {}
         for connected_pipe_name, connected_pipe_cls in cls._connected_classes.items():
             connected_pipe_submodules = {}
@@ -303,11 +303,11 @@ class RBLNDiffusionMixin:
     def _compile_submodules(
         cls,
         model: torch.nn.Module,
-        passed_submodules: Dict[str, RBLNModel],
-        model_save_dir: Optional[PathLike],
+        passed_submodules: dict[str, RBLNModel],
+        model_save_dir: PathLike | None,
         rbln_config: RBLNDiffusionMixinConfig,
-        prefix: Optional[str] = "",
-    ) -> Dict[str, RBLNModel]:
+        prefix: str | None = "",
+    ) -> dict[str, RBLNModel]:
         compiled_submodules = {}
 
         for submodule_name in cls._submodules:
@@ -316,7 +316,7 @@ class RBLNDiffusionMixin:
             if getattr(rbln_config, submodule_name, None) is None:
                 raise ValueError(f"RBLN config for submodule {submodule_name} is not provided.")
 
-            submodule_rbln_cls: Type[RBLNModel] = getattr(rbln_config, submodule_name).rbln_model_cls
+            submodule_rbln_cls: type[RBLNModel] = getattr(rbln_config, submodule_name).rbln_model_cls
             rbln_config = submodule_rbln_cls.update_rbln_config_using_pipe(model, rbln_config, submodule_name)
 
             if submodule is None:
@@ -348,9 +348,9 @@ class RBLNDiffusionMixin:
     def _compile_multicontrolnet(
         cls,
         controlnets: "MultiControlNetModel",
-        model_save_dir: Optional[PathLike],
+        model_save_dir: PathLike | None,
         controlnet_rbln_config: RBLNModelConfig,
-        prefix: Optional[str] = "",
+        prefix: str | None = "",
     ):
         # Compile multiple ControlNet models for a MultiControlNet setup
         from .models.controlnet import RBLNControlNetModel

--- a/src/optimum/rbln/diffusers/models/autoencoders/autoencoder_kl.py
+++ b/src/optimum/rbln/diffusers/models/autoencoders/autoencoder_kl.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import rebel
 import torch
@@ -65,7 +65,7 @@ class RBLNAutoencoderKL(RBLNModel):
         self.image_size = self.rbln_config.image_size
 
     @classmethod
-    def get_compiled_model(cls, model, rbln_config: RBLNAutoencoderKLConfig) -> Dict[str, rebel.RBLNCompiledModel]:
+    def get_compiled_model(cls, model, rbln_config: RBLNAutoencoderKLConfig) -> dict[str, rebel.RBLNCompiledModel]:
         if rbln_config.uses_encoder:
             expected_models = ["encoder", "decoder"]
         else:
@@ -92,7 +92,7 @@ class RBLNAutoencoderKL(RBLNModel):
     @classmethod
     def get_vae_sample_size(
         cls, pipe: "RBLNDiffusionMixin", rbln_config: RBLNAutoencoderKLConfig, return_vae_scale_factor: bool = False
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         sample_size = rbln_config.sample_size
         noise_module = getattr(pipe, "unet", None) or getattr(pipe, "transformer", None)
         vae_scale_factor = (
@@ -189,9 +189,9 @@ class RBLNAutoencoderKL(RBLNModel):
     @classmethod
     def _create_runtimes(
         cls,
-        compiled_models: List[rebel.RBLNCompiledModel],
+        compiled_models: list[rebel.RBLNCompiledModel],
         rbln_config: RBLNAutoencoderKLConfig,
-    ) -> List[rebel.Runtime]:
+    ) -> list[rebel.Runtime]:
         if len(compiled_models) == 1:
             # decoder
             expected_models = ["decoder"]
@@ -215,8 +215,8 @@ class RBLNAutoencoderKL(RBLNModel):
         ]
 
     def encode(
-        self, x: torch.FloatTensor, return_dict: bool = True, **kwargs: Dict[str, Any]
-    ) -> Union[torch.FloatTensor, AutoencoderKLOutput]:
+        self, x: torch.FloatTensor, return_dict: bool = True, **kwargs: dict[str, Any]
+    ) -> torch.FloatTensor | AutoencoderKLOutput:
         """
         Encode an input image into a latent representation.
 
@@ -235,8 +235,8 @@ class RBLNAutoencoderKL(RBLNModel):
         return AutoencoderKLOutput(latent_dist=posterior)
 
     def decode(
-        self, z: torch.FloatTensor, return_dict: bool = True, **kwargs: Dict[str, Any]
-    ) -> Union[torch.FloatTensor, DecoderOutput]:
+        self, z: torch.FloatTensor, return_dict: bool = True, **kwargs: dict[str, Any]
+    ) -> torch.FloatTensor | DecoderOutput:
         """
         Decode a latent representation into an image.
 

--- a/src/optimum/rbln/diffusers/models/autoencoders/autoencoder_kl_cosmos.py
+++ b/src/optimum/rbln/diffusers/models/autoencoders/autoencoder_kl_cosmos.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Dict, List, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import rebel
 import torch
@@ -84,7 +84,7 @@ class RBLNAutoencoderKLCosmos(RBLNModel):
     @classmethod
     def get_compiled_model(
         cls, model, rbln_config: RBLNAutoencoderKLCosmosConfig
-    ) -> Dict[str, rebel.RBLNCompiledModel]:
+    ) -> dict[str, rebel.RBLNCompiledModel]:
         def replaced_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
             if self.temporal_pad != 0:
                 hidden_states_prev = hidden_states[:, :, :1, ...].repeat(1, 1, self.temporal_pad, 1, 1)
@@ -181,9 +181,9 @@ class RBLNAutoencoderKLCosmos(RBLNModel):
     @classmethod
     def _create_runtimes(
         cls,
-        compiled_models: List[rebel.RBLNCompiledModel],
+        compiled_models: list[rebel.RBLNCompiledModel],
         rbln_config: RBLNAutoencoderKLCosmosConfig,
-    ) -> List[rebel.Runtime]:
+    ) -> list[rebel.Runtime]:
         if len(compiled_models) == 1:
             # decoder
             expected_models = ["decoder"]
@@ -206,8 +206,8 @@ class RBLNAutoencoderKLCosmos(RBLNModel):
         ]
 
     def encode(
-        self, x: torch.FloatTensor, return_dict: bool = True, **kwargs: Dict[str, Any]
-    ) -> Union[torch.FloatTensor, AutoencoderKLOutput]:
+        self, x: torch.FloatTensor, return_dict: bool = True, **kwargs: dict[str, Any]
+    ) -> torch.FloatTensor | AutoencoderKLOutput:
         """
         Encode an input video into a latent representation.
 
@@ -225,7 +225,7 @@ class RBLNAutoencoderKLCosmos(RBLNModel):
             return (posterior,)
         return AutoencoderKLOutput(latent_dist=posterior)
 
-    def decode(self, z: torch.FloatTensor, return_dict: bool = True) -> Union[torch.FloatTensor, DecoderOutput]:
+    def decode(self, z: torch.FloatTensor, return_dict: bool = True) -> torch.FloatTensor | DecoderOutput:
         """
         Decode a latent representation into a video.
 

--- a/src/optimum/rbln/diffusers/models/autoencoders/autoencoder_kl_temporal_decoder.py
+++ b/src/optimum/rbln/diffusers/models/autoencoders/autoencoder_kl_temporal_decoder.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Dict, List, Tuple, Union
+from typing import TYPE_CHECKING, Union
 
 import rebel
 import torch  # noqa: I001
@@ -74,7 +74,7 @@ class RBLNAutoencoderKLTemporalDecoder(RBLNModel):
     @classmethod
     def get_compiled_model(
         cls, model, rbln_config: RBLNAutoencoderKLTemporalDecoderConfig
-    ) -> Dict[str, rebel.RBLNCompiledModel]:
+    ) -> dict[str, rebel.RBLNCompiledModel]:
         compiled_models = {}
         if rbln_config.uses_encoder:
             encoder_model, decoder_model = cls._wrap_model_if_needed(model, rbln_config)
@@ -103,7 +103,7 @@ class RBLNAutoencoderKLTemporalDecoder(RBLNModel):
         pipe: "RBLNDiffusionMixin",
         rbln_config: RBLNAutoencoderKLTemporalDecoderConfig,
         return_vae_scale_factor: bool = False,
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         sample_size = rbln_config.sample_size
         if hasattr(pipe, "vae_scale_factor"):
             vae_scale_factor = pipe.vae_scale_factor
@@ -210,9 +210,9 @@ class RBLNAutoencoderKLTemporalDecoder(RBLNModel):
     @classmethod
     def _create_runtimes(
         cls,
-        compiled_models: List[rebel.RBLNCompiledModel],
+        compiled_models: list[rebel.RBLNCompiledModel],
         rbln_config: RBLNAutoencoderKLTemporalDecoderConfig,
-    ) -> List[rebel.Runtime]:
+    ) -> list[rebel.Runtime]:
         if len(compiled_models) == 1:
             # decoder
             expected_models = ["decoder"]
@@ -236,7 +236,7 @@ class RBLNAutoencoderKLTemporalDecoder(RBLNModel):
 
     def encode(
         self, x: torch.FloatTensor, return_dict: bool = True
-    ) -> Union[AutoencoderKLOutput, Tuple[DiagonalGaussianDistribution]]:
+    ) -> AutoencoderKLOutput | tuple[DiagonalGaussianDistribution]:
         """
         Encode an input image into a latent representation.
 

--- a/src/optimum/rbln/diffusers/models/autoencoders/vae.py
+++ b/src/optimum/rbln/diffusers/models/autoencoders/vae.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING, Union
 
 import torch
 from diffusers.models.autoencoders.vae import DiagonalGaussianDistribution, IdentityDistribution
@@ -136,12 +136,12 @@ class RBLNRuntimeVQEncoder(RBLNPytorchRuntime):
 
 
 class RBLNRuntimeVQDecoder(RBLNPytorchRuntime):
-    def decode(self, h: torch.Tensor, force_not_quantize: bool = False, shape=None, **kwargs) -> List[torch.Tensor]:
+    def decode(self, h: torch.Tensor, force_not_quantize: bool = False, shape=None, **kwargs) -> list[torch.Tensor]:
         if not (force_not_quantize and not self.lookup_from_codebook):
             raise ValueError(
                 "Currently, the `decode` method of the class `RBLNVQModel` is executed successfully only if `force_not_quantize` is True and `config.lookup_from_codebook` is False"
             )
-        commit_loss = torch.zeros((h.shape[0])).to(h.device, dtype=h.dtype)
+        commit_loss = torch.zeros(h.shape[0]).to(h.device, dtype=h.dtype)
         dec = self.forward(h.contiguous())
         return dec, commit_loss
 

--- a/src/optimum/rbln/diffusers/models/autoencoders/vq_model.py
+++ b/src/optimum/rbln/diffusers/models/autoencoders/vq_model.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, List, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import rebel
 import torch
@@ -145,9 +145,9 @@ class RBLNVQModel(RBLNModel):
     @classmethod
     def _create_runtimes(
         cls,
-        compiled_models: List[rebel.RBLNCompiledModel],
+        compiled_models: list[rebel.RBLNCompiledModel],
         rbln_config: RBLNVQModelConfig,
-    ) -> List[rebel.Runtime]:
+    ) -> list[rebel.Runtime]:
         if len(compiled_models) == 1:
             # decoder
             expected_models = ["decoder"]
@@ -172,7 +172,7 @@ class RBLNVQModel(RBLNModel):
 
     def encode(
         self, x: torch.FloatTensor, return_dict: bool = True, **kwargs: Any
-    ) -> Union[torch.FloatTensor, VQEncoderOutput]:
+    ) -> torch.FloatTensor | VQEncoderOutput:
         """
         Encode an input image into a quantized latent representation.
 
@@ -192,7 +192,7 @@ class RBLNVQModel(RBLNModel):
 
     def decode(
         self, h: torch.FloatTensor, return_dict: bool = True, **kwargs: Any
-    ) -> Union[torch.FloatTensor, DecoderOutput]:
+    ) -> torch.FloatTensor | DecoderOutput:
         """
         Decode a quantized latent representation back into an image.
 

--- a/src/optimum/rbln/diffusers/models/controlnet.py
+++ b/src/optimum/rbln/diffusers/models/controlnet.py
@@ -224,15 +224,15 @@ class RBLNControlNetModel(RBLNModel):
 
         Args:
             sample (torch.FloatTensor): The noisy input tensor.
-            timestep (Union[torch.Tensor, float, int]): The number of timesteps to denoise an input.
+            timestep (torch.Tensor | float | int): The number of timesteps to denoise an input.
             encoder_hidden_states (torch.Tensor): The encoder hidden states.
             controlnet_cond (torch.FloatTensor): The conditional input tensor of shape `(batch_size, max_seq_len, hidden_size)`.
             conditioning_scale (torch.Tensor): The scale factor for ControlNet outputs.
-            added_cond_kwargs (Dict[str, torch.Tensor]): Additional conditions for the Stable Diffusion XL UNet.
+            added_cond_kwargs (dict[str, torch.Tensor]): Additional conditions for the Stable Diffusion XL UNet.
             return_dict (bool): Whether or not to return a [`~diffusers.models.controlnets.controlnet.ControlNetOutput`] instead of a plain tuple
 
         Returns:
-            (Union[`~diffusers.models.controlnets.controlnet.ControlNetOutput`], Tuple)
+            (`~diffusers.models.controlnets.controlnet.ControlNetOutput`, Tuple)
         """
         sample_batch_size = sample.size()[0]
         compiled_batch_size = self.compiled_batch_size

--- a/src/optimum/rbln/diffusers/models/controlnet.py
+++ b/src/optimum/rbln/diffusers/models/controlnet.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Union
 
 import torch
 from diffusers import ControlNetModel
@@ -45,8 +45,8 @@ class _ControlNetModel(torch.nn.Module):
         timestep: torch.Tensor,
         controlnet_cond: torch.Tensor,
         conditioning_scale,
-        text_embeds: Optional[torch.Tensor] = None,
-        time_ids: Optional[torch.Tensor] = None,
+        text_embeds: torch.Tensor | None = None,
+        time_ids: torch.Tensor | None = None,
     ):
         if text_embeds is not None and time_ids is not None:
             added_cond_kwargs = {"text_embeds": text_embeds, "time_ids": time_ids}
@@ -77,8 +77,8 @@ class _ControlNetModel_Cross_Attention(torch.nn.Module):
         encoder_hidden_states: torch.Tensor,
         controlnet_cond: torch.Tensor,
         conditioning_scale,
-        text_embeds: Optional[torch.Tensor] = None,
-        time_ids: Optional[torch.Tensor] = None,
+        text_embeds: torch.Tensor | None = None,
+        time_ids: torch.Tensor | None = None,
     ):
         if text_embeds is not None and time_ids is not None:
             added_cond_kwargs = {"text_embeds": text_embeds, "time_ids": time_ids}
@@ -211,14 +211,14 @@ class RBLNControlNetModel(RBLNModel):
     def forward(
         self,
         sample: torch.FloatTensor,
-        timestep: Union[torch.Tensor, float, int],
+        timestep: torch.Tensor | float | int,
         encoder_hidden_states: torch.Tensor,
         controlnet_cond: torch.FloatTensor,
         conditioning_scale: torch.Tensor = 1.0,
-        added_cond_kwargs: Optional[Dict[str, torch.Tensor]] = None,
+        added_cond_kwargs: dict[str, torch.Tensor] | None = None,
         return_dict: bool = True,
         **kwargs,
-    ) -> Union[ControlNetOutput, Tuple]:
+    ) -> ControlNetOutput | tuple:
         """
         Forward pass for the RBLN-optimized ControlNetModel.
 

--- a/src/optimum/rbln/diffusers/models/transformers/prior_transformer.py
+++ b/src/optimum/rbln/diffusers/models/transformers/prior_transformer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Union
 
 import torch
 from diffusers.models.transformers.prior_transformer import PriorTransformer, PriorTransformerOutput
@@ -129,12 +129,12 @@ class RBLNPriorTransformer(RBLNModel):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        timestep: Union[torch.Tensor, float, int],
+        timestep: torch.Tensor | float | int,
         proj_embedding: torch.Tensor,
-        encoder_hidden_states: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
+        encoder_hidden_states: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
         return_dict: bool = True,
-    ) -> Union[PriorTransformerOutput, Tuple]:
+    ) -> PriorTransformerOutput | tuple:
         """
         Forward pass for the RBLN-optimized PriorTransformer.
 

--- a/src/optimum/rbln/diffusers/models/transformers/prior_transformer.py
+++ b/src/optimum/rbln/diffusers/models/transformers/prior_transformer.py
@@ -140,14 +140,14 @@ class RBLNPriorTransformer(RBLNModel):
 
         Args:
             hidden_states (torch.Tensor): The currently predicted image embeddings.
-            timestep (Union[torch.Tensor, float, int]): Current denoising step.
+            timestep (torch.Tensor | float | int): Current denoising step.
             proj_embedding (torch.Tensor): Projected embedding vector the denoising process is conditioned on.
-            encoder_hidden_states (Optional[torch.Tensor]): Hidden states of the text embeddings the denoising process is conditioned on.
-            attention_mask (Optional[torch.Tensor]): Text mask for the text embeddings.
+            encoder_hidden_states (torch.Tensor | None): Hidden states of the text embeddings the denoising process is conditioned on.
+            attention_mask (torch.Tensor | None): Text mask for the text embeddings.
             return_dict (bool): Whether or not to return a [`~diffusers.models.transformers.prior_transformer.PriorTransformerOutput`] instead of a plain tuple.
 
         Returns:
-            (Union[`~diffusers.models.transformers.prior_transformer.PriorTransformerOutput`, Tuple])
+            (`~diffusers.models.transformers.prior_transformer.PriorTransformerOutput` | tuple)
         """
         # Convert timestep(long) and attention_mask(bool) to float
         return super().forward(

--- a/src/optimum/rbln/diffusers/models/transformers/transformer_cosmos.py
+++ b/src/optimum/rbln/diffusers/models/transformers/transformer_cosmos.py
@@ -310,13 +310,13 @@ class RBLNCosmosTransformer3DModel(RBLNModel):
             hidden_states (torch.Tensor): The currently predicted image embeddings.
             timestep (torch.Tensor): Current denoising step.
             encoder_hidden_states (torch.Tensor): Conditional embeddings (embeddings computed from the input conditions such as prompts) to use.
-            fps: (Optional[int]): Frames per second for the video being generated.
-            condition_mask (Optional[torch.Tensor]): Tensor of condition mask.
-            padding_mask (Optional[torch.Tensor]): Tensor of padding mask.
+            fps: (int | None): Frames per second for the video being generated.
+            condition_mask (torch.Tensor | None): Tensor of condition mask.
+            padding_mask (torch.Tensor | None): Tensor of padding mask.
             return_dict (bool): Whether or not to return a [`~diffusers.models.modeling_output.Transformer2DModelOutput`] instead of a plain tuple.
 
         Returns:
-            (Union[`~diffusers.models.modeling_output.Transformer2DModelOutput`, Tuple])
+            (`~diffusers.models.modeling_output.Transformer2DModelOutput` | tuple)
         """
         (
             hidden_states,

--- a/src/optimum/rbln/diffusers/models/transformers/transformer_cosmos.py
+++ b/src/optimum/rbln/diffusers/models/transformers/transformer_cosmos.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Union
 
 import rebel
 import torch
@@ -65,8 +65,8 @@ class CosmosTransformer3DModelWrapper(torch.nn.Module):
         temb: torch.Tensor,
         image_rotary_emb_0: torch.Tensor,
         image_rotary_emb_1: torch.Tensor,
-        extra_pos_emb: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
+        extra_pos_emb: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
         return_dict: bool = False,
     ):
         image_rotary_emb = [image_rotary_emb_0, image_rotary_emb_1]
@@ -140,10 +140,10 @@ class RBLNCosmosTransformer3DModel(RBLNModel):
         self,
         hidden_states: torch.Tensor,
         timestep: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
-        fps: Optional[int] = None,
-        condition_mask: Optional[torch.Tensor] = None,
-        padding_mask: Optional[torch.Tensor] = None,
+        attention_mask: torch.Tensor | None = None,
+        fps: int | None = None,
+        condition_mask: torch.Tensor | None = None,
+        padding_mask: torch.Tensor | None = None,
     ):
         batch_size, num_channels, num_frames, height, width = hidden_states.shape
 
@@ -275,9 +275,9 @@ class RBLNCosmosTransformer3DModel(RBLNModel):
     @classmethod
     def _create_runtimes(
         cls,
-        compiled_models: List[rebel.RBLNCompiledModel],
+        compiled_models: list[rebel.RBLNCompiledModel],
         rbln_config: RBLNModelConfig,
-    ) -> List[rebel.Runtime]:
+    ) -> list[rebel.Runtime]:
         if DEFAULT_COMPILED_MODEL_NAME not in rbln_config.device_map:
             cls._raise_missing_compiled_file_error([DEFAULT_COMPILED_MODEL_NAME])
 
@@ -297,12 +297,12 @@ class RBLNCosmosTransformer3DModel(RBLNModel):
         hidden_states: torch.Tensor,
         timestep: torch.Tensor,
         encoder_hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
-        fps: Optional[int] = None,
-        condition_mask: Optional[torch.Tensor] = None,
-        padding_mask: Optional[torch.Tensor] = None,
+        attention_mask: torch.Tensor | None = None,
+        fps: int | None = None,
+        condition_mask: torch.Tensor | None = None,
+        padding_mask: torch.Tensor | None = None,
         return_dict: bool = True,
-    ) -> Union[Transformer2DModelOutput, Tuple]:
+    ) -> Transformer2DModelOutput | tuple:
         """
         Forward pass for the RBLN-optimized CosmosTransformer3DModel.
 

--- a/src/optimum/rbln/diffusers/models/transformers/transformer_sd3.py
+++ b/src/optimum/rbln/diffusers/models/transformers/transformer_sd3.py
@@ -172,7 +172,7 @@ class RBLNSD3Transformer2DModel(RBLNModel):
             return_dict (bool): Whether or not to return a [`~diffusers.models.modeling_output.Transformer2DModelOutput`] instead of a plain tuple.
 
         Returns:
-            (Union[`~diffusers.models.modeling_output.Transformer2DModelOutput`, Tuple])
+            (`~diffusers.models.modeling_output.Transformer2DModelOutput` | tuple)
         """
         sample_batch_size = hidden_states.size()[0]
         compiled_batch_size = self.compiled_batch_size

--- a/src/optimum/rbln/diffusers/models/transformers/transformer_sd3.py
+++ b/src/optimum/rbln/diffusers/models/transformers/transformer_sd3.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import torch
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
@@ -45,8 +45,8 @@ class SD3Transformer2DModelWrapper(torch.nn.Module):
         pooled_projections: torch.FloatTensor = None,
         timestep: torch.LongTensor = None,
         # need controlnet support?
-        block_controlnet_hidden_states: List = None,
-        joint_attention_kwargs: Optional[Dict[str, Any]] = None,
+        block_controlnet_hidden_states: list = None,
+        joint_attention_kwargs: dict[str, Any] | None = None,
         return_dict: bool = True,
     ):
         return self.model(
@@ -156,11 +156,11 @@ class RBLNSD3Transformer2DModel(RBLNModel):
         encoder_hidden_states: torch.FloatTensor = None,
         pooled_projections: torch.FloatTensor = None,
         timestep: torch.LongTensor = None,
-        block_controlnet_hidden_states: List = None,
-        joint_attention_kwargs: Optional[Dict[str, Any]] = None,
+        block_controlnet_hidden_states: list = None,
+        joint_attention_kwargs: dict[str, Any] | None = None,
         return_dict: bool = True,
         **kwargs,
-    ) -> Union[Transformer2DModelOutput, Tuple]:
+    ) -> Transformer2DModelOutput | tuple:
         """
         Forward pass for the RBLN-optimized SD3Transformer2DModel.
 

--- a/src/optimum/rbln/diffusers/models/unets/unet_2d_condition.py
+++ b/src/optimum/rbln/diffusers/models/unets/unet_2d_condition.py
@@ -354,16 +354,16 @@ class RBLNUNet2DConditionModel(RBLNModel):
 
         Args:
             sample (torch.Tensor): The noisy input tensor with the following shape `(batch, channel, height, width)`.
-            timestep (Union[torch.Tensor, float, int]): The number of timesteps to denoise an input.
+            timestep (torch.Tensor | float | int): The number of timesteps to denoise an input.
             encoder_hidden_states (torch.Tensor): The encoder hidden states.
-            added_cond_kwargs (Dict[str, torch.Tensor]): A kwargs dictionary containing additional embeddings that
+            added_cond_kwargs (dict[str, torch.Tensor]): A kwargs dictionary containing additional embeddings that
                 if specified are added to the embeddings that are passed along to the UNet blocks.
-            down_block_additional_residuals (Optional[Tuple[torch.Tensor]]): A tuple of tensors that if specified are added to the residuals of down unet blocks.
-            mid_block_additional_residual (Optional[torch.Tensor]): A tensor that if specified is added to the residual of the middle unet block.
+            down_block_additional_residuals (tuple[torch.Tensor] | None): A tuple of tensors that if specified are added to the residuals of down unet blocks.
+            mid_block_additional_residual (torch.Tensor | None): A tensor that if specified is added to the residual of the middle unet block.
             return_dict (bool): Whether or not to return a [`~diffusers.models.unets.unet_2d_condition.UNet2DConditionOutput`] instead of a plain tuple.
 
         Returns:
-            (Union[`~diffusers.models.unets.unet_2d_condition.UNet2DConditionOutput`], Tuple)
+            (`~diffusers.models.unets.unet_2d_condition.UNet2DConditionOutput`, Tuple)
         """
         sample_batch_size = sample.size()[0]
         compiled_batch_size = self.compiled_batch_size

--- a/src/optimum/rbln/diffusers/models/unets/unet_2d_condition.py
+++ b/src/optimum/rbln/diffusers/models/unets/unet_2d_condition.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import torch
 from diffusers.models.unets.unet_2d_condition import UNet2DConditionModel, UNet2DConditionOutput
@@ -40,11 +40,11 @@ class _UNet_SD(torch.nn.Module):
     def forward(
         self,
         sample: torch.Tensor,
-        timestep: Union[torch.Tensor, float, int],
+        timestep: torch.Tensor | float | int,
         encoder_hidden_states: torch.Tensor,
-        *down_and_mid_block_additional_residuals: Optional[Tuple[torch.Tensor]],
-        text_embeds: Optional[torch.Tensor] = None,
-        time_ids: Optional[torch.Tensor] = None,
+        *down_and_mid_block_additional_residuals: tuple[torch.Tensor] | None,
+        text_embeds: torch.Tensor | None = None,
+        time_ids: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if text_embeds is not None and time_ids is not None:
             added_cond_kwargs = {"text_embeds": text_embeds, "time_ids": time_ids}
@@ -79,9 +79,9 @@ class _UNet_SDXL(torch.nn.Module):
     def forward(
         self,
         sample: torch.Tensor,
-        timestep: Union[torch.Tensor, float, int],
+        timestep: torch.Tensor | float | int,
         encoder_hidden_states: torch.Tensor,
-        *down_and_mid_block_additional_residuals: Optional[Tuple[torch.Tensor]],
+        *down_and_mid_block_additional_residuals: tuple[torch.Tensor] | None,
     ) -> torch.Tensor:
         if len(down_and_mid_block_additional_residuals) == 2:
             added_cond_kwargs = {
@@ -124,7 +124,7 @@ class _UNet_Kandinsky(torch.nn.Module):
     def forward(
         self,
         sample: torch.Tensor,
-        timestep: Union[torch.Tensor, float, int],
+        timestep: torch.Tensor | float | int,
         image_embeds: torch.Tensor,
     ) -> torch.Tensor:
         added_cond_kwargs = {"image_embeds": image_embeds}
@@ -186,8 +186,8 @@ class RBLNUNet2DConditionModel(RBLNModel):
         cls,
         pipe: RBLNDiffusionMixin,
         rbln_config: RBLNUNet2DConditionModelConfig,
-        image_size: Optional[Tuple[int, int]] = None,
-    ) -> Tuple[int, int]:
+        image_size: tuple[int, int] | None = None,
+    ) -> tuple[int, int]:
         if hasattr(pipe, "movq"):
             scale_factor = 2 ** (len(pipe.movq.config.block_out_channels) - 1)
         else:
@@ -335,20 +335,20 @@ class RBLNUNet2DConditionModel(RBLNModel):
     def forward(
         self,
         sample: torch.Tensor,
-        timestep: Union[torch.Tensor, float, int],
+        timestep: torch.Tensor | float | int,
         encoder_hidden_states: torch.Tensor,
-        class_labels: Optional[torch.Tensor] = None,
-        timestep_cond: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        cross_attention_kwargs: Optional[Dict[str, Any]] = None,
-        added_cond_kwargs: Optional[Dict[str, torch.Tensor]] = None,
-        down_block_additional_residuals: Optional[Tuple[torch.Tensor]] = None,
-        mid_block_additional_residual: Optional[torch.Tensor] = None,
-        down_intrablock_additional_residuals: Optional[Tuple[torch.Tensor]] = None,
-        encoder_attention_mask: Optional[torch.Tensor] = None,
+        class_labels: torch.Tensor | None = None,
+        timestep_cond: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        cross_attention_kwargs: dict[str, Any] | None = None,
+        added_cond_kwargs: dict[str, torch.Tensor] | None = None,
+        down_block_additional_residuals: tuple[torch.Tensor] | None = None,
+        mid_block_additional_residual: torch.Tensor | None = None,
+        down_intrablock_additional_residuals: tuple[torch.Tensor] | None = None,
+        encoder_attention_mask: torch.Tensor | None = None,
         return_dict: bool = True,
         **kwargs,
-    ) -> Union[UNet2DConditionOutput, Tuple]:
+    ) -> UNet2DConditionOutput | tuple:
         """
         Forward pass for the RBLN-optimized UNet2DConditionModel.
 

--- a/src/optimum/rbln/diffusers/models/unets/unet_spatio_temporal_condition.py
+++ b/src/optimum/rbln/diffusers/models/unets/unet_spatio_temporal_condition.py
@@ -173,13 +173,13 @@ class RBLNUNetSpatioTemporalConditionModel(RBLNModel):
 
         Args:
             sample (torch.Tensor): The noisy input tensor with the following shape `(batch, channel, height, width)`.
-            timestep (Union[torch.Tensor, float, int]): The number of timesteps to denoise an input.
+            timestep (torch.Tensor | float | int): The number of timesteps to denoise an input.
             encoder_hidden_states (torch.Tensor): The encoder hidden states.
             added_time_ids (torch.Tensor): A tensor containing additional sinusoidal embeddings and added to the time embeddings.
             return_dict (bool): Whether or not to return a [`~diffusers.models.unets.unet_spatio_temporal_condition.UNetSpatioTemporalConditionOutput`] instead of a plain tuple.
 
         Returns:
-            (Union[`~diffusers.models.unets.unet_spatio_temporal_condition.UNetSpatioTemporalConditionOutput`], Tuple)
+            (`~diffusers.models.unets.unet_spatio_temporal_condition.UNetSpatioTemporalConditionOutput`, Tuple)
         """
         sample_batch_size = sample.size()[0]
         compiled_batch_size = self.compiled_batch_size

--- a/src/optimum/rbln/diffusers/models/unets/unet_spatio_temporal_condition.py
+++ b/src/optimum/rbln/diffusers/models/unets/unet_spatio_temporal_condition.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import torch
 from diffusers.models.unets.unet_spatio_temporal_condition import (
@@ -43,7 +43,7 @@ class _UNet_STCM(torch.nn.Module):
     def forward(
         self,
         sample: torch.Tensor,
-        timestep: Union[torch.Tensor, float, int],
+        timestep: torch.Tensor | float | int,
         encoder_hidden_states: torch.Tensor,
         added_time_ids: torch.Tensor,
     ) -> torch.Tensor:
@@ -90,8 +90,8 @@ class RBLNUNetSpatioTemporalConditionModel(RBLNModel):
         cls,
         pipe: RBLNDiffusionMixin,
         rbln_config: RBLNUNetSpatioTemporalConditionModelConfig,
-        image_size: Optional[Tuple[int, int]] = None,
-    ) -> Union[int, Tuple[int, int]]:
+        image_size: tuple[int, int] | None = None,
+    ) -> int | tuple[int, int]:
         scale_factor = pipe.vae_scale_factor
 
         if image_size is None:
@@ -110,7 +110,7 @@ class RBLNUNetSpatioTemporalConditionModel(RBLNModel):
     @classmethod
     def update_rbln_config_using_pipe(
         cls, pipe: RBLNDiffusionMixin, rbln_config: "RBLNDiffusionMixinConfig", submodule_name: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         rbln_config.unet.sample_size = cls.get_unet_sample_size(
             pipe, rbln_config.unet, image_size=rbln_config.image_size
         )
@@ -162,12 +162,12 @@ class RBLNUNetSpatioTemporalConditionModel(RBLNModel):
     def forward(
         self,
         sample: torch.Tensor,
-        timestep: Union[torch.Tensor, float, int],
+        timestep: torch.Tensor | float | int,
         encoder_hidden_states: torch.Tensor,
         added_time_ids: torch.Tensor,
         return_dict: bool = True,
         **kwargs,
-    ) -> Union[UNetSpatioTemporalConditionOutput, Tuple]:
+    ) -> UNetSpatioTemporalConditionOutput | tuple:
         """
         Forward pass for the RBLN-optimized UNetSpatioTemporalConditionModel.
 

--- a/src/optimum/rbln/diffusers/pipelines/auto_pipeline.py
+++ b/src/optimum/rbln/diffusers/pipelines/auto_pipeline.py
@@ -213,7 +213,7 @@ class RBLNAutoPipelineBase:
         Register a new RBLN model class.
 
         Args:
-            rbln_cls (Type[RBLNBaseModel]): The RBLN model class to register.
+            rbln_cls (type[RBLNBaseModel]): The RBLN model class to register.
             exist_ok (bool): Whether to allow registering an already registered model.
         """
         if not issubclass(rbln_cls, RBLNBaseModel):

--- a/src/optimum/rbln/diffusers/pipelines/auto_pipeline.py
+++ b/src/optimum/rbln/diffusers/pipelines/auto_pipeline.py
@@ -15,7 +15,7 @@
 
 import importlib
 from pathlib import Path
-from typing import Any, Dict, Optional, Type, Union
+from typing import Any
 
 from diffusers.models.controlnets import ControlNetUnionModel
 from diffusers.pipelines.auto_pipeline import (
@@ -44,7 +44,7 @@ class RBLNAutoPipelineBase:
     _model_mapping_names = None
 
     @classmethod
-    def get_rbln_cls(cls, pretrained_model_name_or_path: Union[str, Path], export: bool = None, **kwargs):
+    def get_rbln_cls(cls, pretrained_model_name_or_path: str | Path, export: bool = None, **kwargs):
         if isinstance(pretrained_model_name_or_path, Path):
             pretrained_model_name_or_path = pretrained_model_name_or_path.as_posix()
 
@@ -74,7 +74,7 @@ class RBLNAutoPipelineBase:
         return rbln_cls
 
     @classmethod
-    def get_rbln_model_cls_name(cls, pretrained_model_name_or_path: Union[str, Path], **kwargs):
+    def get_rbln_model_cls_name(cls, pretrained_model_name_or_path: str | Path, **kwargs):
         """
         Retrieve the path to the compiled model directory for a given RBLN model.
 
@@ -97,7 +97,7 @@ class RBLNAutoPipelineBase:
     @classmethod
     def _is_compiled_pipeline(
         cls,
-        pretrained_model_name_or_path: Union[str, Path],
+        pretrained_model_name_or_path: str | Path,
         cache_dir=None,
         force_download=False,
         proxies=None,
@@ -123,7 +123,7 @@ class RBLNAutoPipelineBase:
     @classmethod
     def infer_hf_model_class(
         cls,
-        pretrained_model_or_path: Union[str, Path],
+        pretrained_model_or_path: str | Path,
         cache_dir=None,
         force_download=False,
         proxies=None,
@@ -171,10 +171,10 @@ class RBLNAutoPipelineBase:
     @validate_hf_hub_args
     def from_pretrained(
         cls,
-        model_id: Union[str, Path],
+        model_id: str | Path,
         *,
         export: bool = None,
-        rbln_config: Optional[Union[Dict[str, Any], RBLNModelConfig]] = None,
+        rbln_config: dict[str, Any] | RBLNModelConfig | None = None,
         **kwargs: Any,
     ) -> RBLNBaseModel:
         """
@@ -208,7 +208,7 @@ class RBLNAutoPipelineBase:
         return rbln_cls.from_pretrained(model_id, export=export, rbln_config=rbln_config, **kwargs)
 
     @staticmethod
-    def register(rbln_cls: Type[RBLNBaseModel], exist_ok=False):
+    def register(rbln_cls: type[RBLNBaseModel], exist_ok=False):
         """
         Register a new RBLN model class.
 

--- a/src/optimum/rbln/diffusers/pipelines/controlnet/multicontrolnet.py
+++ b/src/optimum/rbln/diffusers/pipelines/controlnet/multicontrolnet.py
@@ -14,7 +14,7 @@
 
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 import torch
 from diffusers.pipelines.controlnet.multicontrolnet import MultiControlNetModel
@@ -33,7 +33,7 @@ class RBLNMultiControlNetModel(RBLNModel):
 
     def __init__(
         self,
-        models: List[RBLNControlNetModel],
+        models: list[RBLNControlNetModel],
     ):
         self.nets = models
         self.dtype = torch.float32
@@ -48,7 +48,7 @@ class RBLNMultiControlNetModel(RBLNModel):
     @classmethod
     def _from_pretrained(
         cls,
-        model_id: Union[str, Path],
+        model_id: str | Path,
         **kwargs,
     ) -> RBLNModel:
         idx = 0
@@ -71,7 +71,7 @@ class RBLNMultiControlNetModel(RBLNModel):
             controlnets,
         )
 
-    def save_pretrained(self, save_directory: Union[str, Path], **kwargs):
+    def save_pretrained(self, save_directory: str | Path, **kwargs):
         for idx, model in enumerate(self.nets):
             suffix = "" if idx == 0 else f"_{idx}"
             real_save_path = save_directory + suffix
@@ -84,15 +84,15 @@ class RBLNMultiControlNetModel(RBLNModel):
     def forward(
         self,
         sample: torch.FloatTensor,
-        timestep: Union[torch.Tensor, float, int],
+        timestep: torch.Tensor | float | int,
         encoder_hidden_states: torch.Tensor,
-        controlnet_cond: List[torch.Tensor],
-        conditioning_scale: List[float],
-        class_labels: Optional[torch.Tensor] = None,
-        timestep_cond: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        added_cond_kwargs: Optional[Dict[str, torch.Tensor]] = None,
-        cross_attention_kwargs: Optional[Dict[str, Any]] = None,
+        controlnet_cond: list[torch.Tensor],
+        conditioning_scale: list[float],
+        class_labels: torch.Tensor | None = None,
+        timestep_cond: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        added_cond_kwargs: dict[str, torch.Tensor] | None = None,
+        cross_attention_kwargs: dict[str, Any] | None = None,
         guess_mode: bool = False,
         return_dict: bool = True,
     ):

--- a/src/optimum/rbln/diffusers/pipelines/controlnet/multicontrolnet.py
+++ b/src/optimum/rbln/diffusers/pipelines/controlnet/multicontrolnet.py
@@ -105,16 +105,16 @@ class RBLNMultiControlNetModel(RBLNModel):
 
         Args:
             sample (torch.FloatTensor): The noisy input tensor.
-            timestep (Union[torch.Tensor, float, int]): The number of timesteps to denoise an input.
+            timestep (torch.Tensor | float | int): The number of timesteps to denoise an input.
             encoder_hidden_states (torch.Tensor): The encoder hidden states from the text encoder.
-            controlnet_cond (List[torch.Tensor]): A list of conditional input tensors, one for each ControlNet model.
-            conditioning_scale (List[float]): A list of scale factors for each ControlNet output. Each scale
+            controlnet_cond (list[torch.Tensor]): A list of conditional input tensors, one for each ControlNet model.
+            conditioning_scale (list[float]): A list of scale factors for each ControlNet output. Each scale
                 controls the strength of the corresponding ControlNet's influence on the generation.
             return_dict (bool): Whether or not to return a dictionary instead of a plain tuple. Currently,
                 this method always returns a tuple regardless of this parameter.
 
         Returns:
-            (Tuple[List[torch.Tensor], torch.Tensor])
+            (tuple[list[torch.Tensor], torch.Tensor])
         """
         for i, (image, scale, controlnet) in enumerate(
             zip(controlnet_cond, conditioning_scale, self.nets, strict=False)

--- a/src/optimum/rbln/diffusers/pipelines/controlnet/pipeline_controlnet.py
+++ b/src/optimum/rbln/diffusers/pipelines/controlnet/pipeline_controlnet.py
@@ -266,10 +266,10 @@ class RBLNStableDiffusionControlNetPipeline(RBLNDiffusionMixin, StableDiffusionC
         The call function to the pipeline for generation.
 
         Args:
-            prompt (`str` or `List[str]`, *optional*):
+            prompt (`str` or `list[str]`, *optional*):
                 The prompt or prompts to guide image generation. If not defined, you need to pass `prompt_embeds`.
-            image (`torch.FloatTensor`, `PIL.Image.Image`, `np.ndarray`, `List[torch.FloatTensor]`, `List[PIL.Image.Image]`, `List[np.ndarray]`,:
-                    `List[List[torch.FloatTensor]]`, `List[List[np.ndarray]]` or `List[List[PIL.Image.Image]]`):
+            image (`torch.FloatTensor`, `PIL.Image.Image`, `np.ndarray`, `list[torch.FloatTensor]`, `list[PIL.Image.Image]`, `list[np.ndarray]`,:
+                    `list[list[torch.FloatTensor]]`, `list[list[np.ndarray]]` or `list[list[PIL.Image.Image]]`):
                 The ControlNet input condition to provide guidance to the `unet` for generation. If the type is
                 specified as `torch.FloatTensor`, it is passed to ControlNet as is. `PIL.Image.Image` can also be
                 accepted as an image. The dimensions of the output image defaults to `image`'s dimensions. If height
@@ -285,14 +285,14 @@ class RBLNStableDiffusionControlNetPipeline(RBLNDiffusionMixin, StableDiffusionC
             num_inference_steps (`int`, *optional*, defaults to 50):
                 The number of denoising steps. More denoising steps usually lead to a higher quality image at the
                 expense of slower inference.
-            timesteps (`List[int]`, *optional*):
+            timesteps (`list[int]`, *optional*):
                 Custom timesteps to use for the denoising process with schedulers which support a `timesteps` argument
                 in their `set_timesteps` method. If not defined, the default behavior when `num_inference_steps` is
                 passed will be used. Must be in descending order.
             guidance_scale (`float`, *optional*, defaults to 7.5):
                 A higher guidance scale value encourages the model to generate images closely linked to the text
                 `prompt` at the expense of lower image quality. Guidance scale is enabled when `guidance_scale > 1`.
-            negative_prompt (`str` or `List[str]`, *optional*):
+            negative_prompt (`str` or `list[str]`, *optional*):
                 The prompt or prompts to guide what to not include in image generation. If not defined, you need to
                 pass `negative_prompt_embeds` instead. Ignored when not using guidance (`guidance_scale < 1`).
             num_images_per_prompt (`int`, *optional*, defaults to 1):
@@ -300,7 +300,7 @@ class RBLNStableDiffusionControlNetPipeline(RBLNDiffusionMixin, StableDiffusionC
             eta (`float`, *optional*, defaults to 0.0):
                 Corresponds to parameter eta (η) from the [DDIM](https://arxiv.org/abs/2010.02502) paper. Only applies
                 to the [`~schedulers.DDIMScheduler`], and is ignored in other schedulers.
-            generator (`torch.Generator` or `List[torch.Generator]`, *optional*):
+            generator (`torch.Generator` or `list[torch.Generator]`, *optional*):
                 A [`torch.Generator`](https://pytorch.org/docs/stable/generated/torch.Generator.html) to make
                 generation deterministic.
             latents (`torch.FloatTensor`, *optional*):
@@ -314,7 +314,7 @@ class RBLNStableDiffusionControlNetPipeline(RBLNDiffusionMixin, StableDiffusionC
                 Pre-generated negative text embeddings. Can be used to easily tweak text inputs (prompt weighting). If
                 not provided, `negative_prompt_embeds` are generated from the `negative_prompt` input argument.
             ip_adapter_image: (`PipelineImageInput`, *optional*): Optional image input to work with IP Adapters.
-            ip_adapter_image_embeds (`List[torch.FloatTensor]`, *optional*):
+            ip_adapter_image_embeds (`list[torch.FloatTensor]`, *optional*):
                 Pre-generated image embeddings for IP-Adapter. It should be a list of length same as number of IP-adapters.
                 Each element should be a tensor of shape `(batch_size, num_images, emb_dim)`. It should contain the negative image embedding
                 if `do_classifier_free_guidance` is set to `True`.
@@ -326,16 +326,16 @@ class RBLNStableDiffusionControlNetPipeline(RBLNDiffusionMixin, StableDiffusionC
             cross_attention_kwargs (`dict`, *optional*):
                 A kwargs dictionary that if specified is passed along to the [`AttentionProcessor`] as defined in
                 [`self.processor`](https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/attention_processor.py).
-            controlnet_conditioning_scale (`float` or `List[float]`, *optional*, defaults to 1.0):
+            controlnet_conditioning_scale (`float` or `list[float]`, *optional*, defaults to 1.0):
                 The outputs of the ControlNet are multiplied by `controlnet_conditioning_scale` before they are added
                 to the residual in the original `unet`. If multiple ControlNets are specified in `init`, you can set
                 the corresponding scale as a list.
             guess_mode (`bool`, *optional*, defaults to `False`):
                 The ControlNet encoder tries to recognize the content of the input image even if you remove all
                 prompts. A `guidance_scale` value between 3.0 and 5.0 is recommended.
-            control_guidance_start (`float` or `List[float]`, *optional*, defaults to 0.0):
+            control_guidance_start (`float` or `list[float]`, *optional*, defaults to 0.0):
                 The percentage of total steps at which the ControlNet starts applying.
-            control_guidance_end (`float` or `List[float]`, *optional*, defaults to 1.0):
+            control_guidance_end (`float` or `list[float]`, *optional*, defaults to 1.0):
                 The percentage of total steps at which the ControlNet stops applying.
             clip_skip (`int`, *optional*):
                 Number of layers to be skipped from CLIP while computing the prompt embeddings. A value of 1 means that

--- a/src/optimum/rbln/diffusers/pipelines/controlnet/pipeline_controlnet.py
+++ b/src/optimum/rbln/diffusers/pipelines/controlnet/pipeline_controlnet.py
@@ -26,7 +26,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from collections.abc import Callable
+from typing import Any
 
 import torch
 import torch.nn.functional as F
@@ -233,34 +234,34 @@ class RBLNStableDiffusionControlNetPipeline(RBLNDiffusionMixin, StableDiffusionC
     @remove_compile_time_kwargs
     def __call__(
         self,
-        prompt: Union[str, List[str]] = None,
+        prompt: str | list[str] = None,
         image: PipelineImageInput = None,
-        height: Optional[int] = None,
-        width: Optional[int] = None,
+        height: int | None = None,
+        width: int | None = None,
         num_inference_steps: int = 50,
-        timesteps: List[int] = None,
+        timesteps: list[int] = None,
         guidance_scale: float = 7.5,
-        negative_prompt: Optional[Union[str, List[str]]] = None,
-        num_images_per_prompt: Optional[int] = 1,
+        negative_prompt: str | list[str] | None = None,
+        num_images_per_prompt: int | None = 1,
         eta: float = 0.0,
-        generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
-        latents: Optional[torch.FloatTensor] = None,
-        prompt_embeds: Optional[torch.FloatTensor] = None,
-        negative_prompt_embeds: Optional[torch.FloatTensor] = None,
-        ip_adapter_image: Optional[PipelineImageInput] = None,
-        ip_adapter_image_embeds: Optional[List[torch.FloatTensor]] = None,
-        output_type: Optional[str] = "pil",
+        generator: torch.Generator | list[torch.Generator] | None = None,
+        latents: torch.FloatTensor | None = None,
+        prompt_embeds: torch.FloatTensor | None = None,
+        negative_prompt_embeds: torch.FloatTensor | None = None,
+        ip_adapter_image: PipelineImageInput | None = None,
+        ip_adapter_image_embeds: list[torch.FloatTensor] | None = None,
+        output_type: str | None = "pil",
         return_dict: bool = True,
-        cross_attention_kwargs: Optional[Dict[str, Any]] = None,
-        controlnet_conditioning_scale: Union[float, List[float]] = 1.0,
+        cross_attention_kwargs: dict[str, Any] | None = None,
+        controlnet_conditioning_scale: float | list[float] = 1.0,
         guess_mode: bool = False,
-        control_guidance_start: Union[float, List[float]] = 0.0,
-        control_guidance_end: Union[float, List[float]] = 1.0,
-        clip_skip: Optional[int] = None,
-        callback_on_step_end: Optional[Callable[[int, int, Dict], None]] = None,
-        callback_on_step_end_tensor_inputs: Optional[List[str]] = None,
+        control_guidance_start: float | list[float] = 0.0,
+        control_guidance_end: float | list[float] = 1.0,
+        clip_skip: int | None = None,
+        callback_on_step_end: Callable[[int, int, dict], None] | None = None,
+        callback_on_step_end_tensor_inputs: list[str] | None = None,
         **kwargs,
-    ) -> Union[StableDiffusionPipelineOutput, Tuple]:
+    ) -> StableDiffusionPipelineOutput | tuple:
         r"""
         The call function to the pipeline for generation.
 

--- a/src/optimum/rbln/diffusers/pipelines/controlnet/pipeline_controlnet_img2img.py
+++ b/src/optimum/rbln/diffusers/pipelines/controlnet/pipeline_controlnet_img2img.py
@@ -259,14 +259,14 @@ class RBLNStableDiffusionControlNetImg2ImgPipeline(RBLNDiffusionMixin, StableDif
         The call function to the pipeline for generation.
 
         Args:
-            prompt (`str` or `List[str]`, *optional*):
+            prompt (`str` or `list[str]`, *optional*):
                 The prompt or prompts to guide image generation. If not defined, you need to pass `prompt_embeds`.
-            image (`torch.FloatTensor`, `PIL.Image.Image`, `np.ndarray`, `List[torch.FloatTensor]`, `List[PIL.Image.Image]`, `List[np.ndarray]`,:
-                    `List[List[torch.FloatTensor]]`, `List[List[np.ndarray]]` or `List[List[PIL.Image.Image]]`):
+            image (`torch.FloatTensor`, `PIL.Image.Image`, `np.ndarray`, `list[torch.FloatTensor]`, `list[PIL.Image.Image]`, `list[np.ndarray]`,:
+                    `list[list[torch.FloatTensor]]`, `list[list[np.ndarray]]` or `list[list[PIL.Image.Image]]`):
                 The initial image to be used as the starting point for the image generation process. Can also accept
                 image latents as `image`, and if passing latents directly they are not encoded again.
-            control_image (`torch.FloatTensor`, `PIL.Image.Image`, `np.ndarray`, `List[torch.FloatTensor]`, `List[PIL.Image.Image]`, `List[np.ndarray]`,:
-                    `List[List[torch.FloatTensor]]`, `List[List[np.ndarray]]` or `List[List[PIL.Image.Image]]`):
+            control_image (`torch.FloatTensor`, `PIL.Image.Image`, `np.ndarray`, `list[torch.FloatTensor]`, `list[PIL.Image.Image]`, `list[np.ndarray]`,:
+                    `list[list[torch.FloatTensor]]`, `list[list[np.ndarray]]` or `list[list[PIL.Image.Image]]`):
                 The ControlNet input condition to provide guidance to the `unet` for generation. If the type is
                 specified as `torch.FloatTensor`, it is passed to ControlNet as is. `PIL.Image.Image` can also be
                 accepted as an image. The dimensions of the output image defaults to `image`'s dimensions. If height
@@ -289,7 +289,7 @@ class RBLNStableDiffusionControlNetImg2ImgPipeline(RBLNDiffusionMixin, StableDif
             guidance_scale (`float`, *optional*, defaults to 7.5):
                 A higher guidance scale value encourages the model to generate images closely linked to the text
                 `prompt` at the expense of lower image quality. Guidance scale is enabled when `guidance_scale > 1`.
-            negative_prompt (`str` or `List[str]`, *optional*):
+            negative_prompt (`str` or `list[str]`, *optional*):
                 The prompt or prompts to guide what to not include in image generation. If not defined, you need to
                 pass `negative_prompt_embeds` instead. Ignored when not using guidance (`guidance_scale < 1`).
             num_images_per_prompt (`int`, *optional*, defaults to 1):
@@ -297,7 +297,7 @@ class RBLNStableDiffusionControlNetImg2ImgPipeline(RBLNDiffusionMixin, StableDif
             eta (`float`, *optional*, defaults to 0.0):
                 Corresponds to parameter eta (η) from the [DDIM](https://arxiv.org/abs/2010.02502) paper. Only applies
                 to the [`~schedulers.DDIMScheduler`], and is ignored in other schedulers.
-            generator (`torch.Generator` or `List[torch.Generator]`, *optional*):
+            generator (`torch.Generator` or `list[torch.Generator]`, *optional*):
                 A [`torch.Generator`](https://pytorch.org/docs/stable/generated/torch.Generator.html) to make
                 generation deterministic.
             latents (`torch.FloatTensor`, *optional*):
@@ -311,7 +311,7 @@ class RBLNStableDiffusionControlNetImg2ImgPipeline(RBLNDiffusionMixin, StableDif
                 Pre-generated negative text embeddings. Can be used to easily tweak text inputs (prompt weighting). If
                 not provided, `negative_prompt_embeds` are generated from the `negative_prompt` input argument.
             ip_adapter_image: (`PipelineImageInput`, *optional*): Optional image input to work with IP Adapters.
-            ip_adapter_image_embeds (`List[torch.FloatTensor]`, *optional*):
+            ip_adapter_image_embeds (`list[torch.FloatTensor]`, *optional*):
                 Pre-generated image embeddings for IP-Adapter. It should be a list of length same as number of IP-adapters.
                 Each element should be a tensor of shape `(batch_size, num_images, emb_dim)`. It should contain the negative image embedding
                 if `do_classifier_free_guidance` is set to `True`.
@@ -324,16 +324,16 @@ class RBLNStableDiffusionControlNetImg2ImgPipeline(RBLNDiffusionMixin, StableDif
             cross_attention_kwargs (`dict`, *optional*):
                 A kwargs dictionary that if specified is passed along to the [`AttentionProcessor`] as defined in
                 [`self.processor`](https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/attention_processor.py).
-            controlnet_conditioning_scale (`float` or `List[float]`, *optional*, defaults to 1.0):
+            controlnet_conditioning_scale (`float` or `list[float]`, *optional*, defaults to 1.0):
                 The outputs of the ControlNet are multiplied by `controlnet_conditioning_scale` before they are added
                 to the residual in the original `unet`. If multiple ControlNets are specified in `init`, you can set
                 the corresponding scale as a list.
             guess_mode (`bool`, *optional*, defaults to `False`):
                 The ControlNet encoder tries to recognize the content of the input image even if you remove all
                 prompts. A `guidance_scale` value between 3.0 and 5.0 is recommended.
-            control_guidance_start (`float` or `List[float]`, *optional*, defaults to 0.0):
+            control_guidance_start (`float` or `list[float]`, *optional*, defaults to 0.0):
                 The percentage of total steps at which the ControlNet starts applying.
-            control_guidance_end (`float` or `List[float]`, *optional*, defaults to 1.0):
+            control_guidance_end (`float` or `list[float]`, *optional*, defaults to 1.0):
                 The percentage of total steps at which the ControlNet stops applying.
             clip_skip (`int`, *optional*):
                 Number of layers to be skipped from CLIP while computing the prompt embeddings. A value of 1 means that

--- a/src/optimum/rbln/diffusers/pipelines/controlnet/pipeline_controlnet_img2img.py
+++ b/src/optimum/rbln/diffusers/pipelines/controlnet/pipeline_controlnet_img2img.py
@@ -26,7 +26,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from collections.abc import Callable
+from typing import Any
 
 import torch
 import torch.nn.functional as F
@@ -225,35 +226,35 @@ class RBLNStableDiffusionControlNetImg2ImgPipeline(RBLNDiffusionMixin, StableDif
     @remove_compile_time_kwargs
     def __call__(
         self,
-        prompt: Union[str, List[str]] = None,
+        prompt: str | list[str] = None,
         image: PipelineImageInput = None,
         control_image: PipelineImageInput = None,
-        height: Optional[int] = None,
-        width: Optional[int] = None,
+        height: int | None = None,
+        width: int | None = None,
         strength: float = 0.8,
         num_inference_steps: int = 50,
         guidance_scale: float = 7.5,
-        negative_prompt: Optional[Union[str, List[str]]] = None,
-        num_images_per_prompt: Optional[int] = 1,
+        negative_prompt: str | list[str] | None = None,
+        num_images_per_prompt: int | None = 1,
         eta: float = 0.0,
-        generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
-        latents: Optional[torch.FloatTensor] = None,
-        prompt_embeds: Optional[torch.FloatTensor] = None,
-        negative_prompt_embeds: Optional[torch.FloatTensor] = None,
-        ip_adapter_image: Optional[PipelineImageInput] = None,
-        ip_adapter_image_embeds: Optional[List[torch.FloatTensor]] = None,
-        output_type: Optional[str] = "pil",
+        generator: torch.Generator | list[torch.Generator] | None = None,
+        latents: torch.FloatTensor | None = None,
+        prompt_embeds: torch.FloatTensor | None = None,
+        negative_prompt_embeds: torch.FloatTensor | None = None,
+        ip_adapter_image: PipelineImageInput | None = None,
+        ip_adapter_image_embeds: list[torch.FloatTensor] | None = None,
+        output_type: str | None = "pil",
         return_dict: bool = True,
-        cross_attention_kwargs: Optional[Dict[str, Any]] = None,
-        controlnet_conditioning_scale: Union[float, List[float]] = 0.8,
+        cross_attention_kwargs: dict[str, Any] | None = None,
+        controlnet_conditioning_scale: float | list[float] = 0.8,
         guess_mode: bool = False,
-        control_guidance_start: Union[float, List[float]] = 0.0,
-        control_guidance_end: Union[float, List[float]] = 1.0,
-        clip_skip: Optional[int] = None,
-        callback_on_step_end: Optional[Callable[[int, int, Dict], None]] = None,
-        callback_on_step_end_tensor_inputs: Optional[List[str]] = None,
+        control_guidance_start: float | list[float] = 0.0,
+        control_guidance_end: float | list[float] = 1.0,
+        clip_skip: int | None = None,
+        callback_on_step_end: Callable[[int, int, dict], None] | None = None,
+        callback_on_step_end_tensor_inputs: list[str] | None = None,
         **kwargs,
-    ) -> Union[StableDiffusionPipelineOutput, Tuple]:
+    ) -> StableDiffusionPipelineOutput | tuple:
         r"""
         The call function to the pipeline for generation.
 

--- a/src/optimum/rbln/diffusers/pipelines/controlnet/pipeline_controlnet_sd_xl.py
+++ b/src/optimum/rbln/diffusers/pipelines/controlnet/pipeline_controlnet_sd_xl.py
@@ -300,13 +300,13 @@ class RBLNStableDiffusionXLControlNetPipeline(RBLNDiffusionMixin, StableDiffusio
         The call function to the pipeline for generation.
 
         Args:
-            prompt (`str` or `List[str]`, *optional*):
+            prompt (`str` or `list[str]`, *optional*):
                 The prompt or prompts to guide image generation. If not defined, you need to pass `prompt_embeds`.
-            prompt_2 (`str` or `List[str]`, *optional*):
+            prompt_2 (`str` or `list[str]`, *optional*):
                 The prompt or prompts to be sent to `tokenizer_2` and `text_encoder_2`. If not defined, `prompt` is
                 used in both text-encoders.
-            image (`torch.FloatTensor`, `PIL.Image.Image`, `np.ndarray`, `List[torch.FloatTensor]`, `List[PIL.Image.Image]`, `List[np.ndarray]`,:
-                    `List[List[torch.FloatTensor]]`, `List[List[np.ndarray]]` or `List[List[PIL.Image.Image]]`):
+            image (`torch.FloatTensor`, `PIL.Image.Image`, `np.ndarray`, `list[torch.FloatTensor]`, `list[PIL.Image.Image]`, `list[np.ndarray]`,:
+                    `list[list[torch.FloatTensor]]`, `list[list[np.ndarray]]` or `list[list[PIL.Image.Image]]`):
                 The ControlNet input condition to provide guidance to the `unet` for generation. If the type is
                 specified as `torch.FloatTensor`, it is passed to ControlNet as is. `PIL.Image.Image` can also be
                 accepted as an image. The dimensions of the output image defaults to `image`'s dimensions. If height
@@ -334,10 +334,10 @@ class RBLNStableDiffusionXLControlNetPipeline(RBLNDiffusionMixin, StableDiffusio
             guidance_scale (`float`, *optional*, defaults to 5.0):
                 A higher guidance scale value encourages the model to generate images closely linked to the text
                 `prompt` at the expense of lower image quality. Guidance scale is enabled when `guidance_scale > 1`.
-            negative_prompt (`str` or `List[str]`, *optional*):
+            negative_prompt (`str` or `list[str]`, *optional*):
                 The prompt or prompts to guide what to not include in image generation. If not defined, you need to
                 pass `negative_prompt_embeds` instead. Ignored when not using guidance (`guidance_scale < 1`).
-            negative_prompt_2 (`str` or `List[str]`, *optional*):
+            negative_prompt_2 (`str` or `list[str]`, *optional*):
                 The prompt or prompts to guide what to not include in image generation. This is sent to `tokenizer_2`
                 and `text_encoder_2`. If not defined, `negative_prompt` is used in both text-encoders.
             num_images_per_prompt (`int`, *optional*, defaults to 1):
@@ -345,7 +345,7 @@ class RBLNStableDiffusionXLControlNetPipeline(RBLNDiffusionMixin, StableDiffusio
             eta (`float`, *optional*, defaults to 0.0):
                 Corresponds to parameter eta (η) from the [DDIM](https://arxiv.org/abs/2010.02502) paper. Only applies
                 to the [`~schedulers.DDIMScheduler`], and is ignored in other schedulers.
-            generator (`torch.Generator` or `List[torch.Generator]`, *optional*):
+            generator (`torch.Generator` or `list[torch.Generator]`, *optional*):
                 A [`torch.Generator`](https://pytorch.org/docs/stable/generated/torch.Generator.html) to make
                 generation deterministic.
             latents (`torch.FloatTensor`, *optional*):
@@ -366,7 +366,7 @@ class RBLNStableDiffusionXLControlNetPipeline(RBLNDiffusionMixin, StableDiffusio
                 weighting). If not provided, pooled `negative_prompt_embeds` are generated from `negative_prompt` input
                 argument.
             ip_adapter_image: (`PipelineImageInput`, *optional*): Optional image input to work with IP Adapters.
-            ip_adapter_image_embeds (`List[torch.FloatTensor]`, *optional*):
+            ip_adapter_image_embeds (`list[torch.FloatTensor]`, *optional*):
                 Pre-generated image embeddings for IP-Adapter. It should be a list of length same as number of IP-adapters.
                 Each element should be a tensor of shape `(batch_size, num_images, emb_dim)`. It should contain the negative image embedding
                 if `do_classifier_free_guidance` is set to `True`.
@@ -379,42 +379,42 @@ class RBLNStableDiffusionXLControlNetPipeline(RBLNDiffusionMixin, StableDiffusio
             cross_attention_kwargs (`dict`, *optional*):
                 A kwargs dictionary that if specified is passed along to the [`AttentionProcessor`] as defined in
                 [`self.processor`](https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/attention_processor.py).
-            controlnet_conditioning_scale (`float` or `List[float]`, *optional*, defaults to 1.0):
+            controlnet_conditioning_scale (`float` or `list[float]`, *optional*, defaults to 1.0):
                 The outputs of the ControlNet are multiplied by `controlnet_conditioning_scale` before they are added
                 to the residual in the original `unet`. If multiple ControlNets are specified in `init`, you can set
                 the corresponding scale as a list.
             guess_mode (`bool`, *optional*, defaults to `False`):
                 The ControlNet encoder tries to recognize the content of the input image even if you remove all
                 prompts. A `guidance_scale` value between 3.0 and 5.0 is recommended.
-            control_guidance_start (`float` or `List[float]`, *optional*, defaults to 0.0):
+            control_guidance_start (`float` or `list[float]`, *optional*, defaults to 0.0):
                 The percentage of total steps at which the ControlNet starts applying.
-            control_guidance_end (`float` or `List[float]`, *optional*, defaults to 1.0):
+            control_guidance_end (`float` or `list[float]`, *optional*, defaults to 1.0):
                 The percentage of total steps at which the ControlNet stops applying.
-            original_size (`Tuple[int]`, *optional*, defaults to (1024, 1024)):
+            original_size (`tuple[int]`, *optional*, defaults to (1024, 1024)):
                 If `original_size` is not the same as `target_size` the image will appear to be down- or upsampled.
                 `original_size` defaults to `(height, width)` if not specified. Part of SDXL's micro-conditioning as
                 explained in section 2.2 of
                 [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952).
-            crops_coords_top_left (`Tuple[int]`, *optional*, defaults to (0, 0)):
+            crops_coords_top_left (`tuple[int]`, *optional*, defaults to (0, 0)):
                 `crops_coords_top_left` can be used to generate an image that appears to be "cropped" from the position
                 `crops_coords_top_left` downwards. Favorable, well-centered images are usually achieved by setting
                 `crops_coords_top_left` to (0, 0). Part of SDXL's micro-conditioning as explained in section 2.2 of
                 [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952).
-            target_size (`Tuple[int]`, *optional*, defaults to (1024, 1024)):
+            target_size (`tuple[int]`, *optional*, defaults to (1024, 1024)):
                 For most cases, `target_size` should be set to the desired height and width of the generated image. If
                 not specified it will default to `(height, width)`. Part of SDXL's micro-conditioning as explained in
                 section 2.2 of [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952).
-            negative_original_size (`Tuple[int]`, *optional*, defaults to (1024, 1024)):
+            negative_original_size (`tuple[int]`, *optional*, defaults to (1024, 1024)):
                 To negatively condition the generation process based on a specific image resolution. Part of SDXL's
                 micro-conditioning as explained in section 2.2 of
                 [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952). For more
                 information, refer to this issue thread: https://github.com/huggingface/diffusers/issues/4208.
-            negative_crops_coords_top_left (`Tuple[int]`, *optional*, defaults to (0, 0)):
+            negative_crops_coords_top_left (`tuple[int]`, *optional*, defaults to (0, 0)):
                 To negatively condition the generation process based on a specific crop coordinates. Part of SDXL's
                 micro-conditioning as explained in section 2.2 of
                 [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952). For more
                 information, refer to this issue thread: https://github.com/huggingface/diffusers/issues/4208.
-            negative_target_size (`Tuple[int]`, *optional*, defaults to (1024, 1024)):
+            negative_target_size (`tuple[int]`, *optional*, defaults to (1024, 1024)):
                 To negatively condition the generation process based on a target image resolution. It should be as same
                 as the `target_size` for most cases. Part of SDXL's micro-conditioning as explained in section 2.2 of
                 [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952). For more

--- a/src/optimum/rbln/diffusers/pipelines/controlnet/pipeline_controlnet_sd_xl.py
+++ b/src/optimum/rbln/diffusers/pipelines/controlnet/pipeline_controlnet_sd_xl.py
@@ -26,7 +26,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from collections.abc import Callable
+from typing import Any
 
 import torch
 import torch.nn.functional as F
@@ -257,44 +258,44 @@ class RBLNStableDiffusionXLControlNetPipeline(RBLNDiffusionMixin, StableDiffusio
     @remove_compile_time_kwargs
     def __call__(
         self,
-        prompt: Union[str, List[str]] = None,
-        prompt_2: Optional[Union[str, List[str]]] = None,
+        prompt: str | list[str] = None,
+        prompt_2: str | list[str] | None = None,
         image: PipelineImageInput = None,
-        height: Optional[int] = None,
-        width: Optional[int] = None,
+        height: int | None = None,
+        width: int | None = None,
         num_inference_steps: int = 50,
-        denoising_end: Optional[float] = None,
+        denoising_end: float | None = None,
         guidance_scale: float = 5.0,
-        negative_prompt: Optional[Union[str, List[str]]] = None,
-        negative_prompt_2: Optional[Union[str, List[str]]] = None,
-        num_images_per_prompt: Optional[int] = 1,
+        negative_prompt: str | list[str] | None = None,
+        negative_prompt_2: str | list[str] | None = None,
+        num_images_per_prompt: int | None = 1,
         eta: float = 0.0,
-        generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
-        latents: Optional[torch.FloatTensor] = None,
-        prompt_embeds: Optional[torch.FloatTensor] = None,
-        negative_prompt_embeds: Optional[torch.FloatTensor] = None,
-        pooled_prompt_embeds: Optional[torch.FloatTensor] = None,
-        negative_pooled_prompt_embeds: Optional[torch.FloatTensor] = None,
-        ip_adapter_image: Optional[PipelineImageInput] = None,
-        ip_adapter_image_embeds: Optional[List[torch.FloatTensor]] = None,
-        output_type: Optional[str] = "pil",
+        generator: torch.Generator | list[torch.Generator] | None = None,
+        latents: torch.FloatTensor | None = None,
+        prompt_embeds: torch.FloatTensor | None = None,
+        negative_prompt_embeds: torch.FloatTensor | None = None,
+        pooled_prompt_embeds: torch.FloatTensor | None = None,
+        negative_pooled_prompt_embeds: torch.FloatTensor | None = None,
+        ip_adapter_image: PipelineImageInput | None = None,
+        ip_adapter_image_embeds: list[torch.FloatTensor] | None = None,
+        output_type: str | None = "pil",
         return_dict: bool = True,
-        cross_attention_kwargs: Optional[Dict[str, Any]] = None,
-        controlnet_conditioning_scale: Union[float, List[float]] = 1.0,
+        cross_attention_kwargs: dict[str, Any] | None = None,
+        controlnet_conditioning_scale: float | list[float] = 1.0,
         guess_mode: bool = False,
-        control_guidance_start: Union[float, List[float]] = 0.0,
-        control_guidance_end: Union[float, List[float]] = 1.0,
-        original_size: Tuple[int, int] = None,
-        crops_coords_top_left: Tuple[int, int] = (0, 0),
-        target_size: Tuple[int, int] = None,
-        negative_original_size: Optional[Tuple[int, int]] = None,
-        negative_crops_coords_top_left: Tuple[int, int] = (0, 0),
-        negative_target_size: Optional[Tuple[int, int]] = None,
-        clip_skip: Optional[int] = None,
-        callback_on_step_end: Optional[Callable[[int, int, Dict], None]] = None,
-        callback_on_step_end_tensor_inputs: Optional[List[str]] = None,
+        control_guidance_start: float | list[float] = 0.0,
+        control_guidance_end: float | list[float] = 1.0,
+        original_size: tuple[int, int] = None,
+        crops_coords_top_left: tuple[int, int] = (0, 0),
+        target_size: tuple[int, int] = None,
+        negative_original_size: tuple[int, int] | None = None,
+        negative_crops_coords_top_left: tuple[int, int] = (0, 0),
+        negative_target_size: tuple[int, int] | None = None,
+        clip_skip: int | None = None,
+        callback_on_step_end: Callable[[int, int, dict], None] | None = None,
+        callback_on_step_end_tensor_inputs: list[str] | None = None,
         **kwargs,
-    ) -> Union[StableDiffusionXLPipelineOutput, Tuple]:
+    ) -> StableDiffusionXLPipelineOutput | tuple:
         r"""
         The call function to the pipeline for generation.
 

--- a/src/optimum/rbln/diffusers/pipelines/controlnet/pipeline_controlnet_sd_xl_img2img.py
+++ b/src/optimum/rbln/diffusers/pipelines/controlnet/pipeline_controlnet_sd_xl_img2img.py
@@ -315,18 +315,18 @@ class RBLNStableDiffusionXLControlNetImg2ImgPipeline(RBLNDiffusionMixin, StableD
         Function invoked when calling the pipeline for generation.
 
         Args:
-            prompt (`str` or `List[str]`, *optional*):
+            prompt (`str` or `list[str]`, *optional*):
                 The prompt or prompts to guide the image generation. If not defined, one has to pass `prompt_embeds`.
                 instead.
-            prompt_2 (`str` or `List[str]`, *optional*):
+            prompt_2 (`str` or `list[str]`, *optional*):
                 The prompt or prompts to be sent to the `tokenizer_2` and `text_encoder_2`. If not defined, `prompt` is
                 used in both text-encoders
-            image (`torch.FloatTensor`, `PIL.Image.Image`, `np.ndarray`, `List[torch.FloatTensor]`, `List[PIL.Image.Image]`, `List[np.ndarray]`,:
-                    `List[List[torch.FloatTensor]]`, `List[List[np.ndarray]]` or `List[List[PIL.Image.Image]]`):
+            image (`torch.FloatTensor`, `PIL.Image.Image`, `np.ndarray`, `list[torch.FloatTensor]`, `list[PIL.Image.Image]`, `list[np.ndarray]`,:
+                    `list[list[torch.FloatTensor]]`, `list[list[np.ndarray]]` or `list[list[PIL.Image.Image]]`):
                 The initial image will be used as the starting point for the image generation process. Can also accept
                 image latents as `image`, if passing latents directly, it will not be encoded again.
-            control_image (`torch.FloatTensor`, `PIL.Image.Image`, `np.ndarray`, `List[torch.FloatTensor]`, `List[PIL.Image.Image]`, `List[np.ndarray]`,:
-                    `List[List[torch.FloatTensor]]`, `List[List[np.ndarray]]` or `List[List[PIL.Image.Image]]`):
+            control_image (`torch.FloatTensor`, `PIL.Image.Image`, `np.ndarray`, `list[torch.FloatTensor]`, `list[PIL.Image.Image]`, `list[np.ndarray]`,:
+                    `list[list[torch.FloatTensor]]`, `list[list[np.ndarray]]` or `list[list[PIL.Image.Image]]`):
                 The ControlNet input condition. ControlNet uses this input condition to generate guidance to Unet. If
                 the type is specified as `Torch.FloatTensor`, it is passed to ControlNet as is. `PIL.Image.Image` can
                 also be accepted as an image. The dimensions of the output image defaults to `image`'s dimensions. If
@@ -356,11 +356,11 @@ class RBLNStableDiffusionXLControlNetImg2ImgPipeline(RBLNDiffusionMixin, StableD
                 Paper](https://arxiv.org/pdf/2205.11487.pdf). Guidance scale is enabled by setting `guidance_scale >
                 1`. Higher guidance scale encourages to generate images that are closely linked to the text `prompt`,
                 usually at the expense of lower image quality.
-            negative_prompt (`str` or `List[str]`, *optional*):
+            negative_prompt (`str` or `list[str]`, *optional*):
                 The prompt or prompts not to guide the image generation. If not defined, one has to pass
                 `negative_prompt_embeds` instead. Ignored when not using guidance (i.e., ignored if `guidance_scale` is
                 less than `1`).
-            negative_prompt_2 (`str` or `List[str]`, *optional*):
+            negative_prompt_2 (`str` or `list[str]`, *optional*):
                 The prompt or prompts not to guide the image generation to be sent to `tokenizer_2` and
                 `text_encoder_2`. If not defined, `negative_prompt` is used in both text-encoders
             num_images_per_prompt (`int`, *optional*, defaults to 1):
@@ -368,7 +368,7 @@ class RBLNStableDiffusionXLControlNetImg2ImgPipeline(RBLNDiffusionMixin, StableD
             eta (`float`, *optional*, defaults to 0.0):
                 Corresponds to parameter eta (η) in the DDIM paper: https://arxiv.org/abs/2010.02502. Only applies to
                 [`schedulers.DDIMScheduler`], will be ignored for others.
-            generator (`torch.Generator` or `List[torch.Generator]`, *optional*):
+            generator (`torch.Generator` or `list[torch.Generator]`, *optional*):
                 One or a list of [torch generator(s)](https://pytorch.org/docs/stable/generated/torch.Generator.html)
                 to make generation deterministic.
             latents (`torch.FloatTensor`, *optional*):
@@ -390,7 +390,7 @@ class RBLNStableDiffusionXLControlNetImg2ImgPipeline(RBLNDiffusionMixin, StableD
                 weighting. If not provided, pooled negative_prompt_embeds will be generated from `negative_prompt`
                 input argument.
             ip_adapter_image: (`PipelineImageInput`, *optional*): Optional image input to work with IP Adapters.
-            ip_adapter_image_embeds (`List[torch.FloatTensor]`, *optional*):
+            ip_adapter_image_embeds (`list[torch.FloatTensor]`, *optional*):
                 Pre-generated image embeddings for IP-Adapter. It should be a list of length same as number of IP-adapters.
                 Each element should be a tensor of shape `(batch_size, num_images, emb_dim)`. It should contain the negative image embedding
                 if `do_classifier_free_guidance` is set to `True`.
@@ -405,42 +405,42 @@ class RBLNStableDiffusionXLControlNetImg2ImgPipeline(RBLNDiffusionMixin, StableD
                 A kwargs dictionary that if specified is passed along to the `AttentionProcessor` as defined under
                 `self.processor` in
                 [diffusers.models.attention_processor](https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/attention_processor.py).
-            controlnet_conditioning_scale (`float` or `List[float]`, *optional*, defaults to 1.0):
+            controlnet_conditioning_scale (`float` or `list[float]`, *optional*, defaults to 1.0):
                 The outputs of the controlnet are multiplied by `controlnet_conditioning_scale` before they are added
                 to the residual in the original unet. If multiple ControlNets are specified in init, you can set the
                 corresponding scale as a list.
             guess_mode (`bool`, *optional*, defaults to `False`):
                 In this mode, the ControlNet encoder will try best to recognize the content of the input image even if
                 you remove all prompts. The `guidance_scale` between 3.0 and 5.0 is recommended.
-            control_guidance_start (`float` or `List[float]`, *optional*, defaults to 0.0):
+            control_guidance_start (`float` or `list[float]`, *optional*, defaults to 0.0):
                 The percentage of total steps at which the controlnet starts applying.
-            control_guidance_end (`float` or `List[float]`, *optional*, defaults to 1.0):
+            control_guidance_end (`float` or `list[float]`, *optional*, defaults to 1.0):
                 The percentage of total steps at which the controlnet stops applying.
-            original_size (`Tuple[int]`, *optional*, defaults to (1024, 1024)):
+            original_size (`tuple[int]`, *optional*, defaults to (1024, 1024)):
                 If `original_size` is not the same as `target_size` the image will appear to be down- or upsampled.
                 `original_size` defaults to `(height, width)` if not specified. Part of SDXL's micro-conditioning as
                 explained in section 2.2 of
                 [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952).
-            crops_coords_top_left (`Tuple[int]`, *optional*, defaults to (0, 0)):
+            crops_coords_top_left (`tuple[int]`, *optional*, defaults to (0, 0)):
                 `crops_coords_top_left` can be used to generate an image that appears to be "cropped" from the position
                 `crops_coords_top_left` downwards. Favorable, well-centered images are usually achieved by setting
                 `crops_coords_top_left` to (0, 0). Part of SDXL's micro-conditioning as explained in section 2.2 of
                 [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952).
-            target_size (`Tuple[int]`, *optional*, defaults to (1024, 1024)):
+            target_size (`tuple[int]`, *optional*, defaults to (1024, 1024)):
                 For most cases, `target_size` should be set to the desired height and width of the generated image. If
                 not specified it will default to `(height, width)`. Part of SDXL's micro-conditioning as explained in
                 section 2.2 of [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952).
-            negative_original_size (`Tuple[int]`, *optional*, defaults to (1024, 1024)):
+            negative_original_size (`tuple[int]`, *optional*, defaults to (1024, 1024)):
                 To negatively condition the generation process based on a specific image resolution. Part of SDXL's
                 micro-conditioning as explained in section 2.2 of
                 [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952). For more
                 information, refer to this issue thread: https://github.com/huggingface/diffusers/issues/4208.
-            negative_crops_coords_top_left (`Tuple[int]`, *optional*, defaults to (0, 0)):
+            negative_crops_coords_top_left (`tuple[int]`, *optional*, defaults to (0, 0)):
                 To negatively condition the generation process based on a specific crop coordinates. Part of SDXL's
                 micro-conditioning as explained in section 2.2 of
                 [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952). For more
                 information, refer to this issue thread: https://github.com/huggingface/diffusers/issues/4208.
-            negative_target_size (`Tuple[int]`, *optional*, defaults to (1024, 1024)):
+            negative_target_size (`tuple[int]`, *optional*, defaults to (1024, 1024)):
                 To negatively condition the generation process based on a target image resolution. It should be as same
                 as the `target_size` for most cases. Part of SDXL's micro-conditioning as explained in section 2.2 of
                 [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952). For more

--- a/src/optimum/rbln/diffusers/pipelines/controlnet/pipeline_controlnet_sd_xl_img2img.py
+++ b/src/optimum/rbln/diffusers/pipelines/controlnet/pipeline_controlnet_sd_xl_img2img.py
@@ -26,7 +26,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from collections.abc import Callable
+from typing import Any
 
 import torch
 import torch.nn.functional as F
@@ -269,47 +270,47 @@ class RBLNStableDiffusionXLControlNetImg2ImgPipeline(RBLNDiffusionMixin, StableD
     @remove_compile_time_kwargs
     def __call__(
         self,
-        prompt: Union[str, List[str]] = None,
-        prompt_2: Optional[Union[str, List[str]]] = None,
+        prompt: str | list[str] = None,
+        prompt_2: str | list[str] | None = None,
         image: PipelineImageInput = None,
         control_image: PipelineImageInput = None,
-        height: Optional[int] = None,
-        width: Optional[int] = None,
+        height: int | None = None,
+        width: int | None = None,
         strength: float = 0.8,
         num_inference_steps: int = 50,
         guidance_scale: float = 5.0,
-        negative_prompt: Optional[Union[str, List[str]]] = None,
-        negative_prompt_2: Optional[Union[str, List[str]]] = None,
-        num_images_per_prompt: Optional[int] = 1,
+        negative_prompt: str | list[str] | None = None,
+        negative_prompt_2: str | list[str] | None = None,
+        num_images_per_prompt: int | None = 1,
         eta: float = 0.0,
-        generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
-        latents: Optional[torch.FloatTensor] = None,
-        prompt_embeds: Optional[torch.FloatTensor] = None,
-        negative_prompt_embeds: Optional[torch.FloatTensor] = None,
-        pooled_prompt_embeds: Optional[torch.FloatTensor] = None,
-        negative_pooled_prompt_embeds: Optional[torch.FloatTensor] = None,
-        ip_adapter_image: Optional[PipelineImageInput] = None,
-        ip_adapter_image_embeds: Optional[List[torch.FloatTensor]] = None,
-        output_type: Optional[str] = "pil",
+        generator: torch.Generator | list[torch.Generator] | None = None,
+        latents: torch.FloatTensor | None = None,
+        prompt_embeds: torch.FloatTensor | None = None,
+        negative_prompt_embeds: torch.FloatTensor | None = None,
+        pooled_prompt_embeds: torch.FloatTensor | None = None,
+        negative_pooled_prompt_embeds: torch.FloatTensor | None = None,
+        ip_adapter_image: PipelineImageInput | None = None,
+        ip_adapter_image_embeds: list[torch.FloatTensor] | None = None,
+        output_type: str | None = "pil",
         return_dict: bool = True,
-        cross_attention_kwargs: Optional[Dict[str, Any]] = None,
-        controlnet_conditioning_scale: Union[float, List[float]] = 0.8,
+        cross_attention_kwargs: dict[str, Any] | None = None,
+        controlnet_conditioning_scale: float | list[float] = 0.8,
         guess_mode: bool = False,
-        control_guidance_start: Union[float, List[float]] = 0.0,
-        control_guidance_end: Union[float, List[float]] = 1.0,
-        original_size: Tuple[int, int] = None,
-        crops_coords_top_left: Tuple[int, int] = (0, 0),
-        target_size: Tuple[int, int] = None,
-        negative_original_size: Optional[Tuple[int, int]] = None,
-        negative_crops_coords_top_left: Tuple[int, int] = (0, 0),
-        negative_target_size: Optional[Tuple[int, int]] = None,
+        control_guidance_start: float | list[float] = 0.0,
+        control_guidance_end: float | list[float] = 1.0,
+        original_size: tuple[int, int] = None,
+        crops_coords_top_left: tuple[int, int] = (0, 0),
+        target_size: tuple[int, int] = None,
+        negative_original_size: tuple[int, int] | None = None,
+        negative_crops_coords_top_left: tuple[int, int] = (0, 0),
+        negative_target_size: tuple[int, int] | None = None,
         aesthetic_score: float = 6.0,
         negative_aesthetic_score: float = 2.5,
-        clip_skip: Optional[int] = None,
-        callback_on_step_end: Optional[Callable[[int, int, Dict], None]] = None,
-        callback_on_step_end_tensor_inputs: Optional[List[str]] = None,
+        clip_skip: int | None = None,
+        callback_on_step_end: Callable[[int, int, dict], None] | None = None,
+        callback_on_step_end_tensor_inputs: list[str] | None = None,
         **kwargs,
-    ) -> Union[StableDiffusionXLPipelineOutput, Tuple]:
+    ) -> StableDiffusionXLPipelineOutput | tuple:
         r"""
         Function invoked when calling the pipeline for generation.
 

--- a/src/optimum/rbln/diffusers/pipelines/cosmos/configuration_cosmos_guardrail.py
+++ b/src/optimum/rbln/diffusers/pipelines/cosmos/configuration_cosmos_guardrail.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Tuple
+from typing import Any
 
 from ....configuration_utils import RBLNAutoConfig, RBLNModelConfig
 from ....transformers import RBLNSiglipVisionModelConfig
@@ -25,9 +25,9 @@ class RBLNVideoSafetyModelConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        input_size: Optional[int] = None,
-        image_size: Optional[Tuple[int, int]] = None,
+        batch_size: int | None = None,
+        input_size: int | None = None,
+        image_size: tuple[int, int] | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -42,8 +42,8 @@ class RBLNRetinaFaceFilterConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        image_size: Optional[Tuple[int, int]] = None,
+        batch_size: int | None = None,
+        image_size: tuple[int, int] | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -60,16 +60,16 @@ class RBLNCosmosSafetyCheckerConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        qwen3guard: Optional[RBLNModelConfig] = None,
-        video_safety_model: Optional[RBLNModelConfig] = None,
-        face_blur_filter: Optional[RBLNModelConfig] = None,
-        siglip_encoder: Optional[RBLNSiglipVisionModelConfig] = None,
+        qwen3guard: RBLNModelConfig | None = None,
+        video_safety_model: RBLNModelConfig | None = None,
+        face_blur_filter: RBLNModelConfig | None = None,
+        siglip_encoder: RBLNSiglipVisionModelConfig | None = None,
         *,
-        batch_size: Optional[int] = None,
-        image_size: Optional[Tuple[int, int]] = None,
-        height: Optional[int] = None,
-        width: Optional[int] = None,
-        max_seq_len: Optional[int] = None,
+        batch_size: int | None = None,
+        image_size: tuple[int, int] | None = None,
+        height: int | None = None,
+        width: int | None = None,
+        max_seq_len: int | None = None,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)

--- a/src/optimum/rbln/diffusers/pipelines/cosmos/cosmos_guardrail.py
+++ b/src/optimum/rbln/diffusers/pipelines/cosmos/cosmos_guardrail.py
@@ -15,7 +15,7 @@
 import os
 import pathlib
 from functools import partial
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Optional
 from unittest.mock import patch
 
 import rebel
@@ -117,7 +117,7 @@ class RBLNSigLIPEncoder(SigLIPEncoder):
         self,
         model_name: str = "google/siglip-so400m-patch14-384",
         checkpoint_id: str = COSMOS_GUARDRAIL_CHECKPOINT,
-        rbln_config: Optional[RBLNCosmosSafetyCheckerConfig] = None,
+        rbln_config: RBLNCosmosSafetyCheckerConfig | None = None,
     ):
         torch.nn.Module.__init__(self)
         if is_compiled_dir(checkpoint_id):
@@ -152,7 +152,7 @@ class RBLNRetinaFaceFilter(RetinaFaceFilter):
         checkpoint_id: str = COSMOS_GUARDRAIL_CHECKPOINT,
         batch_size: int = 1,
         confidence_threshold: float = 0.7,
-        rbln_config: Optional[RBLNCosmosSafetyCheckerConfig] = None,
+        rbln_config: RBLNCosmosSafetyCheckerConfig | None = None,
     ):
         torch.nn.Module.__init__(self)
         if is_compiled_dir(checkpoint_id):
@@ -320,7 +320,7 @@ class RBLNQwen3Guard(Qwen3Guard):
         self,
         checkpoint_id: str = COSMOS_GUARDRAIL_CHECKPOINT,
         base_model_id: str = "Qwen/Qwen3Guard-Gen-0.6B",
-        rbln_config: Optional[RBLNCosmosSafetyCheckerConfig] = None,
+        rbln_config: RBLNCosmosSafetyCheckerConfig | None = None,
     ) -> None:
         if is_compiled_dir(checkpoint_id):
             torch.nn.Module.__init__(self)
@@ -353,7 +353,7 @@ class RBLNCosmosSafetyChecker(CosmosSafetyChecker):
         self,
         checkpoint_id: str = COSMOS_GUARDRAIL_CHECKPOINT,
         textguard_model_id: str = "Qwen/Qwen3Guard-Gen-0.6B",
-        rbln_config: Optional[RBLNCosmosSafetyCheckerConfig] = None,
+        rbln_config: RBLNCosmosSafetyCheckerConfig | None = None,
     ) -> None:
         torch.nn.Module.__init__(self)
         if not COSMOS_AVAILABLE:
@@ -405,9 +405,9 @@ class RBLNCosmosSafetyChecker(CosmosSafetyChecker):
     def from_pretrained(
         cls,
         checkpoint_id: str,
-        rbln_config: Optional[RBLNCosmosSafetyCheckerConfig] = None,
-        subfolder: Optional[str] = None,
-        export: Optional[bool] = True,
+        rbln_config: RBLNCosmosSafetyCheckerConfig | None = None,
+        subfolder: str | None = None,
+        export: bool | None = True,
         **kwargs,
     ):
         rbln_config, kwargs = cls.prepare_rbln_config(rbln_config=rbln_config, **kwargs)
@@ -422,8 +422,8 @@ class RBLNCosmosSafetyChecker(CosmosSafetyChecker):
 
     @classmethod
     def prepare_rbln_config(
-        cls, rbln_config: Optional[Union[Dict[str, Any], RBLNCosmosSafetyCheckerConfig]] = None, **kwargs
-    ) -> Tuple[RBLNCosmosSafetyCheckerConfig, Dict[str, Any]]:
+        cls, rbln_config: dict[str, Any] | RBLNCosmosSafetyCheckerConfig | None = None, **kwargs
+    ) -> tuple[RBLNCosmosSafetyCheckerConfig, dict[str, Any]]:
         # Extract rbln-config from kwargs and convert it to RBLNCosmosSafetyCheckerConfig.
         rbln_config, kwargs = RBLNCosmosSafetyCheckerConfig.initialize_from_kwargs(rbln_config, **kwargs)
         return rbln_config, kwargs

--- a/src/optimum/rbln/diffusers/pipelines/cosmos/pipeline_cosmos_text2world.py
+++ b/src/optimum/rbln/diffusers/pipelines/cosmos/pipeline_cosmos_text2world.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 from diffusers import CosmosTextToWorldPipeline
 from diffusers.schedulers import EDMEulerScheduler
@@ -85,8 +85,8 @@ class RBLNCosmosTextToWorldPipeline(RBLNDiffusionMixin, CosmosTextToWorldPipelin
         model_id: str,
         *,
         export: bool = False,
-        safety_checker: Optional[RBLNCosmosSafetyChecker] = None,
-        rbln_config: Optional[Dict[str, Any]] = None,
+        safety_checker: RBLNCosmosSafetyChecker | None = None,
+        rbln_config: dict[str, Any] | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/diffusers/pipelines/cosmos/pipeline_cosmos_video2world.py
+++ b/src/optimum/rbln/diffusers/pipelines/cosmos/pipeline_cosmos_video2world.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 from diffusers import CosmosVideoToWorldPipeline
 from diffusers.schedulers import EDMEulerScheduler
@@ -85,8 +85,8 @@ class RBLNCosmosVideoToWorldPipeline(RBLNDiffusionMixin, CosmosVideoToWorldPipel
         model_id: str,
         *,
         export: bool = False,
-        safety_checker: Optional[RBLNCosmosSafetyChecker] = None,
-        rbln_config: Optional[Dict[str, Any]] = None,
+        safety_checker: RBLNCosmosSafetyChecker | None = None,
+        rbln_config: dict[str, Any] | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/modeling.py
+++ b/src/optimum/rbln/modeling.py
@@ -15,7 +15,7 @@
 import types
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, get_args, get_origin, get_type_hints
+from typing import TYPE_CHECKING, Any, Optional, Union, get_args, get_origin, get_type_hints
 
 import rebel
 import torch
@@ -77,10 +77,10 @@ class RBLNModel(RBLNBaseModel):
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Any],
+        preprocessors: Any | None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
-        rbln_config: Optional[RBLNModelConfig] = None,
+        rbln_config: RBLNModelConfig | None = None,
     ) -> RBLNModelConfig:
         # Default implementation: return config as-is
         # Subclasses should override to set compile_cfgs if needed
@@ -94,9 +94,9 @@ class RBLNModel(RBLNBaseModel):
     def from_model(
         cls,
         model: "PreTrainedModel",
-        config: Optional[PretrainedConfig] = None,
-        rbln_config: Optional[Union[RBLNModelConfig, Dict]] = None,
-        model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
+        config: PretrainedConfig | None = None,
+        rbln_config: RBLNModelConfig | dict | None = None,
+        model_save_dir: str | Path | TemporaryDirectory | None = None,
         subfolder: str = "",
         **kwargs: Any,
     ) -> "RBLNModel":
@@ -186,7 +186,7 @@ class RBLNModel(RBLNBaseModel):
             preprocessors=preprocessors, model=model, model_config=config, rbln_config=rbln_config
         )
 
-        compiled_model: Union[rebel.RBLNCompiledModel, Dict[str, rebel.RBLNCompiledModel]] = cls.get_compiled_model(
+        compiled_model: rebel.RBLNCompiledModel | dict[str, rebel.RBLNCompiledModel] = cls.get_compiled_model(
             model, rbln_config=rbln_config
         )
 
@@ -221,15 +221,15 @@ class RBLNModel(RBLNBaseModel):
     def get_pytorch_model(
         cls,
         model_id: str,
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
+        token: bool | str | None = None,
+        revision: str | None = None,
         force_download: bool = False,
-        cache_dir: Optional[str] = HUGGINGFACE_HUB_CACHE,
+        cache_dir: str | None = HUGGINGFACE_HUB_CACHE,
         subfolder: str = "",
         local_files_only: bool = False,
         trust_remote_code: bool = False,
         # Some rbln-config should be applied before loading torch module (i.e. quantized llm)
-        rbln_config: Optional[RBLNModelConfig] = None,
+        rbln_config: RBLNModelConfig | None = None,
         **kwargs,
     ) -> "PreTrainedModel":
         kwargs = cls.update_kwargs(kwargs)
@@ -255,9 +255,9 @@ class RBLNModel(RBLNBaseModel):
     @classmethod
     def _create_runtimes(
         cls,
-        compiled_models: List[rebel.RBLNCompiledModel],
+        compiled_models: list[rebel.RBLNCompiledModel],
         rbln_config: RBLNModelConfig,
-    ) -> List[rebel.Runtime]:
+    ) -> list[rebel.Runtime]:
         if len(rbln_config.compile_cfgs) == 0:
             return []
 
@@ -275,7 +275,7 @@ class RBLNModel(RBLNBaseModel):
             for compiled_model in compiled_models
         ]
 
-    def forward(self, *args: Any, return_dict: Optional[bool] = None, **kwargs: Any) -> Any:
+    def forward(self, *args: Any, return_dict: bool | None = None, **kwargs: Any) -> Any:
         """
         Defines the forward pass of `RBLNModel`. The interface mirrors HuggingFace conventions so it can act as a drop-in
         replacement in many cases.

--- a/src/optimum/rbln/modeling.py
+++ b/src/optimum/rbln/modeling.py
@@ -107,8 +107,8 @@ class RBLNModel(RBLNBaseModel):
         Args:
             model (PreTrainedModel): The PyTorch model to be compiled.
                 The object must be an instance of the HuggingFace transformers PreTrainedModel class.
-            config (Optional[PretrainedConfig]): The configuration object associated with the model.
-            rbln_config (Optional[Union[RBLNModelConfig, Dict]]): Configuration for RBLN model compilation and runtime.
+            config (PretrainedConfig | None): The configuration object associated with the model.
+            rbln_config (RBLNModelConfig | dict | None): Configuration for RBLN model compilation and runtime.
                 This can be provided as a dictionary or an instance of the model's configuration class (e.g., `RBLNLlamaForCausalLMConfig` for Llama models).
                 For detailed configuration options, see the specific model's configuration class documentation.
             kwargs: Additional keyword arguments. Arguments with the prefix `rbln_` are passed to rbln_config, while the remaining arguments are passed to the HuggingFace library.

--- a/src/optimum/rbln/modeling_base.py
+++ b/src/optimum/rbln/modeling_base.py
@@ -17,7 +17,7 @@ import os
 import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import rebel
 import torch
@@ -70,13 +70,13 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
 
     def __init__(
         self,
-        models: List[rebel.Runtime],
+        models: list[rebel.Runtime],
         config: "PretrainedConfig",
         rbln_config: RBLNModelConfig,
-        model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
+        model_save_dir: str | Path | TemporaryDirectory | None = None,
         subfolder: str = "",
-        rbln_compiled_models: Optional[rebel.RBLNCompiledModel] = None,
-        rbln_submodules: Optional[List["RBLNBaseModel"]] = None,
+        rbln_compiled_models: rebel.RBLNCompiledModel | None = None,
+        rbln_submodules: list["RBLNBaseModel"] | None = None,
         **kwargs,
     ):
         self.model = models
@@ -131,11 +131,11 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
     @classmethod
     def _load_compiled_model_dir(
         cls,
-        model_id: Union[str, Path],
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
+        model_id: str | Path,
+        token: bool | str | None = None,
+        revision: str | None = None,
         force_download: bool = False,
-        cache_dir: Optional[str] = None,
+        cache_dir: str | None = None,
         subfolder: str = "",
         local_files_only: bool = False,
     ) -> str:
@@ -161,7 +161,7 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
         return str(model_path)
 
     @classmethod
-    def _load_compiled_models(cls, model_path: str, expected_compiled_model_names: List[str]):
+    def _load_compiled_models(cls, model_path: str, expected_compiled_model_names: list[str]):
         compiled_models = Path(model_path).glob("*.rbln")
         expected_compiled_models = [
             Path(model_path) / f"{compiled_model_name}.rbln" for compiled_model_name in expected_compiled_model_names
@@ -187,20 +187,20 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
     @classmethod
     def _from_pretrained(
         cls,
-        model_id: Union[str, Path],
+        model_id: str | Path,
         config: Optional["PretrainedConfig"] = None,
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
+        token: bool | str | None = None,
+        revision: str | None = None,
         force_download: bool = False,
-        cache_dir: Optional[str] = None,
+        cache_dir: str | None = None,
         subfolder: str = "",
         local_files_only: bool = False,
         trust_remote_code: bool = False,
-        model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
+        model_save_dir: str | Path | TemporaryDirectory | None = None,
         # passed from compile function
-        rbln_config: Optional[RBLNModelConfig] = None,
-        rbln_compiled_models: Optional[Dict[str, rebel.RBLNCompiledModel]] = None,
-        rbln_submodules: Optional[List["RBLNBaseModel"]] = None,
+        rbln_config: RBLNModelConfig | None = None,
+        rbln_compiled_models: dict[str, rebel.RBLNCompiledModel] | None = None,
+        rbln_submodules: list["RBLNBaseModel"] | None = None,
         **kwargs,
     ) -> "RBLNBaseModel":
         if rbln_compiled_models is None:
@@ -293,12 +293,12 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
     @classmethod
     def _from_compiled_models(
         cls,
-        rbln_compiled_models: Dict[str, rebel.RBLNCompiledModel],
+        rbln_compiled_models: dict[str, rebel.RBLNCompiledModel],
         rbln_config: RBLNModelConfig,
         config: "PretrainedConfig",
-        model_save_dir: Union[Path, str],
-        subfolder: Union[Path, str],
-        rbln_submodules: Optional[List["RBLNBaseModel"]] = None,
+        model_save_dir: Path | str,
+        subfolder: Path | str,
+        rbln_submodules: list["RBLNBaseModel"] | None = None,
         **kwargs,
     ):
         if rbln_submodules is None:
@@ -353,13 +353,13 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
         )
 
     @classmethod
-    def _export(cls, model_id: Union[str, Path], **kwargs) -> "RBLNBaseModel":
+    def _export(cls, model_id: str | Path, **kwargs) -> "RBLNBaseModel":
         subfolder = kwargs.get("subfolder", "")
         model_save_dir = kwargs.pop("model_save_dir", None)
 
         rbln_config, kwargs = cls.prepare_rbln_config(**kwargs)
 
-        model: "PreTrainedModel" = cls.get_pytorch_model(model_id=model_id, rbln_config=rbln_config, **kwargs)
+        model: PreTrainedModel = cls.get_pytorch_model(model_id=model_id, rbln_config=rbln_config, **kwargs)
         preprocessors = maybe_load_preprocessors(model_id, subfolder=subfolder)
         return cls.from_model(
             model, preprocessors=preprocessors, model_save_dir=model_save_dir, rbln_config=rbln_config, **kwargs
@@ -367,8 +367,8 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
 
     @classmethod
     def prepare_rbln_config(
-        cls, rbln_config: Optional[Union[Dict[str, Any], RBLNModelConfig]] = None, **kwargs
-    ) -> Tuple[RBLNModelConfig, Dict[str, Any]]:
+        cls, rbln_config: dict[str, Any] | RBLNModelConfig | None = None, **kwargs
+    ) -> tuple[RBLNModelConfig, dict[str, Any]]:
         # Extract rbln-config from kwargs and convert it to RBLNModelConfig.
 
         config_cls = cls.get_rbln_config_class()
@@ -378,11 +378,11 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
     @classmethod
     def _is_compiled(
         cls,
-        model_id: Union[str, Path],
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
+        model_id: str | Path,
+        token: bool | str | None = None,
+        revision: str | None = None,
         force_download: bool = False,
-        cache_dir: Optional[str] = None,
+        cache_dir: str | None = None,
         subfolder: str = "",
         local_files_only: bool = False,
     ) -> bool:
@@ -403,10 +403,10 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
 
     @classmethod
     def from_pretrained(
-        cls: Type["RBLNBaseModel"],
-        model_id: Union[str, Path],
-        export: Optional[bool] = None,
-        rbln_config: Optional[Union[Dict, RBLNModelConfig]] = None,
+        cls: type["RBLNBaseModel"],
+        model_id: str | Path,
+        export: bool | None = None,
+        rbln_config: dict | RBLNModelConfig | None = None,
         **kwargs: Any,
     ) -> "RBLNBaseModel":
         """
@@ -450,7 +450,7 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
         model,
         rbln_compile_config: RBLNCompileConfig,
         create_runtimes: bool,
-        device: Union[int, List[int]],
+        device: int | list[int],
         **kwargs,
     ):
         if create_runtimes:
@@ -476,7 +476,7 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
     @classmethod
     def update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
         model: "PreTrainedModel",
         model_config: "PretrainedConfig",
         rbln_config: RBLNModelConfig,
@@ -513,7 +513,7 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
         return cls._hf_class
 
     @classmethod
-    def get_rbln_config_class(cls) -> Type[RBLNModelConfig]:
+    def get_rbln_config_class(cls) -> type[RBLNModelConfig]:
         # Lazily loads and caches the corresponding RBLN model config class.
         if "_rbln_config_class" not in cls.__dict__ or cls._rbln_config_class is None:
             rbln_config_class_name = cls.__name__ + "Config"
@@ -562,7 +562,7 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
 
     def save_pretrained(
         self,
-        save_directory: Union[str, Path],
+        save_directory: str | Path,
         push_to_hub: bool = False,
         **kwargs,
     ):
@@ -653,7 +653,7 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
             return super().push_to_hub(repo_id=repo_id, **kwargs)
 
     @staticmethod
-    def _raise_missing_compiled_file_error(missing_files: List[str]):
+    def _raise_missing_compiled_file_error(missing_files: list[str]):
         # Raises a KeyError with a message indicating missing compiled model files.
 
         if len(missing_files) == 1:

--- a/src/optimum/rbln/modeling_base.py
+++ b/src/optimum/rbln/modeling_base.py
@@ -414,11 +414,11 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
         User can use this function to load a pre-trained model from the HuggingFace library and convert it to a RBLN model to be run on RBLN NPUs.
 
         Args:
-            model_id (Union[str, Path]): The model id of the pre-trained model to be loaded.
+            model_id (str | Path): The model id of the pre-trained model to be loaded.
                 It can be downloaded from the HuggingFace model hub or a local path, or a model id of a compiled model using the RBLN Compiler.
-            export (Optional[bool]): A boolean flag to indicate whether the model should be compiled.
+            export (bool | None): A boolean flag to indicate whether the model should be compiled.
                 If None, it will be determined based on the existence of the compiled model files in the model_id.
-            rbln_config (Optional[Union[Dict, RBLNModelConfig]]): Configuration for RBLN model compilation and runtime.
+            rbln_config (dict | RBLNModelConfig | None): Configuration for RBLN model compilation and runtime.
                 This can be provided as a dictionary or an instance of the model's configuration class (e.g., `RBLNLlamaForCausalLMConfig` for Llama models).
                 For detailed configuration options, see the specific model's configuration class documentation.
             kwargs: Additional keyword arguments. Arguments with the prefix `rbln_` are passed to rbln_config, while the remaining arguments are passed to the HuggingFace library.
@@ -571,7 +571,7 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
         [`~optimum.rbln.modeling_base.RBLNBaseModel.from_pretrained`] class method.
 
         Args:
-            save_directory (Union[str, Path]):
+            save_directory (str | Path):
                 Directory where to save the model file.
             push_to_hub (bool):
                 Whether or not to push your model to the HuggingFace model hub after saving it.

--- a/src/optimum/rbln/transformers/configuration_generic.py
+++ b/src/optimum/rbln/transformers/configuration_generic.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any
 
 from optimum.rbln.utils.deprecation import deprecate_kwarg
 
@@ -20,14 +20,14 @@ from ..configuration_utils import RBLNModelConfig
 
 
 class RBLNTransformerEncoderConfig(RBLNModelConfig):
-    rbln_model_input_names: Optional[List[str]] = None
+    rbln_model_input_names: list[str] | None = None
 
     @deprecate_kwarg(old_name="model_input_shapes", version="0.12.0")
     def __init__(
         self,
-        max_seq_len: Optional[Union[int, List[int]]] = None,
-        batch_size: Optional[int] = None,
-        model_input_names: Optional[List[str]] = None,
+        max_seq_len: int | list[int] | None = None,
+        batch_size: int | None = None,
+        model_input_names: list[str] | None = None,
         **kwargs: Any,
     ):
         """
@@ -57,8 +57,8 @@ class RBLNTransformerEncoderConfig(RBLNModelConfig):
 class RBLNImageModelConfig(RBLNModelConfig):
     def __init__(
         self,
-        image_size: Optional[Union[int, Tuple[int, int]]] = None,
-        batch_size: Optional[int] = None,
+        image_size: int | tuple[int, int] | None = None,
+        batch_size: int | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/transformers/configuration_generic.py
+++ b/src/optimum/rbln/transformers/configuration_generic.py
@@ -32,13 +32,13 @@ class RBLNTransformerEncoderConfig(RBLNModelConfig):
     ):
         """
         Args:
-            max_seq_len (Optional[Union[int, List[int]]]): Maximum sequence length supported by the model.
+            max_seq_len (int | list[int] | None): Maximum sequence length supported by the model.
                 A single integer compiles the model for one sequence length. A list of integers enables
                 sequence-length bucketing: the model is compiled for each length on the default
                 ``[batch_size, max_seq_len]`` input layout and, at inference time, the runtime dispatches
                 to the smallest bucket that fits each input.
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            model_input_names (Optional[List[str]]): Names of the input tensors for the model.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            model_input_names (list[str] | None): Names of the input tensors for the model.
                 Defaults to class-specific rbln_model_input_names if not provided.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
@@ -63,9 +63,9 @@ class RBLNImageModelConfig(RBLNModelConfig):
     ):
         """
         Args:
-            image_size (Optional[Union[int, Tuple[int, int]]]): The size of input images.
+            image_size (int | tuple[int, int] | None): The size of input images.
                 Can be an integer for square images or a tuple (height, width).
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -1,7 +1,7 @@
 import math
 import os
 from collections import defaultdict
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING
 
 import rebel
 
@@ -37,11 +37,11 @@ def _should_skip_attn_validation() -> bool:
 
 
 def set_default_values(
-    attn_impl: Optional[str] = None,
-    kvcache_partition_len: Optional[int] = None,
-    kvcache_block_size: Optional[int] = None,
-    max_seq_len: Optional[int] = None,
-) -> Tuple[str, int, int]:
+    attn_impl: str | None = None,
+    kvcache_partition_len: int | None = None,
+    kvcache_block_size: int | None = None,
+    max_seq_len: int | None = None,
+) -> tuple[str, int, int]:
     if attn_impl is None:
         attn_impl = "eager"
 
@@ -194,7 +194,7 @@ class RBLNDecoderOnlyFlashAttentionMixin:
         cls,
         compiled_models: dict[str, rebel.RBLNCompiledModel],
         rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
-        available_dram: Optional[int] = None,
+        available_dram: int | None = None,
     ) -> int:
         if "prefill" not in rbln_config.phases:
             logger.warning(
@@ -217,12 +217,12 @@ class RBLNDecoderOnlyFlashAttentionMixin:
         cls,
         compiled_models: dict[str, rebel.RBLNCompiledModel],
         rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
-        available_dram: Optional[int] = None,
-    ) -> Tuple[dict[Tuple[int, int], int], dict[str, list[list[int]]], int, set[Tuple[int, int]]]:
+        available_dram: int | None = None,
+    ) -> tuple[dict[tuple[int, int], int], dict[str, list[list[int]]], int, set[tuple[int, int]]]:
         # Returns non-KV alloc, KV sizes, per-bucket DRAM budget, and the (node, chiplet)
         # buckets to check. ATOM reports one chiplet, so it shares the per-chiplet path.
-        alloc_without_dram: dict[Tuple[int, int], int] = defaultdict(int)
-        chiplets: set[Tuple[int, int]] = set()
+        alloc_without_dram: dict[tuple[int, int], int] = defaultdict(int)
+        chiplets: set[tuple[int, int]] = set()
 
         if is_compiler_supports_chiplet_alloc():
             for compiled_model in compiled_models.values():
@@ -270,21 +270,21 @@ class RBLNDecoderOnlyFlashAttentionMixin:
     def _search_num_kvcache_blocks(
         cls,
         rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
-        alloc_without_dram: dict[Tuple[int, int], int],
+        alloc_without_dram: dict[tuple[int, int], int],
         kvcache_tensor_sizes: dict[str, list[list[int]]],
         available_per_chiplet: int,
-        chiplets: set[Tuple[int, int]],
+        chiplets: set[tuple[int, int]],
     ) -> int:
-        remaining_dram_at_chiplet: dict[Tuple[int, int], int] = {
+        remaining_dram_at_chiplet: dict[tuple[int, int], int] = {
             key: available_per_chiplet - alloc_without_dram.get(key, 0) for key in chiplets
         }
         kvcache_meta_can_resize: dict[str, bool] = {
             kvcache_meta.name: kvcache_meta.can_resize for kvcache_meta in rbln_config.kvcache_metas
         }
 
-        def kvcache_sizes_at_chiplet(multiplier: int) -> dict[Tuple[int, int], int]:
+        def kvcache_sizes_at_chiplet(multiplier: int) -> dict[tuple[int, int], int]:
             # Resize multiplier applies only to resizable tensors; 2MB-aligned.
-            sizes: dict[Tuple[int, int], int] = defaultdict(int)
+            sizes: dict[tuple[int, int], int] = defaultdict(int)
             for key, sizes_at_node in kvcache_tensor_sizes.items():
                 m = multiplier if kvcache_meta_can_resize[key] else 1
                 for node_id, sizes_at_chiplet in enumerate(sizes_at_node):
@@ -292,7 +292,7 @@ class RBLNDecoderOnlyFlashAttentionMixin:
                         sizes[(node_id, chiplet_id)] += align_2MB(size * m)
             return sizes
 
-        def check_memory_fits(multiplier: int) -> Tuple[bool, dict[Tuple[int, int], int]]:
+        def check_memory_fits(multiplier: int) -> tuple[bool, dict[tuple[int, int], int]]:
             # Fits only if every chiplet bucket has room.
             kvcache_sizes = kvcache_sizes_at_chiplet(multiplier)
             fits = all(remaining_dram_at_chiplet[key] >= kvcache_sizes.get(key, 0) for key in chiplets)

--- a/src/optimum/rbln/transformers/modeling_generic.py
+++ b/src/optimum/rbln/transformers/modeling_generic.py
@@ -97,10 +97,10 @@ class RBLNTransformerEncoder(RBLNModel):
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]] = None,
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None = None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
-        rbln_config: Optional[RBLNTransformerEncoderConfig] = None,
+        rbln_config: RBLNTransformerEncoderConfig | None = None,
     ) -> RBLNTransformerEncoderConfig:
         return cls.update_rbln_config_for_transformers_encoder(
             preprocessors=preprocessors,
@@ -112,10 +112,10 @@ class RBLNTransformerEncoder(RBLNModel):
     @classmethod
     def update_rbln_config_for_transformers_encoder(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]] = None,
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None = None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
-        rbln_config: Optional[RBLNTransformerEncoderConfig] = None,
+        rbln_config: RBLNTransformerEncoderConfig | None = None,
     ) -> RBLNTransformerEncoderConfig:
         max_position_embeddings = getattr(model_config, "n_positions", None) or getattr(
             model_config, "max_position_embeddings", None
@@ -188,7 +188,7 @@ class RBLNTransformerEncoder(RBLNModel):
         rbln_config.set_compile_cfgs([RBLNCompileConfig(input_info=input_info)])
         return rbln_config
 
-    def forward(self, *args: Any, return_dict: Optional[bool] = None, **kwargs: Any) -> Any:
+    def forward(self, *args: Any, return_dict: bool | None = None, **kwargs: Any) -> Any:
         compile_cfg = self.rbln_config.compile_cfgs[0]
         if not compile_cfg.is_multiple_input_info:
             # No sequence-length bucketing: use the default single-shape path.
@@ -233,10 +233,10 @@ class RBLNImageModel(RBLNModel):
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]] = None,
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None = None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
-        rbln_config: Optional[RBLNImageModelConfig] = None,
+        rbln_config: RBLNImageModelConfig | None = None,
     ) -> RBLNImageModelConfig:
         return cls.update_rbln_config_for_image_model(
             preprocessors=preprocessors,
@@ -248,10 +248,10 @@ class RBLNImageModel(RBLNModel):
     @classmethod
     def update_rbln_config_for_image_model(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]] = None,
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None = None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
-        rbln_config: Optional[RBLNImageModelConfig] = None,
+        rbln_config: RBLNImageModelConfig | None = None,
     ) -> RBLNImageModelConfig:
         if rbln_config.image_size is None:
             for processor in preprocessors:

--- a/src/optimum/rbln/transformers/modeling_outputs.py
+++ b/src/optimum/rbln/transformers/modeling_outputs.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Optional, Tuple
 
 import torch
 from transformers.modeling_outputs import ModelOutput
@@ -26,12 +25,12 @@ class RBLNDecoderOnlyOutput(ModelOutput):
     logits: torch.FloatTensor = None
     generate_idx: torch.Tensor = None
     padded_cache_lengths: int = None
-    hidden_states: Tuple[torch.FloatTensor] = None
+    hidden_states: tuple[torch.FloatTensor] = None
 
 
 @dataclass
 class RBLNGemma3ForCausalLMOutput(RBLNDecoderOnlyOutput):
-    attention_mask: Optional[torch.Tensor] = None
+    attention_mask: torch.Tensor | None = None
 
 
 @dataclass
@@ -42,10 +41,10 @@ class RBLNGemma4ForCausalLMOutput(RBLNGemma3ForCausalLMOutput):
 @dataclass
 class RBLNSeq2SeqTSDecoderOutput(ModelOutput):
     last_hidden_states: torch.FloatTensor = None
-    params: Tuple[torch.FloatTensor] = None
+    params: tuple[torch.FloatTensor] = None
 
 
-def _validate_output_hidden_states(output_hidden_states: Optional[bool], rbln_config: RBLNModelConfig):
+def _validate_output_hidden_states(output_hidden_states: bool | None, rbln_config: RBLNModelConfig):
     output_hidden_states = (
         output_hidden_states if output_hidden_states is not None else rbln_config.output_hidden_states
     )
@@ -58,7 +57,7 @@ def _validate_output_hidden_states(output_hidden_states: Optional[bool], rbln_co
     return output_hidden_states
 
 
-def _validate_output_attentions(output_attentions: Optional[bool], rbln_config: RBLNModelConfig):
+def _validate_output_attentions(output_attentions: bool | None, rbln_config: RBLNModelConfig):
     output_attentions = output_attentions if output_attentions is not None else rbln_config.output_attentions
     if output_attentions != rbln_config.output_attentions:
         raise ValueError(

--- a/src/optimum/rbln/transformers/modeling_rope_utils.py
+++ b/src/optimum/rbln/transformers/modeling_rope_utils.py
@@ -43,9 +43,9 @@ def _get_rope_theta(config: PretrainedConfig) -> float:
 
 
 def _compute_default_rope_parameters(
-    config: Optional[PretrainedConfig] = None,
+    config: PretrainedConfig | None = None,
     device: Optional["torch.device"] = None,
-    seq_len: Optional[int] = None,
+    seq_len: int | None = None,
 ) -> tuple["torch.Tensor", float]:
     """
     Computes the inverse frequencies according to the original RoPE implementation
@@ -73,9 +73,9 @@ def _compute_default_rope_parameters(
 
 
 def _compute_linear_scaling_rope_parameters(
-    config: Optional[PretrainedConfig] = None,
+    config: PretrainedConfig | None = None,
     device: Optional["torch.device"] = None,
-    seq_len: Optional[int] = None,
+    seq_len: int | None = None,
 ) -> tuple["torch.Tensor", float]:
     """
     Computes the inverse frequencies with linear scaling. Credits to the Reddit user /u/kaiokendev
@@ -103,9 +103,9 @@ def _compute_linear_scaling_rope_parameters(
 
 
 def _compute_dynamic_ntk_parameters(
-    config: Optional[PretrainedConfig] = None,
+    config: PretrainedConfig | None = None,
     device: Optional["torch.device"] = None,
-    seq_len: Optional[int] = None,
+    seq_len: int | None = None,
 ) -> tuple["torch.Tensor", float]:
     """
     Computes the inverse frequencies with NTK scaling. Credits to the Reddit users /u/bloc97 and /u/emozilla
@@ -165,7 +165,7 @@ def _compute_dynamic_ntk_parameters(
 
 
 def _compute_yarn_parameters(
-    config: PretrainedConfig, device: "torch.device", seq_len: Optional[int] = None
+    config: PretrainedConfig, device: "torch.device", seq_len: int | None = None
 ) -> tuple["torch.Tensor", float]:
     """
     Computes the inverse frequencies with NTK scaling. Please refer to the
@@ -252,7 +252,7 @@ def _compute_yarn_parameters(
 
 
 def _compute_longrope_parameters(
-    config: PretrainedConfig, device: "torch.device", seq_len: Optional[int] = None
+    config: PretrainedConfig, device: "torch.device", seq_len: int | None = None
 ) -> tuple["torch.Tensor", float]:
     """
     Computes the inverse frequencies with LongRoPE scaling. Please refer to the
@@ -306,7 +306,7 @@ def _compute_longrope_parameters(
 
 
 def _compute_llama3_parameters(
-    config: PretrainedConfig, device: "torch.device", seq_len: Optional[int] = None
+    config: PretrainedConfig, device: "torch.device", seq_len: int | None = None
 ) -> tuple["torch.Tensor", float]:
     """
     Computes the inverse frequencies for llama 3.1.
@@ -349,8 +349,8 @@ def _compute_llama3_parameters(
 def _compute_proportional_rope_parameters(
     config: PretrainedConfig,
     device: "torch.device",
-    seq_len: Optional[int] = None,
-    layer_type: Optional[str] = None,
+    seq_len: int | None = None,
+    layer_type: str | None = None,
     head_dim_key: str = "head_dim",
 ) -> tuple["torch.Tensor", float]:
     """

--- a/src/optimum/rbln/transformers/models/audio_spectrogram_transformer/configuration_audio_spectrogram_transformer.py
+++ b/src/optimum/rbln/transformers/models/audio_spectrogram_transformer/configuration_audio_spectrogram_transformer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....utils.deprecation import deprecate_kwarg
@@ -26,8 +26,8 @@ class RBLNASTForAudioClassificationConfig(RBLNModelConfig):
     @deprecate_kwarg(old_name="num_mel_bins", version="0.10.0")
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        max_length: Optional[int] = None,
+        batch_size: int | None = None,
+        max_length: int | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/transformers/models/audio_spectrogram_transformer/configuration_audio_spectrogram_transformer.py
+++ b/src/optimum/rbln/transformers/models/audio_spectrogram_transformer/configuration_audio_spectrogram_transformer.py
@@ -32,8 +32,8 @@ class RBLNASTForAudioClassificationConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            max_length (Optional[int]): Maximum length of the audio input in time dimension.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            max_length (int | None): Maximum length of the audio input in time dimension.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/transformers/models/audio_spectrogram_transformer/modeling_audio_spectrogram_transformer.py
+++ b/src/optimum/rbln/transformers/models/audio_spectrogram_transformer/modeling_audio_spectrogram_transformer.py
@@ -47,7 +47,7 @@ class RBLNASTForAudioClassification(RBLNModel):
         preprocessors: "AutoFeatureExtractor" = None,
         model: Optional["PreTrainedModel"] = None,
         model_config: "PretrainedConfig" = None,
-        rbln_config: Optional[RBLNASTForAudioClassificationConfig] = None,
+        rbln_config: RBLNASTForAudioClassificationConfig | None = None,
     ) -> RBLNASTForAudioClassificationConfig:
         num_mel_bins = getattr(model_config, "num_mel_bins", None)
 

--- a/src/optimum/rbln/transformers/models/auto/auto_factory.py
+++ b/src/optimum/rbln/transformers/models/auto/auto_factory.py
@@ -254,7 +254,7 @@ class _BaseAutoModelClass:
         Register a new RBLN model class.
 
         Args:
-            rbln_cls (Type[RBLNBaseModel]): The RBLN model class to register.
+            rbln_cls (type[RBLNBaseModel]): The RBLN model class to register.
             exist_ok (bool): Whether to allow registering an already registered model.
         """
         if not issubclass(rbln_cls, RBLNBaseModel):

--- a/src/optimum/rbln/transformers/models/auto/auto_factory.py
+++ b/src/optimum/rbln/transformers/models/auto/auto_factory.py
@@ -15,7 +15,7 @@ import importlib
 import inspect
 import warnings
 from pathlib import Path
-from typing import Any, Dict, Optional, Type, Union
+from typing import Any
 
 from transformers import AutoConfig, PretrainedConfig, PreTrainedModel
 from transformers.dynamic_module_utils import get_class_from_dynamic_module
@@ -36,7 +36,7 @@ class _BaseAutoModelClass:
     _model_mapping = None
 
     def __init__(self, *args, **kwargs):
-        raise EnvironmentError(
+        raise OSError(
             f"{self.__class__.__name__} is designed to be instantiated "
             f"using the `{self.__class__.__name__}.from_pretrained(pretrained_model_name_or_path)`"
         )
@@ -44,7 +44,7 @@ class _BaseAutoModelClass:
     @classmethod
     def get_rbln_cls(
         cls,
-        pretrained_model_name_or_path: Union[str, Path],
+        pretrained_model_name_or_path: str | Path,
         *args: Any,
         export: bool = None,
         **kwargs: Any,
@@ -100,7 +100,7 @@ class _BaseAutoModelClass:
     @classmethod
     def infer_hf_model_class(
         cls,
-        pretrained_model_name_or_path: Union[str, Path],
+        pretrained_model_name_or_path: str | Path,
         *args: Any,
         **kwargs: Any,
     ):
@@ -156,7 +156,7 @@ class _BaseAutoModelClass:
         return model_class
 
     @classmethod
-    def get_rbln_model_cls_name(cls, pretrained_model_name_or_path: Union[str, Path], **kwargs):
+    def get_rbln_model_cls_name(cls, pretrained_model_name_or_path: str | Path, **kwargs):
         """
         Retrieve the path to the compiled model directory for a given RBLN model.
 
@@ -181,10 +181,10 @@ class _BaseAutoModelClass:
     @classmethod
     def from_pretrained(
         cls,
-        model_id: Union[str, Path],
+        model_id: str | Path,
         export: bool = None,
-        rbln_config: Optional[Union[Dict, RBLNModelConfig]] = None,
-        **kwargs: Optional[Dict[str, Any]],
+        rbln_config: dict | RBLNModelConfig | None = None,
+        **kwargs: dict[str, Any] | None,
     ) -> RBLNBaseModel:
         """
         Load an RBLN-accelerated model from a pretrained checkpoint or a compiled RBLN artifact.
@@ -222,8 +222,8 @@ class _BaseAutoModelClass:
     def from_model(
         cls,
         model: PreTrainedModel,
-        config: Optional[PretrainedConfig] = None,
-        rbln_config: Optional[Union[RBLNModelConfig, Dict]] = None,
+        config: PretrainedConfig | None = None,
+        rbln_config: RBLNModelConfig | dict | None = None,
         **kwargs: Any,
     ) -> RBLNBaseModel:
         """
@@ -249,7 +249,7 @@ class _BaseAutoModelClass:
         return rbln_cls.from_model(model, config=config, rbln_config=rbln_config, **kwargs)
 
     @staticmethod
-    def register(rbln_cls: Type[RBLNBaseModel], exist_ok: bool = False):
+    def register(rbln_cls: type[RBLNBaseModel], exist_ok: bool = False):
         """
         Register a new RBLN model class.
 

--- a/src/optimum/rbln/transformers/models/bart/bart_architecture.py
+++ b/src/optimum/rbln/transformers/models/bart/bart_architecture.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple
 
 import torch
 from torch import nn
@@ -145,7 +144,7 @@ class BartSelfAttention(Seq2SeqSelfAttention):
         else:
             self.attn_decode = torch.ops.rbln_custom_ops.paged_causal_attn_decode
 
-    def projection(self, hidden_states) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def projection(self, hidden_states) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         query_states = self.q_proj(hidden_states) * self.scaling
         key_states = self.k_proj(hidden_states)
         value_states = self.v_proj(hidden_states)

--- a/src/optimum/rbln/transformers/models/bart/modeling_bart.py
+++ b/src/optimum/rbln/transformers/models/bart/modeling_bart.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import inspect
-from typing import Any, Callable, Optional, Tuple, Union
+from collections.abc import Callable
+from typing import Any
 
 import torch
 from transformers import BartForConditionalGeneration, PreTrainedModel
@@ -39,10 +40,10 @@ class RBLNBartModel(RBLNTransformerEncoderForFeatureExtraction):
 
     def forward(
         self,
-        input_ids: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
+        input_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
         **kwargs,
-    ) -> Union[Tuple, Seq2SeqModelOutput]:
+    ) -> tuple | Seq2SeqModelOutput:
         """
         Forward pass for the RBLN-optimized BART model for feature extraction tasks.
 

--- a/src/optimum/rbln/transformers/models/bert/modeling_bert.py
+++ b/src/optimum/rbln/transformers/models/bert/modeling_bert.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Tuple, Union
 
 import torch
 from transformers.modeling_outputs import (
@@ -47,12 +46,12 @@ class RBLNBertModel(RBLNTransformerEncoderForFeatureExtraction):
 
     def forward(
         self,
-        input_ids: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        token_type_ids: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.Tensor] = None,
+        input_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        token_type_ids: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
         **kwargs,
-    ) -> Union[BaseModelOutputWithPoolingAndCrossAttentions, Tuple]:
+    ) -> BaseModelOutputWithPoolingAndCrossAttentions | tuple:
         """
         Forward pass for the RBLN-optimized BERT model for feature extraction tasks.
 
@@ -95,11 +94,11 @@ class RBLNBertForMaskedLM(RBLNModelForMaskedLM):
 
     def forward(
         self,
-        input_ids: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        token_type_ids: Optional[torch.Tensor] = None,
+        input_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        token_type_ids: torch.Tensor | None = None,
         **kwargs,
-    ) -> Union[MaskedLMOutput, Tuple]:
+    ) -> MaskedLMOutput | tuple:
         """
         Forward pass for the RBLN-optimized BERT model for masked language modeling tasks.
 
@@ -128,11 +127,11 @@ class RBLNBertForQuestionAnswering(RBLNModelForQuestionAnswering):
 
     def forward(
         self,
-        input_ids: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        token_type_ids: Optional[torch.Tensor] = None,
+        input_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        token_type_ids: torch.Tensor | None = None,
         **kwargs,
-    ) -> Union[QuestionAnsweringModelOutput, Tuple]:
+    ) -> QuestionAnsweringModelOutput | tuple:
         """
         Forward pass for the RBLN-optimized BERT model for question answering tasks.
 

--- a/src/optimum/rbln/transformers/models/blip_2/configuration_blip_2.py
+++ b/src/optimum/rbln/transformers/models/blip_2/configuration_blip_2.py
@@ -36,7 +36,7 @@ class RBLNBlip2VisionModelConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
         """
         super().__init__(**kwargs)
@@ -62,8 +62,8 @@ class RBLNBlip2QFormerModelConfig(RBLNModelConfig):
     ):
         """
         Args:
-            num_query_tokens (Optional[int]): The number of query tokens passed through the Transformer.
-            image_text_hidden_size (Optional[int]): Dimensionality of the hidden state of the image-text fusion layer.
+            num_query_tokens (int | None): The number of query tokens passed through the Transformer.
+            image_text_hidden_size (int | None): Dimensionality of the hidden state of the image-text fusion layer.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
         """
         super().__init__(**kwargs)
@@ -95,10 +95,10 @@ class RBLNBlip2ForConditionalGenerationConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            vision_model (Optional[RBLNModelConfig]): Configuration for the vision encoder component.
-            qformer (Optional[RBLNModelConfig]): Configuration for the RBLN-optimized BLIP-2 Q-Former model.
-            language_model (Optional[RBLNModelConfig]): Configuration for the language model component.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            vision_model (RBLNModelConfig | None): Configuration for the vision encoder component.
+            qformer (RBLNModelConfig | None): Configuration for the RBLN-optimized BLIP-2 Q-Former model.
+            language_model (RBLNModelConfig | None): Configuration for the language model component.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/transformers/models/blip_2/configuration_blip_2.py
+++ b/src/optimum/rbln/transformers/models/blip_2/configuration_blip_2.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....utils.logging import get_logger
@@ -31,7 +31,7 @@ class RBLNBlip2VisionModelConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
+        batch_size: int | None = None,
         **kwargs: Any,
     ):
         """
@@ -55,9 +55,9 @@ class RBLNBlip2QFormerModelConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        num_query_tokens: Optional[int] = None,
-        image_text_hidden_size: Optional[int] = None,
+        batch_size: int | None = None,
+        num_query_tokens: int | None = None,
+        image_text_hidden_size: int | None = None,
         **kwargs: Any,
     ):
         """
@@ -87,10 +87,10 @@ class RBLNBlip2ForConditionalGenerationConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        vision_model: Optional[RBLNModelConfig] = None,
-        qformer: Optional[RBLNModelConfig] = None,
-        language_model: Optional[RBLNModelConfig] = None,
+        batch_size: int | None = None,
+        vision_model: RBLNModelConfig | None = None,
+        qformer: RBLNModelConfig | None = None,
+        language_model: RBLNModelConfig | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/optimum/rbln/transformers/models/blip_2/modeling_blip_2.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import inspect
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import torch
 from transformers import (
@@ -86,10 +87,10 @@ class RBLNBlip2VisionModel(RBLNModel):
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
-        rbln_config: Optional[RBLNModelConfig] = None,
+        rbln_config: RBLNModelConfig | None = None,
     ) -> RBLNModelConfig:
         input_info = [
             (
@@ -112,8 +113,8 @@ class RBLNBlip2VisionModel(RBLNModel):
         self,
         pixel_values: torch.FloatTensor,
         interpolate_pos_encoding: bool = False,
-        return_dict: Optional[bool] = None,
-    ) -> Union[Tuple, BaseModelOutputWithPooling]:
+        return_dict: bool | None = None,
+    ) -> tuple | BaseModelOutputWithPooling:
         """
         Forward pass for the RBLN-optimized Blip2VisionModel model.
 
@@ -169,8 +170,8 @@ class RBLNBlip2QFormerModel(RBLNModel):
             def forward(
                 self,
                 query_embeds: torch.FloatTensor,
-                encoder_hidden_states: Optional[torch.FloatTensor] = None,
-                encoder_attention_mask: Optional[torch.FloatTensor] = None,
+                encoder_hidden_states: torch.FloatTensor | None = None,
+                encoder_attention_mask: torch.FloatTensor | None = None,
             ) -> torch.Tensor:
                 qformer_out = self.model(
                     query_embeds=query_embeds,
@@ -187,7 +188,7 @@ class RBLNBlip2QFormerModel(RBLNModel):
         cls,
         model: "PreTrainedModel",
         rbln_config: RBLNModelConfig,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
     ):
         if rbln_config.num_query_tokens is None:
             rbln_config.num_query_tokens = model.config.num_query_tokens
@@ -200,10 +201,10 @@ class RBLNBlip2QFormerModel(RBLNModel):
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
-        rbln_config: Optional[RBLNModelConfig] = None,
+        rbln_config: RBLNModelConfig | None = None,
     ) -> RBLNModelConfig:
         input_info = [
             (
@@ -240,10 +241,10 @@ class RBLNBlip2QFormerModel(RBLNModel):
     def forward(
         self,
         query_embeds: torch.FloatTensor,
-        encoder_hidden_states: Optional[torch.FloatTensor] = None,
-        encoder_attention_mask: Optional[torch.FloatTensor] = None,
-        return_dict: Optional[bool] = None,
-    ) -> Union[Tuple[torch.Tensor], BaseModelOutputWithPoolingAndCrossAttentions]:
+        encoder_hidden_states: torch.FloatTensor | None = None,
+        encoder_attention_mask: torch.FloatTensor | None = None,
+        return_dict: bool | None = None,
+    ) -> tuple[torch.Tensor] | BaseModelOutputWithPoolingAndCrossAttentions:
         """
         The forward pass for the RBLN-optimized Blip2QFormerModel model.
 
@@ -369,10 +370,10 @@ class RBLNBlip2ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
-        rbln_config: Optional[RBLNModelConfig] = None,
+        rbln_config: RBLNModelConfig | None = None,
     ) -> RBLNModelConfig:
         input_info = [
             (
@@ -422,8 +423,8 @@ class RBLNBlip2ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
         self,
         pixel_values: torch.FloatTensor,
         input_ids: torch.FloatTensor,
-        attention_mask: Optional[torch.LongTensor] = None,
-        return_dict: Optional[bool] = None,
+        attention_mask: torch.LongTensor | None = None,
+        return_dict: bool | None = None,
         interpolate_pos_encoding: bool = False,
         **kwargs,
     ):
@@ -460,12 +461,12 @@ class RBLNBlip2ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
     def generate(
         self,
         pixel_values: torch.FloatTensor,
-        input_ids: Optional[torch.LongTensor] = None,
-        attention_mask: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
         interpolate_pos_encoding: bool = False,
         **generate_kwargs,
-    ) -> List[torch.LongTensor]:
+    ) -> list[torch.LongTensor]:
         """
         The generate function is utilized in its standard form as in the HuggingFace transformers library. User can use this function to generate text from the model.
         Check the [HuggingFace transformers documentation](https://huggingface.co/docs/transformers/v4.57.1/en/model_doc/blip-2#transformers.Blip2ForConditionalGeneration.generate) for more details.

--- a/src/optimum/rbln/transformers/models/clip/configuration_clip.py
+++ b/src/optimum/rbln/transformers/models/clip/configuration_clip.py
@@ -21,7 +21,7 @@ class RBLNCLIPTextModelConfig(RBLNModelConfig):
     def __init__(self, batch_size: int | None = None, **kwargs: Any):
         """
         Args:
-            batch_size (Optional[int]): The batch size for text processing. Defaults to 1.
+            batch_size (int | None): The batch size for text processing. Defaults to 1.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:
@@ -54,12 +54,12 @@ class RBLNCLIPVisionModelConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for image processing. Defaults to 1.
-            image_size (Optional[int]): The size of input images. Can be an integer for square images,
+            batch_size (int | None): The batch size for image processing. Defaults to 1.
+            image_size (int | None): The size of input images. Can be an integer for square images,
                 a tuple/list (height, width), or a dictionary with 'height' and 'width' keys.
-            interpolate_pos_encoding (Optional[bool]): Whether or not to interpolate pre-trained position encodings. Defaults to `False`.
-            output_hidden_states (Optional[bool]): Whether or not to return the hidden states of all layers.
-            output_attentions (Optional[bool]): Whether or not to return the attentions tensors of all attention layers
+            interpolate_pos_encoding (bool | None): Whether or not to interpolate pre-trained position encodings. Defaults to `False`.
+            output_hidden_states (bool | None): Whether or not to return the hidden states of all layers.
+            output_attentions (bool | None): Whether or not to return the attentions tensors of all attention layers
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/transformers/models/clip/configuration_clip.py
+++ b/src/optimum/rbln/transformers/models/clip/configuration_clip.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 
 
 class RBLNCLIPTextModelConfig(RBLNModelConfig):
-    def __init__(self, batch_size: Optional[int] = None, **kwargs: Any):
+    def __init__(self, batch_size: int | None = None, **kwargs: Any):
         """
         Args:
             batch_size (Optional[int]): The batch size for text processing. Defaults to 1.
@@ -45,11 +45,11 @@ class RBLNCLIPTextModelWithProjectionConfig(RBLNCLIPTextModelConfig):
 class RBLNCLIPVisionModelConfig(RBLNModelConfig):
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        image_size: Optional[int] = None,
-        interpolate_pos_encoding: Optional[bool] = None,
-        output_hidden_states: Optional[bool] = None,
-        output_attentions: Optional[bool] = None,
+        batch_size: int | None = None,
+        image_size: int | None = None,
+        interpolate_pos_encoding: bool | None = None,
+        output_hidden_states: bool | None = None,
+        output_attentions: bool | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/transformers/models/clip/modeling_clip.py
+++ b/src/optimum/rbln/transformers/models/clip/modeling_clip.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import torch
 from transformers import CLIPTextConfig, CLIPTextModel, CLIPVisionConfig, CLIPVisionModel
@@ -68,7 +68,7 @@ class RBLNCLIPTextModel(RBLNModel):
         preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"],
         model: Optional["PreTrainedModel"] = None,
         model_config: "CLIPTextConfig" = None,
-        rbln_config: Optional[RBLNCLIPTextModelConfig] = None,
+        rbln_config: RBLNCLIPTextModelConfig | None = None,
     ) -> RBLNCLIPTextModelConfig:
         input_info = [
             (
@@ -84,7 +84,7 @@ class RBLNCLIPTextModel(RBLNModel):
         rbln_config.set_compile_cfgs([RBLNCompileConfig(input_info=input_info)])
         return rbln_config
 
-    def forward(self, input_ids: torch.LongTensor, return_dict: Optional[bool] = None, **kwargs) -> torch.FloatTensor:
+    def forward(self, input_ids: torch.LongTensor, return_dict: bool | None = None, **kwargs) -> torch.FloatTensor:
         """
         Forward pass for the RBLN-optimized CLIP text encoder model.
 
@@ -179,7 +179,7 @@ class RBLNCLIPVisionModel(RBLNModel):
         preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"],
         model: Optional["PreTrainedModel"] = None,
         model_config: "CLIPVisionConfig" = None,
-        rbln_config: Optional[RBLNCLIPVisionModelConfig] = None,
+        rbln_config: RBLNCLIPVisionModelConfig | None = None,
     ) -> RBLNCLIPVisionModelConfig:
         if rbln_config.image_size is None:
             rbln_config.image_size = getattr(model_config, "image_size", None)
@@ -218,11 +218,11 @@ class RBLNCLIPVisionModel(RBLNModel):
         self,
         pixel_values: torch.FloatTensor,
         return_dict: bool = True,
-        output_attentions: Optional[bool] = None,
-        output_hidden_states: Optional[bool] = None,
+        output_attentions: bool | None = None,
+        output_hidden_states: bool | None = None,
         interpolate_pos_encoding: bool = False,
         **kwargs,
-    ) -> Union[Tuple, BaseModelOutputWithPooling]:
+    ) -> tuple | BaseModelOutputWithPooling:
         """
         Forward pass for the RBLN-optimized CLIP vision encoder model.
 
@@ -316,11 +316,11 @@ class RBLNCLIPVisionModelWithProjection(RBLNCLIPVisionModel):
         self,
         pixel_values: torch.FloatTensor,
         return_dict: bool = True,
-        output_attentions: Optional[bool] = None,
-        output_hidden_states: Optional[bool] = None,
+        output_attentions: bool | None = None,
+        output_hidden_states: bool | None = None,
         interpolate_pos_encoding: bool = False,
         **kwargs,
-    ) -> Union[Tuple, CLIPVisionModelOutput]:
+    ) -> tuple | CLIPVisionModelOutput:
         """
         Forward pass for the RBLN-optimized CLIP vision encoder model with projection.
 

--- a/src/optimum/rbln/transformers/models/clip/modeling_clip.py
+++ b/src/optimum/rbln/transformers/models/clip/modeling_clip.py
@@ -90,7 +90,7 @@ class RBLNCLIPTextModel(RBLNModel):
 
         Args:
             input_ids (torch.LongTensor): The input ids to the model.
-            return_dict (Optional[bool]): Whether to return a dictionary of outputs.
+            return_dict (bool | None): Whether to return a dictionary of outputs.
 
         Returns:
             The model outputs. If return_dict=False is passed, returns a tuple of tensors. Otherwise, returns a CLIPTextModelOutput object.
@@ -229,8 +229,8 @@ class RBLNCLIPVisionModel(RBLNModel):
         Args:
             pixel_values (torch.Tensor): The pixel values to the model.
             return_dict (bool): Whether to return a dictionary of outputs.
-            output_attentions (Optional[bool]): Whether to return attentions.
-            output_hidden_states (Optional[bool]): Whether to return hidden states.
+            output_attentions (bool | None): Whether to return attentions.
+            output_hidden_states (bool | None): Whether to return hidden states.
             interpolate_pos_encoding (bool): Whether to interpolate position encoding.
 
         Returns:
@@ -327,8 +327,8 @@ class RBLNCLIPVisionModelWithProjection(RBLNCLIPVisionModel):
         Args:
             pixel_values (torch.Tensor): The pixel values to the model.
             return_dict (bool): Whether to return a dictionary of outputs.
-            output_attentions (Optional[bool]): Whether to return attentions.
-            output_hidden_states (Optional[bool]): Whether to return hidden states.
+            output_attentions (bool | None): Whether to return attentions.
+            output_hidden_states (bool | None): Whether to return hidden states.
             interpolate_pos_encoding (bool): Whether to interpolate position encoding.
 
         Returns:

--- a/src/optimum/rbln/transformers/models/colpali/colpali_architecture.py
+++ b/src/optimum/rbln/transformers/models/colpali/colpali_architecture.py
@@ -1,5 +1,3 @@
-from typing import List, Optional, Tuple, Union
-
 import torch
 from torch import nn
 from transformers import GemmaForCausalLM, GemmaModel
@@ -74,7 +72,7 @@ class RBLNColPaliForRetrievalWrapper(nn.Module):
 
 class ColPaliModel(nn.Module):
     def __init__(
-        self, model, layers: List["ColPaliLayer"], output_hidden_states: bool = False, max_seq_len: int = 2048
+        self, model, layers: list["ColPaliLayer"], output_hidden_states: bool = False, max_seq_len: int = 2048
     ):
         super().__init__()
         self.layers = nn.ModuleList(layers)
@@ -86,10 +84,10 @@ class ColPaliModel(nn.Module):
 
     def forward(
         self,
-        inputs_embeds: Optional[torch.Tensor] = None,
+        inputs_embeds: torch.Tensor | None = None,
         attention_mask: torch.Tensor = None,
-        rotary_emb: Optional[Union[nn.Module, torch.Tensor]] = None,
-        position_ids: Optional[torch.Tensor] = None,
+        rotary_emb: nn.Module | torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
     ):
         hidden_states = inputs_embeds * self.hidden_size**0.5
 
@@ -126,10 +124,10 @@ class ColPaliLayer(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
-        cos: Optional[torch.Tensor] = None,
-        sin: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.FloatTensor]:
+        attention_mask: torch.Tensor | None = None,
+        cos: torch.Tensor | None = None,
+        sin: torch.Tensor | None = None,
+    ) -> tuple[torch.FloatTensor]:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
 
@@ -171,7 +169,7 @@ class ColPaliAttention(nn.Module):
         self.v_proj = self_attn.v_proj
         self.o_proj = self_attn.o_proj
 
-    def projection(self, hidden_states) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def projection(self, hidden_states) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         query_states = self.q_proj(hidden_states)
         key_states = self.k_proj(hidden_states)
         value_states = self.v_proj(hidden_states)
@@ -182,8 +180,8 @@ class ColPaliAttention(nn.Module):
         self,
         hidden_states: torch.Tensor,
         attention_mask: torch.Tensor,
-        cos: Optional[torch.Tensor] = None,
-        sin: Optional[torch.Tensor] = None,
+        cos: torch.Tensor | None = None,
+        sin: torch.Tensor | None = None,
     ):
         batch_size, query_length, _ = hidden_states.size()
 

--- a/src/optimum/rbln/transformers/models/colpali/configuration_colpali.py
+++ b/src/optimum/rbln/transformers/models/colpali/configuration_colpali.py
@@ -61,9 +61,9 @@ class RBLNColPaliForRetrievalConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for the model.
-            vlm (Optional[RBLNModelConfig]): Configuration for the VLM component.
-            output_hidden_states (Optional[bool]): Whether to output the hidden states of the decoder. Defaults to False.
+            batch_size (int | None): The batch size for the model.
+            vlm (RBLNModelConfig | None): Configuration for the VLM component.
+            output_hidden_states (bool | None): Whether to output the hidden states of the decoder. Defaults to False.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
         Raises:
             ValueError: If batch_size is not a positive integer.

--- a/src/optimum/rbln/transformers/models/colpali/configuration_colpali.py
+++ b/src/optimum/rbln/transformers/models/colpali/configuration_colpali.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Optional
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....utils.logging import get_logger
@@ -54,9 +54,9 @@ class RBLNColPaliForRetrievalConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        vlm: Optional[RBLNModelConfig] = None,
-        output_hidden_states: Optional[bool] = None,
+        batch_size: int | None = None,
+        vlm: RBLNModelConfig | None = None,
+        output_hidden_states: bool | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/transformers/models/colpali/modeling_colpali.py
+++ b/src/optimum/rbln/transformers/models/colpali/modeling_colpali.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Optional, Tuple, Union
 
 import torch
 from transformers.initialization import no_init_weights
@@ -142,13 +141,13 @@ class RBLNColPaliForRetrieval(RBLNModel):
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        pixel_values: Optional[torch.FloatTensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        output_hidden_states: Optional[bool] = None,
-        return_dict: Optional[bool] = None,
+        input_ids: torch.LongTensor | None = None,
+        pixel_values: torch.FloatTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
         **kwargs,
-    ) -> Union[Tuple, ColPaliForRetrievalOutput]:
+    ) -> tuple | ColPaliForRetrievalOutput:
         """
         Forward pass for the RBLN-optimized ColPaliForRetrieval model.
 

--- a/src/optimum/rbln/transformers/models/colqwen2/configuration_colqwen2.py
+++ b/src/optimum/rbln/transformers/models/colqwen2/configuration_colqwen2.py
@@ -65,9 +65,9 @@ class RBLNColQwen2ForRetrievalConfig(RBLNDecoderOnlyModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for the model.
-            output_hidden_states (Optional[bool]): Whether to output the hidden states of the VLM model.
-            vlm (Optional[RBLNModelConfig]): Configuration for the VLM component.
+            batch_size (int | None): The batch size for the model.
+            output_hidden_states (bool | None): Whether to output the hidden states of the VLM model.
+            vlm (RBLNModelConfig | None): Configuration for the VLM component.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
         Raises:
             ValueError: If batch_size is not a positive integer.

--- a/src/optimum/rbln/transformers/models/colqwen2/configuration_colqwen2.py
+++ b/src/optimum/rbln/transformers/models/colqwen2/configuration_colqwen2.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
+from typing import Any
 
 from optimum.rbln.configuration_utils import RBLNModelConfig
 
@@ -58,9 +58,9 @@ class RBLNColQwen2ForRetrievalConfig(RBLNDecoderOnlyModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        output_hidden_states: Optional[bool] = None,
-        vlm: Optional[RBLNModelConfig] = None,
+        batch_size: int | None = None,
+        output_hidden_states: bool | None = None,
+        vlm: RBLNModelConfig | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/transformers/models/colqwen2/modeling_colqwen2.py
+++ b/src/optimum/rbln/transformers/models/colqwen2/modeling_colqwen2.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 
 import torch
 from transformers import ColQwen2Config, ColQwen2ForRetrieval
@@ -119,15 +119,15 @@ class RBLNColQwen2ForRetrieval(RBLNModel):
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        pixel_values: Optional[torch.Tensor] = None,
-        image_grid_thw: Optional[torch.LongTensor] = None,
-        output_hidden_states: Optional[bool] = None,
-        return_dict: Optional[bool] = None,
+        input_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
         **kwargs,
-    ) -> Union[Tuple, ColQwen2ForRetrievalOutput]:
+    ) -> tuple | ColQwen2ForRetrievalOutput:
         """
         Runs a ColQwen2 retrieval forward pass on text tokens and optional visual inputs.
 

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -65,58 +65,58 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            max_seq_len (Optional[int]): The maximum sequence length supported by the model.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            max_seq_len (int | None): The maximum sequence length supported by the model.
                 If not provided, it attempts to infer from the model's configuration
                 (`max_position_embeddings` or `n_positions`). Must be specified if not available
                 in the model config.
-            use_inputs_embeds (Optional[bool]): Whether to use input embeddings (`inputs_embeds`)
+            use_inputs_embeds (bool | None): Whether to use input embeddings (`inputs_embeds`)
                 directly instead of `input_ids`. Defaults to False. Requires the model to be
                 compiled with this option enabled.
-            use_attention_mask (Optional[bool]): Whether the model requires attention masks during
+            use_attention_mask (bool | None): Whether the model requires attention masks during
                 inference. This is typically determined based on the target device and model
                 architecture. Defaults are often set automatically based on the model and RBLN NPU.
-            use_position_ids (Optional[bool]): Whether to use position IDs. Defaults to False.
-            attn_impl (Optional[str]): Specifies the attention implementation to use.
+            use_position_ids (bool | None): Whether to use position IDs. Defaults to False.
+            attn_impl (str | None): Specifies the attention implementation to use.
                 See the "Attention Implementation (`attn_impl`)" section below for details.
-            kvcache_partition_len (Optional[int]): Defines the partition length for the KV cache
+            kvcache_partition_len (int | None): Defines the partition length for the KV cache
                 when using "flash_attn". See the "KV Cache Partition Length (`kvcache_partition_len`)"
                 section below for details.
-            kvcache_block_size (Optional[int]): Sets the size (in number of tokens) of each block
+            kvcache_block_size (int | None): Sets the size (in number of tokens) of each block
                 in the PagedAttention KV cache. See the "KV Cache Block Size (`kvcache_block_size`)"
                 section below for details.
-            quantization (Optional[Dict[str, Any]]): Configuration dictionary for applying model
+            quantization (dict[str, Any] | None): Configuration dictionary for applying model
                 quantization. Specifies format, etc.
-            lora_config (Optional[Union[Dict[str, Any], RBLNLoRAConfig]]): Configuration for LoRA
+            lora_config (dict[str, Any] | RBLNLoRAConfig | None): Configuration for LoRA
                 (Low-Rank Adaptation) settings when using (multi-)LoRA support. Can be provided as
                 a dictionary or an RBLNLoRAConfig instance. When provided, enables LoRA functionality
                 for the model compilation. Defaults to None (no LoRA).
-            prefill_chunk_size (Optional[int]): The chunk size used during the prefill phase for
+            prefill_chunk_size (int | None): The chunk size used during the prefill phase for
                 processing input sequences. Defaults to 128. Must be a positive integer
                 divisible by 64. Affects prefill performance and memory usage.
-            kvcache_num_blocks (Optional[int]): The total number of blocks to allocate for the
+            kvcache_num_blocks (int | None): The total number of blocks to allocate for the
                 PagedAttention KV cache at compile time. Defaults to 0 (automatically determined).
                 See the "KV Cache Number of Blocks (`kvcache_num_blocks`)" section below for details.
-            decoder_batch_sizes (Optional[List[int]]): A list of batch sizes for which separate decoder models will be compiled.
+            decoder_batch_sizes (list[int] | None): A list of batch sizes for which separate decoder models will be compiled.
                 This allows the model to handle varying batch sizes efficiently during generation. If not specified,
                 defaults to a list containing only the model's main batch size. When specifying multiple batch sizes:
                 1) All values must be less than or equal to the main batch size.
                 2) The list will be sorted in descending order (larger batch sizes first).
                 3) If using multiple decoders, at least one batch size should match the main batch size.
-            cache_impl (Optional[CacheImplType]): Specifies the KV cache implementation strategy. Defaults to "static".
+            cache_impl (CacheImplType | None): Specifies the KV cache implementation strategy. Defaults to "static".
                 - "static": Uses a fixed-size global KV cache for all layers, suitable for standard attention patterns.
                 - "sliding_window": Implements a sliding window KV cache, where each layer maintains a local cache of recent tokens.
                 - "hybrid": Combines both static and sliding window approaches, allowing different layers to use different cache strategies.
                 The choice affects memory usage and attention patterns. When using "sliding_window" or "hybrid",
                 you must specify the `sliding_window` size and optionally `sliding_window_layers` for hybrid mode.
-            sliding_window (Optional[int]): The size of the sliding window. Defaults to None.
-            sliding_window_layers (Optional[List[int]]): The layers to use for the sliding window used in the hybrid model. Defaults to None.
-            phases (Optional[List[PhaseType]]): The phases to compile the model for. Defaults to ["prefill"] if DecoderOnlyModel is used,
+            sliding_window (int | None): The size of the sliding window. Defaults to None.
+            sliding_window_layers (list[int] | None): The layers to use for the sliding window used in the hybrid model. Defaults to None.
+            phases (list[PhaseType] | None): The phases to compile the model for. Defaults to ["prefill"] if DecoderOnlyModel is used,
                 ["prefill", "decode"] if DecoderOnlyModelForCausalLM is used.
-            logits_to_keep (Optional[int]): The number of logits to keep for the decoder.  If set to 0, the decoder will keep all logits.
+            logits_to_keep (int | None): The number of logits to keep for the decoder.  If set to 0, the decoder will keep all logits.
                 Defaults to 0 if DecoderOnlyModel is used, 1 if DecoderOnlyModelForCausalLM is used.
-            output_hidden_states (Optional[bool]): Whether to output the hidden states of the decoder. Defaults to False.
-            kvcache_metas (Optional[List["KVCacheMeta"]]): The metadata for the KV cache tensors. Handled internally if not provided. Defaults to None.
+            output_hidden_states (bool | None): Whether to output the hidden states of the decoder. Defaults to False.
+            kvcache_metas (list["KVCacheMeta"] | None): The metadata for the KV cache tensors. Handled internally if not provided. Defaults to None.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import asdict, dataclass
-from typing import Any, Dict, List, Literal, Optional, Union, get_args
+from typing import Any, Literal, get_args
 
 from ....configuration_utils import RBLNModelConfig, RBLNSerializableConfigProtocol
 from ....utils.logging import get_logger
@@ -41,26 +41,26 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        max_seq_len: Optional[int] = None,
-        use_inputs_embeds: Optional[bool] = None,
-        use_attention_mask: Optional[bool] = None,
-        use_position_ids: Optional[bool] = None,
-        attn_impl: Optional[str] = None,
-        kvcache_partition_len: Optional[int] = None,
-        kvcache_block_size: Optional[int] = None,
-        quantization: Optional[Union[Dict[str, Any], RBLNQuantizationConfig]] = None,
-        lora_config: Optional[Union[Dict[str, Any], RBLNLoRAConfig]] = None,
-        prefill_chunk_size: Optional[int] = None,
-        kvcache_num_blocks: Optional[int] = None,
-        decoder_batch_sizes: Optional[List[int]] = None,
-        cache_impl: Optional[CacheImplType] = None,
-        sliding_window: Optional[int] = None,
-        sliding_window_layers: Optional[List[int]] = None,
-        phases: Optional[List[PhaseType]] = None,
-        logits_to_keep: Optional[int] = None,
-        output_hidden_states: Optional[bool] = None,
-        kvcache_metas: Optional[List["KVCacheMeta"]] = None,
+        batch_size: int | None = None,
+        max_seq_len: int | None = None,
+        use_inputs_embeds: bool | None = None,
+        use_attention_mask: bool | None = None,
+        use_position_ids: bool | None = None,
+        attn_impl: str | None = None,
+        kvcache_partition_len: int | None = None,
+        kvcache_block_size: int | None = None,
+        quantization: dict[str, Any] | RBLNQuantizationConfig | None = None,
+        lora_config: dict[str, Any] | RBLNLoRAConfig | None = None,
+        prefill_chunk_size: int | None = None,
+        kvcache_num_blocks: int | None = None,
+        decoder_batch_sizes: list[int] | None = None,
+        cache_impl: CacheImplType | None = None,
+        sliding_window: int | None = None,
+        sliding_window_layers: list[int] | None = None,
+        phases: list[PhaseType] | None = None,
+        logits_to_keep: int | None = None,
+        output_hidden_states: bool | None = None,
+        kvcache_metas: list["KVCacheMeta"] | None = None,
         **kwargs: Any,
     ):
         """
@@ -259,10 +259,10 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
                 # Larger batch size should be at the beginning of the list.
                 self.decoder_batch_sizes.sort(reverse=True)
 
-        self.kvcache_metas: List["KVCacheMeta"] = kvcache_metas or []
+        self.kvcache_metas: list[KVCacheMeta] = kvcache_metas or []
 
     @staticmethod
-    def validate_phases_type(phases: List[PhaseType]):
+    def validate_phases_type(phases: list[PhaseType]):
         if not isinstance(phases, list):
             raise ValueError("`phases` must be a list.")
         if not all(phase in get_args(PhaseType) for phase in phases):

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_lora.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_lora.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from huggingface_hub import snapshot_download
 
@@ -78,13 +78,13 @@ class RBLNLoRAAdapterConfig(RBLNSerializableConfigProtocol):
         self,
         lora_int_id: int,
         lora_name: str,
-        lora_path: Union[str, Path],
-        r: Optional[int] = None,
-        lora_alpha: Optional[float] = None,
-        target_modules: Optional[List[str]] = None,
-        bias: Optional[str] = None,
-        use_rslora: Optional[bool] = None,
-        scaling_factor: Optional[float] = None,
+        lora_path: str | Path,
+        r: int | None = None,
+        lora_alpha: float | None = None,
+        target_modules: list[str] | None = None,
+        bias: str | None = None,
+        use_rslora: bool | None = None,
+        scaling_factor: float | None = None,
     ):
         """
         Args:
@@ -185,7 +185,7 @@ class RBLNLoRAAdapterConfig(RBLNSerializableConfigProtocol):
                 f"Error: {e}"
             ) from e
 
-    def _load_adapter_config(self) -> Dict[str, Any]:
+    def _load_adapter_config(self) -> dict[str, Any]:
         """
         Load adapter configuration from adapter_config.json file.
 
@@ -202,7 +202,7 @@ class RBLNLoRAAdapterConfig(RBLNSerializableConfigProtocol):
             return {}
 
         try:
-            with open(config_path, "r", encoding="utf-8") as f:
+            with open(config_path, encoding="utf-8") as f:
                 adapter_config = json.load(f)
             logger.info(f"Loaded adapter config from {config_path}")
             return adapter_config
@@ -210,7 +210,7 @@ class RBLNLoRAAdapterConfig(RBLNSerializableConfigProtocol):
             logger.warning(f"Failed to load adapter config from {config_path}: {e}, using default values")
             return {}
 
-    def _prepare_for_serialization(self) -> Dict[str, Any]:
+    def _prepare_for_serialization(self) -> dict[str, Any]:
         config_dict = {
             "lora_int_id": self.lora_int_id,
             "lora_name": self.lora_name,
@@ -236,13 +236,13 @@ class RBLNLoRABaseAdapterConfig(RBLNLoRAAdapterConfig):
         self,
         lora_int_id: int = 0,
         lora_name: str = "base",
-        lora_path: Union[str, Path] = "__reserved_base__",
-        r: Optional[int] = 1,
-        lora_alpha: Optional[float] = 1.0,
-        target_modules: Optional[List[str]] = None,
-        bias: Optional[str] = "none",
-        use_rslora: Optional[bool] = False,
-        scaling_factor: Optional[float] = 1.0,
+        lora_path: str | Path = "__reserved_base__",
+        r: int | None = 1,
+        lora_alpha: float | None = 1.0,
+        target_modules: list[str] | None = None,
+        bias: str | None = "none",
+        use_rslora: bool | None = False,
+        scaling_factor: float | None = 1.0,
     ):
         if lora_int_id != 0:
             raise ValueError("RBLNLoRABaseAdapterConfig must have lora_int_id=0")
@@ -283,9 +283,7 @@ class RBLNLoRAConfig(RBLNSerializableConfigProtocol):
     4. Runtime can only switch between pre-compiled adapters
     """
 
-    def __init__(
-        self, adapters: List[Union[Dict[str, Any], RBLNLoRAAdapterConfig]], max_lora_rank: Optional[int] = None
-    ):
+    def __init__(self, adapters: list[dict[str, Any] | RBLNLoRAAdapterConfig], max_lora_rank: int | None = None):
         """
         Args:
             adapters (List[Union[Dict[str, Any], RBLNLoRAAdapterConfig]]): List of LoRA adapters
@@ -303,7 +301,7 @@ class RBLNLoRAConfig(RBLNSerializableConfigProtocol):
             raise ValueError("adapters list cannot be empty")
 
         # Convert dict adapters to RBLNLoRAAdapterConfig objects
-        self.adapters: List[RBLNLoRAAdapterConfig] = []
+        self.adapters: list[RBLNLoRAAdapterConfig] = []
         for adapter in adapters:
             if isinstance(adapter, dict):
                 self.adapters.append(RBLNLoRAAdapterConfig(**adapter))
@@ -352,26 +350,26 @@ class RBLNLoRAConfig(RBLNSerializableConfigProtocol):
         return len(self.adapters)
 
     @property
-    def adapter_ids(self) -> List[int]:
+    def adapter_ids(self) -> list[int]:
         return [adapter.lora_int_id for adapter in self.adapters]
 
     @property
-    def adapter_names(self) -> List[str]:
+    def adapter_names(self) -> list[str]:
         return [adapter.lora_name for adapter in self.adapters]
 
-    def get_adapter_by_id(self, lora_int_id: int) -> Optional[RBLNLoRAAdapterConfig]:
+    def get_adapter_by_id(self, lora_int_id: int) -> RBLNLoRAAdapterConfig | None:
         for adapter in self.adapters:
             if adapter.lora_int_id == lora_int_id:
                 return adapter
         return None
 
-    def get_adapter_by_name(self, lora_name: str) -> Optional[RBLNLoRAAdapterConfig]:
+    def get_adapter_by_name(self, lora_name: str) -> RBLNLoRAAdapterConfig | None:
         for adapter in self.adapters:
             if adapter.lora_name == lora_name:
                 return adapter
         return None
 
-    def validate_adapter_weights(self) -> Dict[int, bool]:
+    def validate_adapter_weights(self) -> dict[int, bool]:
         validation_results = {}
         for adapter in self.adapters:
             try:
@@ -401,7 +399,7 @@ class RBLNLoRAConfig(RBLNSerializableConfigProtocol):
 
         return validation_results
 
-    def _prepare_for_serialization(self) -> Dict[str, Any]:
+    def _prepare_for_serialization(self) -> dict[str, Any]:
         # Do not serialize the reserved base adapter (id=0)
         serializable_adapters = [adapter for adapter in self.adapters if adapter.lora_int_id != 0]
         serializable_map = {

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_lora.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_lora.py
@@ -91,19 +91,19 @@ class RBLNLoRAAdapterConfig(RBLNSerializableConfigProtocol):
             lora_int_id (int): Unique identifier for this LoRA adapter (e.g., 0, 1, 2).
                 This ID will be used during runtime to select which adapter to use.
             lora_name (str): Human-readable name for this adapter (e.g., "math_tuned", "code_tuned").
-            lora_path (Union[str, Path]): Path to the LoRA adapter weights directory or file.
+            lora_path (str | Path): Path to the LoRA adapter weights directory or file.
                 Must be accessible at compile time to load the weights.
-            r (Optional[int]): The rank of the LoRA approximation for this adapter. If None,
+            r (int | None): The rank of the LoRA approximation for this adapter. If None,
                 will be loaded from adapter config file.
-            lora_alpha (Optional[float]): The LoRA scaling parameter for this adapter. If None,
+            lora_alpha (float | None): The LoRA scaling parameter for this adapter. If None,
                 will be loaded from adapter config file.
-            target_modules (Optional[List[str]]): List of module names to apply LoRA to.
+            target_modules (list[str] | None): List of module names to apply LoRA to.
                 If None, will be loaded from adapter config file or inherit from parent RBLNLoRAConfig.
-            bias (Optional[str]): Bias handling strategy. Options: "none", "all", "lora_only".
+            bias (str | None): Bias handling strategy. Options: "none", "all", "lora_only".
                 If None, will be loaded from adapter config file.
-            use_rslora (Optional[bool]): Whether to use Rank-Stabilized LoRA. If None,
+            use_rslora (bool | None): Whether to use Rank-Stabilized LoRA. If None,
                 will be loaded from adapter config file.
-            scaling_factor (Optional[float]): Additional scaling factor for this adapter. Defaults to 1.0.
+            scaling_factor (float | None): Additional scaling factor for this adapter. Defaults to 1.0.
             **kwargs: Additional adapter-specific arguments.
 
         Raises:
@@ -286,10 +286,10 @@ class RBLNLoRAConfig(RBLNSerializableConfigProtocol):
     def __init__(self, adapters: list[dict[str, Any] | RBLNLoRAAdapterConfig], max_lora_rank: int | None = None):
         """
         Args:
-            adapters (List[Union[Dict[str, Any], RBLNLoRAAdapterConfig]]): List of LoRA adapters
+            adapters (list[dict[str, Any] | RBLNLoRAAdapterConfig]): List of LoRA adapters
                 to be compiled into the model. Each adapter must be fully specified with weights
                 accessible at compile time.
-            max_lora_rank (Optional[int]): Maximum rank across all adapters. If None, automatically
+            max_lora_rank (int | None): Maximum rank across all adapters. If None, automatically
                 determined from the provided adapters. Used for memory allocation optimization.
 
         Raises:

--- a/src/optimum/rbln/transformers/models/decoderonly/decoderonly_architecture.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/decoderonly_architecture.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional
 
 import torch
 from torch import nn
@@ -272,12 +272,12 @@ class DecoderOnlyForCausalLM(nn.Module):
         cache_position: torch.Tensor = None,
         position_ids: torch.Tensor = None,
         query_position: torch.Tensor = None,
-        past_key_values: Tuple[Tuple[torch.Tensor]] = None,
+        past_key_values: tuple[tuple[torch.Tensor]] = None,
         rotary_emb: nn.Module = None,
-        global_block_tables: Optional[torch.Tensor] = None,
-        local_block_tables: Optional[torch.Tensor] = None,
-        lora_int_id: Optional[torch.Tensor] = None,
-        output_hidden_states: Optional[bool] = None,
+        global_block_tables: torch.Tensor | None = None,
+        local_block_tables: torch.Tensor | None = None,
+        lora_int_id: torch.Tensor | None = None,
+        output_hidden_states: bool | None = None,
     ):
         # outputs
         hidden_states, all_hidden_states = self.model(
@@ -383,7 +383,7 @@ class DecoderOnlyModel(nn.Module):
     def __init__(
         self,
         model,
-        layers: List["DecoderOnlyLayer"],
+        layers: list["DecoderOnlyLayer"],
         rbln_config: "RBLNDecoderOnlyModelConfig",
         use_learned_pos_emb=None,
         use_rotary_emb=True,
@@ -457,17 +457,17 @@ class DecoderOnlyModel(nn.Module):
     def forward(
         self,
         input_ids: torch.Tensor = None,
-        inputs_embeds: Optional[torch.Tensor] = None,
+        inputs_embeds: torch.Tensor | None = None,
         attention_mask: torch.Tensor = None,
         cache_position: torch.Tensor = None,
         position_ids: torch.Tensor = None,
         query_position: torch.Tensor = None,
-        past_key_values: Tuple[Tuple[torch.Tensor]] = None,
-        rotary_emb: Optional[Union[nn.Module, torch.Tensor]] = None,
-        global_block_tables: Optional[torch.Tensor] = None,
-        local_block_tables: Optional[torch.Tensor] = None,
-        lora_int_id: Optional[torch.Tensor] = None,
-        output_hidden_states: Optional[bool] = None,
+        past_key_values: tuple[tuple[torch.Tensor]] = None,
+        rotary_emb: nn.Module | torch.Tensor | None = None,
+        global_block_tables: torch.Tensor | None = None,
+        local_block_tables: torch.Tensor | None = None,
+        lora_int_id: torch.Tensor | None = None,
+        output_hidden_states: bool | None = None,
     ):
         # retrieve input_ids and inputs_embeds
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -586,7 +586,7 @@ class DecoderOnlyLayer(nn.Module):
     _POST_FF_LAYERNORM_ATTRS = None
     _MLP_ATTR = ("mlp",)
 
-    def __init__(self, layer, self_attn: "DecoderOnlyAttention", lora_config: Optional[RBLNLoRAConfig] = None):
+    def __init__(self, layer, self_attn: "DecoderOnlyAttention", lora_config: RBLNLoRAConfig | None = None):
         super().__init__()
 
         self.pre_attention_layernorm = _get_attr_from_candidates(layer, self._PRE_ATTN_LAYERNORM)
@@ -637,7 +637,7 @@ class DecoderOnlyLayer(nn.Module):
     def get_mlp(self) -> nn.Module:
         return self.mlp
 
-    def forward_mlp(self, hidden_states: torch.Tensor, lora_int_id: Optional[torch.Tensor] = None) -> torch.Tensor:
+    def forward_mlp(self, hidden_states: torch.Tensor, lora_int_id: torch.Tensor | None = None) -> torch.Tensor:
         mlp = self.get_mlp()
         if self.lora_config and lora_int_id is not None:
             gate = mlp.gate_proj(hidden_states, lora_int_id)
@@ -658,11 +658,11 @@ class DecoderOnlyLayer(nn.Module):
         hidden_states: torch.Tensor,
         attention_mask: torch.Tensor,
         seq_positions: torch.LongTensor,
-        past_key_values: Tuple[Tuple[torch.Tensor]],
-        cos: Optional[torch.Tensor] = None,
-        sin: Optional[torch.Tensor] = None,
-        block_tables: Optional[torch.Tensor] = None,
-        lora_int_id: Optional[torch.Tensor] = None,
+        past_key_values: tuple[tuple[torch.Tensor]],
+        cos: torch.Tensor | None = None,
+        sin: torch.Tensor | None = None,
+        block_tables: torch.Tensor | None = None,
+        lora_int_id: torch.Tensor | None = None,
     ):
         residual = hidden_states
         hidden_states = self.get_pre_attention_layernorm()(hidden_states)
@@ -814,8 +814,8 @@ class DecoderOnlyAttention(nn.Module):
             self._init_lora_weights()
 
     def projection(
-        self, hidden_states, lora_int_id: Optional[torch.Tensor] = None
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        self, hidden_states, lora_int_id: torch.Tensor | None = None
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Projects input hidden states into query, key, and value representations.
 
         Args:
@@ -845,7 +845,7 @@ class DecoderOnlyAttention(nn.Module):
     def get_attn_scale(self, self_attn):
         return 1 / math.sqrt(self_attn.head_dim)
 
-    def maybe_get_kvcache_scale(self) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+    def maybe_get_kvcache_scale(self) -> tuple[torch.Tensor | None, torch.Tensor | None]:
         k_scale = getattr(self, "k_scale", None)
         v_scale = getattr(self, "v_scale", None)
         return k_scale, v_scale
@@ -855,11 +855,11 @@ class DecoderOnlyAttention(nn.Module):
         hidden_states: torch.Tensor,
         attention_mask: torch.Tensor,
         seq_positions: torch.LongTensor,
-        past_key_values: Tuple[Tuple[torch.Tensor]],
-        cos: Optional[torch.Tensor] = None,
-        sin: Optional[torch.Tensor] = None,
-        block_tables: Optional[torch.Tensor] = None,
-        lora_int_id: Optional[torch.Tensor] = None,
+        past_key_values: tuple[tuple[torch.Tensor]],
+        cos: torch.Tensor | None = None,
+        sin: torch.Tensor | None = None,
+        block_tables: torch.Tensor | None = None,
+        lora_int_id: torch.Tensor | None = None,
     ):
         batch_size, query_length, _ = hidden_states.size()
 
@@ -966,10 +966,10 @@ class AttentionOp(nn.Module):
         scale: torch.Tensor,
         block_tables: torch.Tensor,
         block_size: int,
-        k_scale: Optional[torch.Tensor] = None,
-        v_scale: Optional[torch.Tensor] = None,
-        s_aux: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        k_scale: torch.Tensor | None = None,
+        v_scale: torch.Tensor | None = None,
+        s_aux: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Compute attention with static shapes and explicit cache management.
 
         Args:
@@ -1208,17 +1208,17 @@ class SlidingWindowAttentionOp(AttentionOp):
         query_state: torch.Tensor,
         key_state: torch.Tensor,
         value_state: torch.Tensor,
-        attn_mask: Optional[torch.Tensor],
+        attn_mask: torch.Tensor | None,
         past_key_state: torch.Tensor,
         past_value_state: torch.Tensor,
-        seq_position: Tuple[torch.Tensor],
+        seq_position: tuple[torch.Tensor],
         scale: torch.Tensor,
         block_tables: torch.Tensor,
         block_size: int,
-        k_scale: Optional[torch.Tensor] = None,
-        v_scale: Optional[torch.Tensor] = None,
-        s_aux: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        k_scale: torch.Tensor | None = None,
+        v_scale: torch.Tensor | None = None,
+        s_aux: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         assert self.quantization is None, "Sliding window attention does not support quantization"
         assert k_scale is None and v_scale is None, "Sliding window attention does not support quantization"
 
@@ -1363,7 +1363,7 @@ def apply_rotary_pos_emb(q, k, cos, sin):
     return q_embed, k_embed
 
 
-def apply_rotary_pos_emb_partial(query_states, key_states, cos, sin, ndim) -> Tuple[torch.Tensor, torch.Tensor]:
+def apply_rotary_pos_emb_partial(query_states, key_states, cos, sin, ndim) -> tuple[torch.Tensor, torch.Tensor]:
     # Partial rotary embedding
     query_rot, query_pass = (
         query_states[..., :ndim],
@@ -1385,7 +1385,7 @@ def apply_rotary_pos_emb_partial(query_states, key_states, cos, sin, ndim) -> Tu
 
 def _get_attr_from_candidates(
     src: object,
-    candidates: Optional[List[str]] = None,
+    candidates: list[str] | None = None,
 ):
     """
     Get an attribute from a list of candidate names.

--- a/src/optimum/rbln/transformers/models/decoderonly/decoderonly_architecture.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/decoderonly_architecture.py
@@ -365,7 +365,7 @@ class DecoderOnlyModel(nn.Module):
 
     Args:
         model: Original Huggingface model to adapt
-        layers (List[DecoderOnlyLayer]): Modified transformer layers optimized for RBLN
+        layers (list[DecoderOnlyLayer]): Modified transformer layers optimized for RBLN
         rbln_config: RBLN model configuration
         use_learned_pos_emb: Whether to use learned position embeddings (class-specific override)
 

--- a/src/optimum/rbln/transformers/models/decoderonly/decoderonly_runtime_utils.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/decoderonly_runtime_utils.py
@@ -131,9 +131,7 @@ class RBLNPageTableManager:
         return get_global_block_tables(), get_local_block_tables()
 
     # Whether block_tables and local_block_tables are provided by the user
-    def is_external_block_tables(
-        self, block_tables: Optional[torch.Tensor], local_block_tables: Optional[torch.Tensor]
-    ):
+    def is_external_block_tables(self, block_tables: torch.Tensor | None, local_block_tables: torch.Tensor | None):
         if self.rbln_config.cache_impl == "static" and block_tables is None:
             return False
         elif self.rbln_config.cache_impl == "sliding_window" and local_block_tables is None:
@@ -154,8 +152,8 @@ class RBLNPageTableManager:
         cache_position: torch.Tensor,
         batch_idx: int = None,
         phase: str = "prefill",
-        block_tables: Optional[torch.Tensor] = None,
-        local_block_tables: Optional[torch.Tensor] = None,
+        block_tables: torch.Tensor | None = None,
+        local_block_tables: torch.Tensor | None = None,
     ):
         is_external_block_tables = self.is_external_block_tables(block_tables, local_block_tables)
         if not is_external_block_tables:
@@ -178,7 +176,7 @@ class RBLNRuntimeModel(RBLNPytorchRuntime):
         page_table_manager: RBLNPageTableManager,
         rbln_config: RBLNDecoderOnlyModelForCausalLMConfig,
         config: Optional["PreTrainedConfig"] = None,
-        logits_last_dim: Optional[int] = None,
+        logits_last_dim: int | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(runtime, **kwargs)
@@ -201,7 +199,7 @@ class RBLNRuntimeModel(RBLNPytorchRuntime):
         self.lora_int_ids = None
 
     def inputs_embeddings_if_needed(
-        self, input_ids: Optional[torch.Tensor] = None, inputs_embeds: Optional[torch.Tensor] = None
+        self, input_ids: torch.Tensor | None = None, inputs_embeds: torch.Tensor | None = None
     ):
         if input_ids is None and inputs_embeds is None:
             raise ValueError("Either `input_ids` or `inputs_embeds` must be provided.")
@@ -213,17 +211,17 @@ class RBLNRuntimeModel(RBLNPytorchRuntime):
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.Tensor] = None,
+        input_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
         cache_position: torch.Tensor = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        batch_idx: Optional[int] = None,
-        block_tables: Optional[torch.Tensor] = None,
-        position_embed: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.Tensor] = None,
-        token_type_ids: Optional[torch.Tensor] = None,
-        local_block_tables: Optional[torch.Tensor] = None,
-        lora_int_ids: Optional[torch.Tensor] = None,
+        attention_mask: torch.Tensor | None = None,
+        batch_idx: int | None = None,
+        block_tables: torch.Tensor | None = None,
+        position_embed: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        token_type_ids: torch.Tensor | None = None,
+        local_block_tables: torch.Tensor | None = None,
+        lora_int_ids: torch.Tensor | None = None,
     ):
         inputs = self.inputs_embeddings_if_needed(input_ids, inputs_embeds)
         block_tables, local_block_tables, is_external_block_tables = (
@@ -269,11 +267,11 @@ class RBLNRuntimeModel(RBLNPytorchRuntime):
         cache_position: torch.Tensor = None,
         block_tables: torch.Tensor = None,
         is_external_block_tables: bool = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_embed: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.Tensor] = None,
-        local_block_tables: Optional[torch.Tensor] = None,
-        lora_int_ids: Optional[torch.Tensor] = None,
+        attention_mask: torch.Tensor | None = None,
+        position_embed: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        local_block_tables: torch.Tensor | None = None,
+        lora_int_ids: torch.Tensor | None = None,
     ) -> torch.FloatTensor:
         if self.rbln_config.use_lora and lora_int_ids is None:
             if self.lora_int_ids is None:
@@ -348,11 +346,11 @@ class RBLNRuntimeModel(RBLNPytorchRuntime):
     def _prepare_prefill_inputs(
         self,
         inputs: torch.Tensor,
-        cache_position: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.Tensor] = None,
-        position_embed: Optional[torch.Tensor] = None,
-        token_type_ids: Optional[torch.Tensor] = None,
+        cache_position: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        position_embed: torch.Tensor | None = None,
+        token_type_ids: torch.Tensor | None = None,
     ):
         """
         Prepare inputs for prefill phase.
@@ -440,7 +438,7 @@ class RBLNRuntimeModel(RBLNPytorchRuntime):
     def _prepare_prefill_outputs(
         self,
         query_length: int,
-        attention_mask: Optional[torch.Tensor] = None,
+        attention_mask: torch.Tensor | None = None,
     ):
         # Prepare out buffers
         padding_size = (self.rbln_config.prefill_chunk_size - query_length) % self.rbln_config.prefill_chunk_size
@@ -503,16 +501,16 @@ class RBLNRuntimeModel(RBLNPytorchRuntime):
     def prefill_forward(
         self,
         inputs: torch.Tensor,
-        cache_position: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        batch_idx: Optional[int] = None,
-        block_tables: Optional[torch.Tensor] = None,
-        is_external_block_tables: Optional[bool] = None,
-        position_ids: Optional[torch.Tensor] = None,
-        position_embed: Optional[torch.Tensor] = None,
-        token_type_ids: Optional[torch.Tensor] = None,
-        local_block_tables: Optional[torch.Tensor] = None,
-        lora_int_ids: Optional[torch.Tensor] = None,
+        cache_position: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        batch_idx: int | None = None,
+        block_tables: torch.Tensor | None = None,
+        is_external_block_tables: bool | None = None,
+        position_ids: torch.Tensor | None = None,
+        position_embed: torch.Tensor | None = None,
+        token_type_ids: torch.Tensor | None = None,
+        local_block_tables: torch.Tensor | None = None,
+        lora_int_ids: torch.Tensor | None = None,
     ) -> torch.FloatTensor:
         """
         Performs chunked prefill for efficient KV-cache updates and memory optimization.
@@ -677,14 +675,14 @@ class RBLNDecoderOnlyChunkedMultimodalPrefillMixin:
         self,
         runtime,
         input_chunk: torch.Tensor,
-        per_layer_chunk: Optional[torch.Tensor],
+        per_layer_chunk: torch.Tensor | None,
         cache_pos_chunk: torch.Tensor,
         block_tables: torch.Tensor,
-        local_block_tables: Optional[torch.Tensor],
+        local_block_tables: torch.Tensor | None,
         query_position: torch.Tensor,
         chunked_attention_mask: torch.Tensor,
-        position_ids_chunk: Optional[torch.Tensor],
-        lora_int_ids: Optional[torch.Tensor],
+        position_ids_chunk: torch.Tensor | None,
+        lora_int_ids: torch.Tensor | None,
     ):
         # Map a single chunk onto the compiled graph's positional argument order. Subclasses MUST
         # match their wrapper's `prepare_forward_args` exactly (including any per-layer / position
@@ -766,7 +764,7 @@ class RBLNDecoderOnlyChunkedMultimodalPrefillMixin:
             )
         return run_len, bucket
 
-    def _plan_prefill_chunks(self, token_type_ids: Optional[torch.Tensor], query_length: int):
+    def _plan_prefill_chunks(self, token_type_ids: torch.Tensor | None, query_length: int):
         # Plans the chunked prefill once so the loop and block allocation stay in sync.
         # Walks the input exactly the way prefill_forward does and records, per chunk, the
         # cache padding that precedes it.
@@ -830,10 +828,10 @@ class RBLNDecoderOnlyChunkedMultimodalPrefillMixin:
 
     def _extend_cache_position_for_alloc(
         self,
-        cache_position: Optional[torch.Tensor],
-        token_type_ids: Optional[torch.Tensor],
-        attention_mask: Optional[torch.Tensor],
-    ) -> Optional[torch.Tensor]:
+        cache_position: torch.Tensor | None,
+        token_type_ids: torch.Tensor | None,
+        attention_mask: torch.Tensor | None,
+    ) -> torch.Tensor | None:
         # During prefill, the tight-pack plan may touch cache slots past `query_length` (trailing
         # chunk write-extent + partition-alignment padding). Extend cache_position so the page table
         # reserves those slots. Returns cache_position unchanged for decode or non-multimodal prefill.
@@ -867,17 +865,17 @@ class RBLNDecoderOnlyChunkedMultimodalPrefillMixin:
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.Tensor] = None,
+        input_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
         cache_position: torch.Tensor = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        batch_idx: Optional[int] = None,
-        block_tables: Optional[torch.Tensor] = None,
-        position_embed: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.Tensor] = None,
-        token_type_ids: Optional[torch.Tensor] = None,
-        local_block_tables: Optional[torch.Tensor] = None,
-        lora_int_ids: Optional[torch.Tensor] = None,
+        attention_mask: torch.Tensor | None = None,
+        batch_idx: int | None = None,
+        block_tables: torch.Tensor | None = None,
+        position_embed: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        token_type_ids: torch.Tensor | None = None,
+        local_block_tables: torch.Tensor | None = None,
+        lora_int_ids: torch.Tensor | None = None,
     ):
         # Shared dispatch for models without per-layer inputs. Subclasses that carry per-layer
         # inputs (e.g. Gemma4) override `forward` to thread that extra tensor through, calling
@@ -926,16 +924,16 @@ class RBLNDecoderOnlyChunkedMultimodalPrefillMixin:
         self,
         inputs: torch.Tensor,
         cache_position: torch.Tensor = None,
-        attention_mask: Optional[torch.Tensor] = None,
+        attention_mask: torch.Tensor | None = None,
         batch_idx: int = None,
         block_tables: torch.Tensor = None,
         is_external_block_tables: bool = None,
-        position_ids: Optional[torch.Tensor] = None,
-        position_embed: Optional[torch.Tensor] = None,
-        token_type_ids: Optional[torch.Tensor] = None,
-        local_block_tables: Optional[torch.Tensor] = None,
-        lora_int_ids: Optional[torch.Tensor] = None,
-        per_layer_inputs: Optional[torch.Tensor] = None,
+        position_ids: torch.Tensor | None = None,
+        position_embed: torch.Tensor | None = None,
+        token_type_ids: torch.Tensor | None = None,
+        local_block_tables: torch.Tensor | None = None,
+        lora_int_ids: torch.Tensor | None = None,
+        per_layer_inputs: torch.Tensor | None = None,
     ) -> torch.FloatTensor:
         if self._prefill_output_cls is None:
             raise NotImplementedError(

--- a/src/optimum/rbln/transformers/models/decoderonly/generation_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/generation_decoderonly.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 import torch
 from transformers import GenerationConfig
@@ -34,10 +34,10 @@ class RBLNDecoderOnlyGenerationMixin(GenerationMixin):
     def prepare_inputs_for_generation(
         self,
         input_ids: torch.LongTensor,
-        generate_idx: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.Tensor] = None,
-        padded_cache_lengths: Optional[torch.Tensor] = None,
+        generate_idx: torch.Tensor | None = None,
+        attention_mask: torch.LongTensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        padded_cache_lengths: torch.Tensor | None = None,
         **kwargs,
     ):
         model_inputs = {}
@@ -82,8 +82,8 @@ class RBLNDecoderOnlyGenerationMixin(GenerationMixin):
         return model_inputs
 
     def _update_model_kwargs_for_generation(
-        self, outputs: "RBLNDecoderOnlyOutput", model_kwargs: Dict[str, Any], **kwargs
-    ) -> Dict[str, Any]:
+        self, outputs: "RBLNDecoderOnlyOutput", model_kwargs: dict[str, Any], **kwargs
+    ) -> dict[str, Any]:
         # update generate_idx
         model_kwargs["generate_idx"] = outputs.generate_idx
         model_kwargs["padded_cache_lengths"] = outputs.padded_cache_lengths
@@ -92,10 +92,10 @@ class RBLNDecoderOnlyGenerationMixin(GenerationMixin):
     def generate(
         self,
         input_ids: torch.LongTensor,
-        attention_mask: Optional[torch.LongTensor] = None,
-        generation_config: Optional[GenerationConfig] = None,
+        attention_mask: torch.LongTensor | None = None,
+        generation_config: GenerationConfig | None = None,
         **kwargs,
-    ) -> Union[ModelOutput, torch.LongTensor]:
+    ) -> ModelOutput | torch.LongTensor:
         """
         The generate function is utilized in its standard form as in the HuggingFace transformers library. User can use this function to generate text from the model.
         Check the [HuggingFace transformers documentation](https://huggingface.co/docs/transformers/v4.57.1/en/main_classes/text_generation#transformers.GenerationMixin.generate) for more details.

--- a/src/optimum/rbln/transformers/models/decoderonly/lora_architecture.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/lora_architecture.py
@@ -1,6 +1,5 @@
 import math
 from pathlib import Path
-from typing import Optional
 
 import safetensors.torch
 import torch
@@ -166,7 +165,7 @@ class LoRALinear(nn.Module):
             "lora_b_weights", torch.stack(lora_b_transposed, dim=0).to(self.weight.dtype)
         )  # [num_adapters, rank, out_features]
 
-    def forward(self, x: torch.Tensor, lora_int_id: Optional[torch.Tensor] = None) -> torch.Tensor:
+    def forward(self, x: torch.Tensor, lora_int_id: torch.Tensor | None = None) -> torch.Tensor:
         """
         Forward pass that combines base linear transformation with LoRA.
 

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import inspect
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import rebel
 import torch
@@ -137,15 +138,15 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
     def get_quantized_model(
         cls,
         model_id: str,
-        config: Optional[PretrainedConfig] = None,
-        token: Optional[Union[bool, str]] = None,
-        revision: Optional[str] = None,
+        config: PretrainedConfig | None = None,
+        token: bool | str | None = None,
+        revision: str | None = None,
         force_download: bool = False,
-        cache_dir: Optional[str] = None,
+        cache_dir: str | None = None,
         subfolder: str = "",
         local_files_only: bool = False,
         trust_remote_code: bool = False,
-        rbln_config: Optional[RBLNDecoderOnlyModelConfig] = None,
+        rbln_config: RBLNDecoderOnlyModelConfig | None = None,
         **kwargs,
     ):
         kwargs = cls.update_kwargs(kwargs)
@@ -258,7 +259,7 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
                 quantization.maybe_reset_quantization_env()
 
     @classmethod
-    def _get_compile_context(cls, compile_config: RBLNCompileConfig, example_inputs: List[torch.Tensor]):
+    def _get_compile_context(cls, compile_config: RBLNCompileConfig, example_inputs: list[torch.Tensor]):
         context = CompileContext(use_weight_sharing=True)
 
         # Mark static tensors (self kv states)
@@ -336,7 +337,7 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
 
     @classmethod
     def get_pytorch_model(
-        cls, *args, rbln_config: Optional[RBLNDecoderOnlyModelConfig] = None, **kwargs
+        cls, *args, rbln_config: RBLNDecoderOnlyModelConfig | None = None, **kwargs
     ) -> PreTrainedModel:
         if rbln_config and rbln_config.quantization:
             model = cls.get_quantized_model(*args, rbln_config=rbln_config, **kwargs)
@@ -539,10 +540,10 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]] = None,
-        model: Optional[PreTrainedModel] = None,
-        model_config: Optional[PretrainedConfig] = None,
-        rbln_config: Optional[RBLNDecoderOnlyModelForCausalLMConfig] = None,
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None = None,
+        model: PreTrainedModel | None = None,
+        model_config: PretrainedConfig | None = None,
+        rbln_config: RBLNDecoderOnlyModelForCausalLMConfig | None = None,
     ) -> RBLNDecoderOnlyModelForCausalLMConfig:
         if rbln_config.max_seq_len is None:
             rbln_config.max_seq_len = getattr(model_config, "max_position_embeddings", None) or getattr(
@@ -609,9 +610,9 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
     @classmethod
     def _create_runtimes(
         cls,
-        compiled_models: List[rebel.RBLNCompiledModel],
+        compiled_models: list[rebel.RBLNCompiledModel],
         rbln_config: RBLNDecoderOnlyModelForCausalLMConfig,
-    ) -> List[rebel.Runtime]:
+    ) -> list[rebel.Runtime]:
         expected_model_names = rbln_config.expected_compiled_model_names
 
         if any(model_name not in rbln_config.device_map for model_name in expected_model_names):
@@ -643,12 +644,12 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.LongTensor] = None,
-        position_ids: Optional[torch.Tensor] = None,
-        position_embed: Optional[torch.Tensor] = None,
-        output_hidden_states: Optional[bool] = None,
+        input_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        attention_mask: torch.LongTensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        position_embed: torch.Tensor | None = None,
+        output_hidden_states: bool | None = None,
         **kwargs,
     ) -> BaseModelOutputWithPast:
         """
@@ -735,7 +736,7 @@ class RBLNDecoderOnlyModelForCausalLM(RBLNDecoderOnlyModel, RBLNDecoderOnlyGener
     def logits_last_dim(self):
         return self.config.vocab_size
 
-    def set_lora_int_ids(self, lora_int_ids: Optional[torch.Tensor]):
+    def set_lora_int_ids(self, lora_int_ids: torch.Tensor | None):
         if isinstance(lora_int_ids, int):
             lora_int_ids = torch.tensor([lora_int_ids], dtype=torch.int32)
         elif isinstance(lora_int_ids, list):
@@ -748,7 +749,7 @@ class RBLNDecoderOnlyModelForCausalLM(RBLNDecoderOnlyModel, RBLNDecoderOnlyGener
             for batch_size in self.rbln_config.decoder_batch_sizes:
                 self.decoders[batch_size].lora_int_ids = lora_int_ids
 
-    def set_adapter(self, adapter_name: Union[str, List[str]]) -> None:
+    def set_adapter(self, adapter_name: str | list[str]) -> None:
         """
         Sets the active adapter(s) for the model using adapter name(s).
 
@@ -784,19 +785,19 @@ class RBLNDecoderOnlyModelForCausalLM(RBLNDecoderOnlyModel, RBLNDecoderOnlyGener
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.Tensor] = None,
-        cache_position: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.LongTensor] = None,
-        generate_idx: Optional[torch.Tensor] = None,
-        padded_cache_lengths: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.Tensor] = None,
-        token_type_ids: Optional[torch.Tensor] = None,
-        lora_int_ids: Optional[torch.Tensor] = None,
-        return_dict: Optional[torch.Tensor] = None,
-        output_hidden_states: Optional[bool] = None,
+        input_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        cache_position: torch.Tensor | None = None,
+        attention_mask: torch.LongTensor | None = None,
+        generate_idx: torch.Tensor | None = None,
+        padded_cache_lengths: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        token_type_ids: torch.Tensor | None = None,
+        lora_int_ids: torch.Tensor | None = None,
+        return_dict: torch.Tensor | None = None,
+        output_hidden_states: bool | None = None,
         **kwargs,
-    ) -> Tuple[torch.FloatTensor]:
+    ) -> tuple[torch.FloatTensor]:
         # Forward method for the RBLN-optimized model, designed for integration with the HuggingFace generate API.
         # For continuous batching, the prefill stage processes one batch at a time and updates the KV cache using batch_idx.
         # A for-loop ensures synchronization with the HuggingFace generate API.

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -754,7 +754,7 @@ class RBLNDecoderOnlyModelForCausalLM(RBLNDecoderOnlyModel, RBLNDecoderOnlyGener
         Sets the active adapter(s) for the model using adapter name(s).
 
         Args:
-            adapter_name (Union[str, List[str]]): The name(s) of the adapter(s) to be activated.
+            adapter_name (str | list[str]): The name(s) of the adapter(s) to be activated.
                 Can be a single adapter name or a list of adapter names.
 
         Raises:

--- a/src/optimum/rbln/transformers/models/depth_anything/modeling_depth_anything.py
+++ b/src/optimum/rbln/transformers/models/depth_anything/modeling_depth_anything.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 
-from typing import Tuple, Union
-
 import torch
 from transformers.modeling_outputs import DepthEstimatorOutput
 
@@ -29,7 +27,7 @@ class RBLNDepthAnythingForDepthEstimation(RBLNModelForDepthEstimation):
     models on RBLN devices, providing the most capable monocular depth estimation (MDE) model.
     """
 
-    def forward(self, pixel_values: torch.Tensor, **kwargs) -> Union[Tuple, DepthEstimatorOutput]:
+    def forward(self, pixel_values: torch.Tensor, **kwargs) -> tuple | DepthEstimatorOutput:
         """
         Forward pass for the RBLN-optimized DepthAnythingForDepthEstimation model.
 

--- a/src/optimum/rbln/transformers/models/detr/configuration_detr.py
+++ b/src/optimum/rbln/transformers/models/detr/configuration_detr.py
@@ -33,9 +33,9 @@ class RBLNDetrForObjectDetectionConfig(RBLNImageModelConfig):
     ):
         """
         Args:
-            image_size (Optional[Union[int, Tuple[int, int]]]): The size of input images
+            image_size (int | tuple[int, int] | None): The size of input images
                 for compile shape. Can be an integer for square images or a tuple (height, width).
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/transformers/models/detr/configuration_detr.py
+++ b/src/optimum/rbln/transformers/models/detr/configuration_detr.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Tuple, Union
+from typing import Any
 
 from ...configuration_generic import RBLNImageModelConfig
 
@@ -27,8 +27,8 @@ class RBLNDetrForObjectDetectionConfig(RBLNImageModelConfig):
 
     def __init__(
         self,
-        image_size: Optional[Union[int, Tuple[int, int]]] = None,
-        batch_size: Optional[int] = None,
+        image_size: int | tuple[int, int] | None = None,
+        batch_size: int | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/transformers/models/detr/modeling_detr.py
+++ b/src/optimum/rbln/transformers/models/detr/modeling_detr.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import torch
 from transformers import AutoModelForObjectDetection
@@ -45,7 +45,7 @@ class RBLNDetrForObjectDetection(RBLNModel):
         preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"],
         model: Optional["PreTrainedModel"] = None,
         model_config: "DetrConfig" = None,
-        rbln_config: Optional[RBLNDetrForObjectDetectionConfig] = None,
+        rbln_config: RBLNDetrForObjectDetectionConfig | None = None,
     ) -> RBLNDetrForObjectDetectionConfig:
         if rbln_config.image_size is None:
             for processor in preprocessors:
@@ -86,10 +86,10 @@ class RBLNDetrForObjectDetection(RBLNModel):
     def forward(
         self,
         pixel_values: torch.Tensor,
-        pixel_mask: Optional[torch.Tensor] = None,
+        pixel_mask: torch.Tensor | None = None,
         return_dict: bool = None,
         **kwargs,
-    ) -> Union[Tuple, DetrObjectDetectionOutput]:
+    ) -> tuple | DetrObjectDetectionOutput:
         """
         Forward pass for the RBLN-optimized DETR model for object detection.
 

--- a/src/optimum/rbln/transformers/models/distilbert/modeling_distilbert.py
+++ b/src/optimum/rbln/transformers/models/distilbert/modeling_distilbert.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Tuple, Union
 
 import torch
 from transformers.modeling_outputs import QuestionAnsweringModelOutput
@@ -33,10 +32,10 @@ class RBLNDistilBertForQuestionAnswering(RBLNModelForQuestionAnswering):
 
     def forward(
         self,
-        input_ids: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
+        input_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
         **kwargs,
-    ) -> Union[Tuple, QuestionAnsweringModelOutput]:
+    ) -> tuple | QuestionAnsweringModelOutput:
         """
         Forward pass for the RBLN-optimized DistilBERT model for question answering tasks.
 

--- a/src/optimum/rbln/transformers/models/dpt/modeling_dpt.py
+++ b/src/optimum/rbln/transformers/models/dpt/modeling_dpt.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 
-from typing import Tuple, Union
-
 import torch
 from transformers.modeling_outputs import DepthEstimatorOutput
 
@@ -29,7 +27,7 @@ class RBLNDPTForDepthEstimation(RBLNModelForDepthEstimation):
     models on RBLN devices, supporting monocular depth estimation from single images.
     """
 
-    def forward(self, pixel_values: torch.Tensor, **kwargs) -> Union[Tuple, DepthEstimatorOutput]:
+    def forward(self, pixel_values: torch.Tensor, **kwargs) -> tuple | DepthEstimatorOutput:
         """
         Forward pass for the RBLN-optimized DPT model.
 

--- a/src/optimum/rbln/transformers/models/exaone/modeling_exaone.py
+++ b/src/optimum/rbln/transformers/models/exaone/modeling_exaone.py
@@ -109,11 +109,11 @@ class RBLNExaoneForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         User can use this function to load a pre-trained model from the HuggingFace library and convert it to a RBLN model to be run on RBLN NPUs.
 
         Args:
-            model_id (Union[str, Path]): The model id of the pre-trained model to be loaded.
+            model_id (str | Path): The model id of the pre-trained model to be loaded.
                 It can be downloaded from the HuggingFace model hub or a local path, or a model id of a compiled model using the RBLN Compiler.
-            export (Optional[bool]): A boolean flag to indicate whether the model should be compiled.
+            export (bool | None): A boolean flag to indicate whether the model should be compiled.
                 If None, it will be determined based on the existence of the compiled model files in the model_id.
-            rbln_config (Optional[Union[Dict, RBLNModelConfig]]): Configuration for RBLN model compilation and runtime.
+            rbln_config (dict | RBLNModelConfig | None): Configuration for RBLN model compilation and runtime.
                 This can be provided as a dictionary or an instance of the model's configuration class (e.g., `RBLNExaoneForCausalLMConfig` for EXAONE models).
                 For detailed configuration options, see the specific model's configuration class documentation.
             trust_remote_code (bool): Whether or not to trust the remote code when loading a model from the Hub.

--- a/src/optimum/rbln/transformers/models/exaone/modeling_exaone.py
+++ b/src/optimum/rbln/transformers/models/exaone/modeling_exaone.py
@@ -14,8 +14,9 @@
 
 
 import inspect
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any
 
 from transformers import AutoModelForCausalLM
 from transformers.generation.utils import GenerationMixin
@@ -96,11 +97,11 @@ class RBLNExaoneForCausalLM(RBLNDecoderOnlyModelForCausalLM):
     @classmethod
     def from_pretrained(
         cls,
-        model_id: Union[str, Path],
+        model_id: str | Path,
         *,
-        export: Optional[bool] = None,
-        rbln_config: Optional[Union[Dict, RBLNModelConfig]] = None,
-        trust_remote_code: Optional[bool] = None,
+        export: bool | None = None,
+        rbln_config: dict | RBLNModelConfig | None = None,
+        trust_remote_code: bool | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/transformers/models/exaone4_5/configuration_exaone4_5.py
+++ b/src/optimum/rbln/transformers/models/exaone4_5/configuration_exaone4_5.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, List, Optional, Union
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ..decoderonly.configuration_decoderonly import RBLNDecoderOnlyModelConfig, RBLNDecoderOnlyModelForCausalLMConfig
@@ -32,7 +32,7 @@ class RBLNExaone4_5_ForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausal
     def __init__(
         self,
         use_inputs_embeds: bool = True,
-        visual: Optional[RBLNModelConfig] = None,
+        visual: RBLNModelConfig | None = None,
         **kwargs: Any,
     ):
         """
@@ -60,7 +60,7 @@ class RBLNExaone4_5_ModelConfig(RBLNDecoderOnlyModelConfig):
 
     submodules = ["visual"]
 
-    def __init__(self, visual: Optional[RBLNModelConfig] = None, **kwargs: Any):
+    def __init__(self, visual: RBLNModelConfig | None = None, **kwargs: Any):
         super().__init__(**kwargs)
         self.visual = self.initialize_submodule_config(submodule_config=visual)
 
@@ -74,7 +74,7 @@ class RBLNExaone4_5_VisionModelConfig(RBLNModelConfig):
     mechanisms for processing images and videos.
     """
 
-    def __init__(self, max_seq_len: Union[int, List[int]] = None, **kwargs: Any):
+    def __init__(self, max_seq_len: int | list[int] = None, **kwargs: Any):
         """
         Args:
             max_seq_len (Optional[Union[int, List[int]]]): Maximum sequence lengths for Vision

--- a/src/optimum/rbln/transformers/models/exaone4_5/configuration_exaone4_5.py
+++ b/src/optimum/rbln/transformers/models/exaone4_5/configuration_exaone4_5.py
@@ -38,7 +38,7 @@ class RBLNExaone4_5_ForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausal
         """
         Args:
             use_inputs_embeds (bool): Whether or not to use `inputs_embeds` as input. Defaults to `True`.
-            visual (Optional[RBLNModelConfig]): Configuration for the vision encoder component.
+            visual (RBLNModelConfig | None): Configuration for the vision encoder component.
             kwargs: Additional arguments passed to the parent `RBLNDecoderOnlyModelForCausalLMConfig`.
 
         Raises:
@@ -77,7 +77,7 @@ class RBLNExaone4_5_VisionModelConfig(RBLNModelConfig):
     def __init__(self, max_seq_len: int | list[int] = None, **kwargs: Any):
         """
         Args:
-            max_seq_len (Optional[Union[int, List[int]]]): Maximum sequence lengths for Vision
+            max_seq_len (int | list[int] | None): Maximum sequence lengths for Vision
                 Transformer attention. Can be an integer or list of integers, each indicating
                 the number of patches in a sequence for an image or video. For window-based
                 attention, `max_seq_len` must be a multiple of `(window_size / patch_size)^2`.

--- a/src/optimum/rbln/transformers/models/exaone4_5/exaone4_5_architecture.py
+++ b/src/optimum/rbln/transformers/models/exaone4_5/exaone4_5_architecture.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING
 
 import torch
 import torch.nn as nn
@@ -95,7 +95,7 @@ class Exaone4_5VisionBlock(torch.nn.Module):
         self,
         hidden_states: torch.Tensor,
         attn_masks: torch.Tensor,
-        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
     ) -> torch.Tensor:
         hidden_states = hidden_states + self.attn(
             self.norm1(hidden_states),
@@ -124,7 +124,7 @@ class Exaone4_5VisionFullAttention(nn.Module):
         self,
         hidden_states: torch.Tensor,
         attn_masks: torch.Tensor,
-        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
         if self.num_key_value_heads == self.num_heads:
@@ -180,7 +180,7 @@ class Exaone4_5VisionWindowAttention(nn.Module):
         self,
         hidden_states: torch.Tensor,
         attn_masks: torch.Tensor,
-        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
     ) -> torch.Tensor:
         seq_length, hidden_dim = hidden_states.shape
         assert seq_length % self.window_seq_len == 0
@@ -267,11 +267,11 @@ class Exaone4_5DecoderLayer(DecoderOnlyLayer):
         hidden_states: torch.Tensor,
         attention_mask: torch.Tensor,
         seq_positions: torch.LongTensor,
-        past_key_values: Tuple[Tuple[torch.Tensor]],
-        cos: Optional[torch.Tensor] = None,
-        sin: Optional[torch.Tensor] = None,
-        block_tables: Optional[torch.Tensor] = None,
-        lora_int_id: Optional[torch.Tensor] = None,
+        past_key_values: tuple[tuple[torch.Tensor]],
+        cos: torch.Tensor | None = None,
+        sin: torch.Tensor | None = None,
+        block_tables: torch.Tensor | None = None,
+        lora_int_id: torch.Tensor | None = None,
     ):
         residual = hidden_states
 

--- a/src/optimum/rbln/transformers/models/exaone4_5/modeling_exaone4_5.py
+++ b/src/optimum/rbln/transformers/models/exaone4_5/modeling_exaone4_5.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import inspect
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import torch
 from transformers import AutoModelForImageTextToText, PretrainedConfig, PreTrainedModel
@@ -120,7 +121,7 @@ class RBLNExaone4_5_VisionModel(RBLNModel):
         preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"],
         model: Optional["PreTrainedModel"] = None,
         model_config: "PretrainedConfig" = None,
-        rbln_config: Optional[RBLNExaone4_5_VisionModelConfig] = None,
+        rbln_config: RBLNExaone4_5_VisionModelConfig | None = None,
     ) -> RBLNExaone4_5_VisionModelConfig:
         model_config = model_config.vision_config if hasattr(model_config, "vision_config") else model_config
         window_size = model_config.window_size
@@ -156,9 +157,9 @@ class RBLNExaone4_5_VisionModel(RBLNModel):
 
     @staticmethod
     def _pad_for_window_attn_layers(
-        window_indice: List[int],
+        window_indice: list[int],
         hidden_states: torch.Tensor,
-        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
         window_seq_len: int,
         max_seq_len: int,
     ):
@@ -348,10 +349,10 @@ class RBLNExaone4_5_Model(RBLNDecoderOnlyModel):
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]] = None,
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None = None,
         model: Optional["PreTrainedModel"] = None,
-        model_config: Optional[PretrainedConfig] = None,
-        rbln_config: Optional[RBLNExaone4_5_ForConditionalGenerationConfig] = None,
+        model_config: PretrainedConfig | None = None,
+        rbln_config: RBLNExaone4_5_ForConditionalGenerationConfig | None = None,
     ):
         if model is not None:
             _disable_mtp(model.config)
@@ -392,17 +393,17 @@ class RBLNExaone4_5_Model(RBLNDecoderOnlyModel):
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        pixel_values: Optional[torch.Tensor] = None,
-        pixel_values_videos: Optional[torch.FloatTensor] = None,
-        image_grid_thw: Optional[torch.LongTensor] = None,
-        video_grid_thw: Optional[torch.LongTensor] = None,
-        cache_position: Optional[torch.LongTensor] = None,
-        second_per_grid_ts: Optional[torch.Tensor] = None,
-        output_hidden_states: Optional[bool] = None,
-        return_dict: Optional[bool] = None,
+        input_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        pixel_values_videos: torch.FloatTensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        video_grid_thw: torch.LongTensor | None = None,
+        cache_position: torch.LongTensor | None = None,
+        second_per_grid_ts: torch.Tensor | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
         inputs_embeds = self._preprocess_prefill(
@@ -483,9 +484,9 @@ class RBLNExaone4_5_ForConditionalGeneration(RBLNExaone4_5_Model, RBLNDecoderOnl
     def prepare_inputs_for_generation(
         self,
         input_ids: torch.LongTensor,
-        generate_idx: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.Tensor] = None,
+        generate_idx: torch.Tensor | None = None,
+        attention_mask: torch.LongTensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
         pixel_values=None,
         pixel_values_videos=None,
         image_grid_thw=None,
@@ -525,18 +526,18 @@ class RBLNExaone4_5_ForConditionalGeneration(RBLNExaone4_5_Model, RBLNDecoderOnl
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        pixel_values: Optional[torch.Tensor] = None,
-        pixel_values_videos: Optional[torch.FloatTensor] = None,
-        image_grid_thw: Optional[torch.LongTensor] = None,
-        video_grid_thw: Optional[torch.LongTensor] = None,
-        cache_position: Optional[torch.LongTensor] = None,
-        second_per_grid_ts: Optional[torch.Tensor] = None,
-        generate_idx: Optional[torch.Tensor] = None,
-        return_dict: Optional[bool] = None,
-        output_hidden_states: Optional[bool] = None,
+        input_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        pixel_values_videos: torch.FloatTensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        video_grid_thw: torch.LongTensor | None = None,
+        cache_position: torch.LongTensor | None = None,
+        second_per_grid_ts: torch.Tensor | None = None,
+        generate_idx: torch.Tensor | None = None,
+        return_dict: bool | None = None,
+        output_hidden_states: bool | None = None,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)

--- a/src/optimum/rbln/transformers/models/gemma2/gemma2_architecture.py
+++ b/src/optimum/rbln/transformers/models/gemma2/gemma2_architecture.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Tuple, Union
 
 import torch
 
@@ -39,12 +38,12 @@ class Gemma2DecoderLayer(DecoderOnlyLayer):
         self,
         hidden_states: torch.Tensor,
         attention_mask: torch.Tensor,
-        seq_positions: Union[torch.LongTensor, Tuple[torch.LongTensor]],
-        past_key_values: Tuple[Tuple[torch.Tensor]],
-        cos: Optional[torch.Tensor] = None,
-        sin: Optional[torch.Tensor] = None,
-        block_tables: Optional[torch.Tensor] = None,
-        lora_int_id: Optional[torch.Tensor] = None,
+        seq_positions: torch.LongTensor | tuple[torch.LongTensor],
+        past_key_values: tuple[tuple[torch.Tensor]],
+        cos: torch.Tensor | None = None,
+        sin: torch.Tensor | None = None,
+        block_tables: torch.Tensor | None = None,
+        lora_int_id: torch.Tensor | None = None,
     ):
         residual = hidden_states
         hidden_states = self.get_pre_attention_layernorm()(hidden_states)

--- a/src/optimum/rbln/transformers/models/gemma3/configuration_gemma3.py
+++ b/src/optimum/rbln/transformers/models/gemma3/configuration_gemma3.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Optional
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....utils.logging import get_logger
@@ -24,10 +24,10 @@ logger = get_logger(__name__)
 class RBLNGemma3ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
     def __init__(
         self,
-        use_position_ids: Optional[bool] = None,
-        use_attention_mask: Optional[bool] = None,
-        prefill_chunk_size: Optional[int] = None,
-        image_prefill_chunk_size: Optional[int] = None,
+        use_position_ids: bool | None = None,
+        use_attention_mask: bool | None = None,
+        prefill_chunk_size: int | None = None,
+        image_prefill_chunk_size: int | None = None,
         **kwargs: Any,
     ):
         """
@@ -67,9 +67,9 @@ class RBLNGemma3ForConditionalGenerationConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        vision_tower: Optional[RBLNModelConfig] = None,
-        language_model: Optional[RBLNModelConfig] = None,
+        batch_size: int | None = None,
+        vision_tower: RBLNModelConfig | None = None,
+        language_model: RBLNModelConfig | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/transformers/models/gemma3/configuration_gemma3.py
+++ b/src/optimum/rbln/transformers/models/gemma3/configuration_gemma3.py
@@ -32,12 +32,12 @@ class RBLNGemma3ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
     ):
         """
         Args:
-            use_position_ids (Optional[bool]): Whether or not to use `position_ids`, which is indices of positions of each input sequence tokens in the position embeddings.
-            use_attention_mask (Optional[bool]): Whether or not to use `attention_mask` to to avoid performing attention on padding token indices.
-            prefill_chunk_size (Optional[int]): The chunk size used during the prefill phase for
+            use_position_ids (bool | None): Whether or not to use `position_ids`, which is indices of positions of each input sequence tokens in the position embeddings.
+            use_attention_mask (bool | None): Whether or not to use `attention_mask` to to avoid performing attention on padding token indices.
+            prefill_chunk_size (int | None): The chunk size used during the prefill phase for
                 processing input sequences. Defaults to 256. Must be a positive integer
                 divisible by 64. Affects prefill performance and memory usage.
-            image_prefill_chunk_size (Optional[int]): The chunk size used during the prefill phase for
+            image_prefill_chunk_size (int | None): The chunk size used during the prefill phase for
                 processing images. This config is used when `use_image_prefill` is True.
                 Currently, the `prefill_chunk_size` and `image_prefill_chunk_size` should be the same value.
             kwargs: Additional arguments passed to the parent `RBLNDecoderOnlyModelForCausalLMConfig`.
@@ -74,9 +74,9 @@ class RBLNGemma3ForConditionalGenerationConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            vision_tower (Optional[RBLNModelConfig]): Configuration for the vision encoder component.
-            language_model (Optional[RBLNModelConfig]): Configuration for the language model component.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            vision_tower (RBLNModelConfig | None): Configuration for the vision encoder component.
+            language_model (RBLNModelConfig | None): Configuration for the language model component.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/transformers/models/gemma3/gemma3_architecture.py
+++ b/src/optimum/rbln/transformers/models/gemma3/gemma3_architecture.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import copy
-from typing import Optional, Tuple, Union
 
 import torch
 
@@ -62,12 +61,12 @@ class Gemma3TextModel(DecoderOnlyModel):
         cache_position: torch.Tensor = None,
         position_ids: torch.Tensor = None,
         query_position: torch.Tensor = None,
-        past_key_values: Tuple[Tuple[torch.Tensor]] = None,
+        past_key_values: tuple[tuple[torch.Tensor]] = None,
         rotary_emb: torch.nn.Module = None,
-        global_block_tables: Optional[torch.Tensor] = None,
-        local_block_tables: Optional[torch.Tensor] = None,
-        lora_int_id: Optional[torch.Tensor] = None,
-        output_hidden_states: Optional[bool] = None,
+        global_block_tables: torch.Tensor | None = None,
+        local_block_tables: torch.Tensor | None = None,
+        lora_int_id: torch.Tensor | None = None,
+        output_hidden_states: bool | None = None,
     ):
         # retrieve input_ids and inputs_embeds
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -132,12 +131,12 @@ class Gemma3DecoderLayer(DecoderOnlyLayer):
         self,
         hidden_states: torch.Tensor,
         attention_mask: torch.Tensor,
-        seq_positions: Union[torch.LongTensor, Tuple[torch.LongTensor]],
-        past_key_values: Tuple[Tuple[torch.Tensor]],
-        cos: Optional[torch.Tensor] = None,
-        sin: Optional[torch.Tensor] = None,
-        block_tables: Optional[torch.Tensor] = None,
-        lora_int_id: Optional[torch.Tensor] = None,
+        seq_positions: torch.LongTensor | tuple[torch.LongTensor],
+        past_key_values: tuple[tuple[torch.Tensor]],
+        cos: torch.Tensor | None = None,
+        sin: torch.Tensor | None = None,
+        block_tables: torch.Tensor | None = None,
+        lora_int_id: torch.Tensor | None = None,
     ):
         residual = hidden_states
         hidden_states = self.get_pre_attention_layernorm()(hidden_states)

--- a/src/optimum/rbln/transformers/models/gemma3/gemma3_runtime_utils.py
+++ b/src/optimum/rbln/transformers/models/gemma3/gemma3_runtime_utils.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Optional
+from typing import Any
 
 import rebel
 import torch
@@ -33,7 +33,7 @@ class RBLNGemma3RuntimeModel(RBLNDecoderOnlyChunkedMultimodalPrefillMixin, RBLNR
 
     _prefill_output_cls = RBLNGemma3ForCausalLMOutput
 
-    def __init__(self, *args: Any, image_prefill: Optional[rebel.Runtime] = None, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, image_prefill: rebel.Runtime | None = None, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.image_prefill = RBLNPytorchRuntime(image_prefill)
         self.prefill = RBLNPytorchRuntime(self.runtime) if self.phase == "prefill" else None
@@ -42,14 +42,14 @@ class RBLNGemma3RuntimeModel(RBLNDecoderOnlyChunkedMultimodalPrefillMixin, RBLNR
         self,
         runtime,
         input_chunk: torch.Tensor,
-        per_layer_chunk: Optional[torch.Tensor],
+        per_layer_chunk: torch.Tensor | None,
         cache_pos_chunk: torch.Tensor,
         block_tables: torch.Tensor,
-        local_block_tables: Optional[torch.Tensor],
+        local_block_tables: torch.Tensor | None,
         query_position: torch.Tensor,
         chunked_attention_mask: torch.Tensor,
-        position_ids_chunk: Optional[torch.Tensor],
-        lora_int_ids: Optional[torch.Tensor],
+        position_ids_chunk: torch.Tensor | None,
+        lora_int_ids: torch.Tensor | None,
     ):
         # Gemma3 has no per-layer inputs, so `per_layer_chunk` is ignored. Argument order mirrors
         # Gemma3ForCausalLMWrapper.prepare_forward_args. The callee owns the `use_lora` gate.

--- a/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 import importlib
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Union
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import torch
 from transformers import AutoModelForImageTextToText, Gemma3ForConditionalGeneration, PretrainedConfig, PreTrainedModel
@@ -133,10 +134,10 @@ class RBLNGemma3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
-        rbln_config: Optional[RBLNModelConfig] = None,
+        rbln_config: RBLNModelConfig | None = None,
     ) -> RBLNModelConfig:
         image_feature_dim = (model_config.vision_config.image_size // model_config.vision_config.patch_size) ** 2
         feature_size = model_config.vision_config.hidden_size
@@ -186,9 +187,9 @@ class RBLNGemma3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
     def _update_model_kwargs_for_generation(
         self,
         outputs: RBLNDecoderOnlyOutput,
-        model_kwargs: Dict[str, Any],
+        model_kwargs: dict[str, Any],
         **kwargs,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         # update generate_idx
         model_kwargs["generate_idx"] = outputs.generate_idx
         model_kwargs["padded_cache_lengths"] = outputs.padded_cache_lengths
@@ -224,9 +225,9 @@ class RBLNGemma3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
 
     def _preprocess_prefill(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        pixel_values: Optional[torch.FloatTensor] = None,
+        input_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        pixel_values: torch.FloatTensor | None = None,
         **kwargs,
     ):
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -260,14 +261,14 @@ class RBLNGemma3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
         attention_mask: torch.Tensor = None,
         token_type_ids: torch.Tensor = None,
         pixel_values: torch.FloatTensor = None,
-        cache_position: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        generate_idx: Optional[torch.Tensor] = None,
-        padded_cache_lengths: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.Tensor] = None,
-        output_hidden_states: Optional[bool] = None,
-        **lm_kwargs: Dict[str, Any],
-    ) -> Union[Tuple, RBLNDecoderOnlyOutput]:
+        cache_position: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        generate_idx: torch.Tensor | None = None,
+        padded_cache_lengths: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        output_hidden_states: bool | None = None,
+        **lm_kwargs: dict[str, Any],
+    ) -> tuple | RBLNDecoderOnlyOutput:
         output_hidden_states = (
             output_hidden_states
             if output_hidden_states is not None
@@ -411,7 +412,7 @@ class RBLNGemma3ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         cls,
         model: "PreTrainedModel",
         rbln_config: RBLNModelConfig,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
     ):
         if rbln_config.image_prefill_chunk_size is None:
             rbln_config.image_prefill_chunk_size = model.config.mm_tokens_per_image

--- a/src/optimum/rbln/transformers/models/gemma4/configuration_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/configuration_gemma4.py
@@ -45,10 +45,10 @@ class RBLNGemma4ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
     ):
         """
         Args:
-            use_position_ids (Optional[bool]): Whether to use `position_ids`. Forced to `True` for Gemma4.
-            use_attention_mask (Optional[bool]): Whether to use `attention_mask`. Forced to `True` for Gemma4.
-            prefill_chunk_size (Optional[int]): Chunk size used during the prefill phase. Defaults to 128.
-            image_prefill_chunk_size (Optional[Union[int, List[int]]]): Chunk size(s) used for image-prefill
+            use_position_ids (bool | None): Whether to use `position_ids`. Forced to `True` for Gemma4.
+            use_attention_mask (bool | None): Whether to use `attention_mask`. Forced to `True` for Gemma4.
+            prefill_chunk_size (int | None): Chunk size used during the prefill phase. Defaults to 128.
+            image_prefill_chunk_size (int | list[int] | None): Chunk size(s) used for image-prefill
                 (multimodal Gemma4). A single int compiles one `image_prefill` graph; a list compiles one
                 graph per value (sorted in descending order) and the runtime picks the smallest bucket that
                 fits an image run. When not given, it is derived from the vision tower's `max_soft_tokens`
@@ -138,16 +138,16 @@ class RBLNGemma4VisionModelConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size of images (number of images, not patches). Defaults to 1.
-            max_soft_tokens (Optional[Union[int, List[int]]]): The number of soft tokens emitted per image
+            batch_size (int | None): The batch size of images (number of images, not patches). Defaults to 1.
+            max_soft_tokens (int | list[int] | None): The number of soft tokens emitted per image
                 after pooling. Defaults to 280 (the upstream default in `Gemma4ImageProcessor`). A single int
                 compiles one vision graph; a list compiles one graph per value (sorted descending) so the
                 runtime can serve images at multiple soft-token counts. Must be a value supported by the image
                 processor (e.g. 70/140/280/560/1120).
-            pooling_kernel_size (Optional[int]): Spatial pooling kernel size applied after patchification.
+            pooling_kernel_size (int | None): Spatial pooling kernel size applied after patchification.
                 Defaults to `model_config.pooling_kernel_size` (3 by default).
-            patch_size (Optional[int]): Patch height/width in pixels. Defaults to `model_config.patch_size`.
-            output_hidden_states (Optional[bool]): Whether to return per-layer hidden states.
+            patch_size (int | None): Patch height/width in pixels. Defaults to `model_config.patch_size`.
+            output_hidden_states (bool | None): Whether to return per-layer hidden states.
             kwargs: Additional arguments passed to the parent `RBLNModelConfig`.
 
         Raises:
@@ -196,9 +196,9 @@ class RBLNGemma4ForConditionalGenerationConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            vision_tower (Optional[RBLNModelConfig]): Configuration for the vision encoder component.
-            language_model (Optional[RBLNModelConfig]): Configuration for the language model component.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            vision_tower (RBLNModelConfig | None): Configuration for the vision encoder component.
+            language_model (RBLNModelConfig | None): Configuration for the language model component.
             kwargs: Additional arguments passed to the parent `RBLNModelConfig`.
 
         Raises:

--- a/src/optimum/rbln/transformers/models/gemma4/configuration_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/configuration_gemma4.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, List, Optional, Union
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....utils.logging import get_logger
@@ -37,10 +37,10 @@ class RBLNGemma4ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
 
     def __init__(
         self,
-        use_position_ids: Optional[bool] = None,
-        use_attention_mask: Optional[bool] = None,
-        prefill_chunk_size: Optional[int] = None,
-        image_prefill_chunk_size: Optional[Union[int, List[int]]] = None,
+        use_position_ids: bool | None = None,
+        use_attention_mask: bool | None = None,
+        prefill_chunk_size: int | None = None,
+        image_prefill_chunk_size: int | list[int] | None = None,
         **kwargs: Any,
     ):
         """
@@ -84,7 +84,7 @@ class RBLNGemma4ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
             raise ValueError("use_attention_mask and use_position_ids must be True for RBLNGemma4ForCausalLM")
 
     @staticmethod
-    def _validate_image_prefill_chunk_size(chunk_size: Union[int, List[int]]) -> List[int]:
+    def _validate_image_prefill_chunk_size(chunk_size: int | list[int]) -> list[int]:
         # Single enforcement point: validates that every image_prefill_chunk_size (int or list) is a
         # positive multiple of 128 and returns it in canonical form — de-duplicated and sorted descending.
         if isinstance(chunk_size, int):
@@ -129,11 +129,11 @@ class RBLNGemma4VisionModelConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        max_soft_tokens: Optional[Union[int, List[int]]] = None,
-        pooling_kernel_size: Optional[int] = None,
-        patch_size: Optional[int] = None,
-        output_hidden_states: Optional[bool] = None,
+        batch_size: int | None = None,
+        max_soft_tokens: int | list[int] | None = None,
+        pooling_kernel_size: int | None = None,
+        patch_size: int | None = None,
+        output_hidden_states: bool | None = None,
         **kwargs: Any,
     ):
         """
@@ -189,9 +189,9 @@ class RBLNGemma4ForConditionalGenerationConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        vision_tower: Optional[RBLNModelConfig] = None,
-        language_model: Optional[RBLNModelConfig] = None,
+        batch_size: int | None = None,
+        vision_tower: RBLNModelConfig | None = None,
+        language_model: RBLNModelConfig | None = None,
         **kwargs: Any,
     ):
         """
@@ -224,7 +224,7 @@ class RBLNGemma4ForConditionalGenerationConfig(RBLNModelConfig):
 
         self._update_image_prefill_chunk_size()
 
-    def _get_vision_max_soft_tokens(self) -> List[int]:
+    def _get_vision_max_soft_tokens(self) -> list[int]:
         # Per-image soft-token counts the vision tower emits, sorted in descending order.
         # Reads max_soft_tokens from the vision sub-config (may still be a raw dict at this point)
         # and falls back to DEFAULT_MAX_SOFT_TOKENS when unset, matching the default applied in

--- a/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
+++ b/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import copy
-from typing import Any, Optional, Tuple, Union
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -181,8 +181,8 @@ class Gemma4TextModel(DecoderOnlyModel):
     def _project_per_layer_inputs(
         self,
         inputs_embeds: torch.Tensor,
-        per_layer_inputs: Optional[torch.Tensor],
-    ) -> Optional[torch.Tensor]:
+        per_layer_inputs: torch.Tensor | None,
+    ) -> torch.Tensor | None:
         if not self.hidden_size_per_layer_input:
             return None
 
@@ -205,17 +205,17 @@ class Gemma4TextModel(DecoderOnlyModel):
         self,
         input_ids: torch.Tensor = None,
         inputs_embeds: torch.Tensor = None,
-        per_layer_inputs: Optional[torch.Tensor] = None,
+        per_layer_inputs: torch.Tensor | None = None,
         attention_mask: torch.Tensor = None,
         cache_position: torch.Tensor = None,
         position_ids: torch.Tensor = None,
         query_position: torch.Tensor = None,
-        past_key_values: Tuple[Tuple[torch.Tensor]] = None,
+        past_key_values: tuple[tuple[torch.Tensor]] = None,
         rotary_emb: torch.nn.Module = None,
-        global_block_tables: Optional[torch.Tensor] = None,
-        local_block_tables: Optional[torch.Tensor] = None,
-        lora_int_id: Optional[torch.Tensor] = None,
-        output_hidden_states: Optional[bool] = None,
+        global_block_tables: torch.Tensor | None = None,
+        local_block_tables: torch.Tensor | None = None,
+        lora_int_id: torch.Tensor | None = None,
+        output_hidden_states: bool | None = None,
     ):
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
@@ -281,7 +281,7 @@ class Gemma4DecoderLayer(DecoderOnlyLayer):
     _PRE_FF_LAYERNORM_ATTRS = ["pre_feedforward_layernorm"]
     _POST_FF_LAYERNORM_ATTRS = ["post_feedforward_layernorm"]
 
-    def __init__(self, layer, self_attn: DecoderOnlyAttention, lora_config: Optional[RBLNLoRAConfig] = None):
+    def __init__(self, layer, self_attn: DecoderOnlyAttention, lora_config: RBLNLoRAConfig | None = None):
         super().__init__(layer, self_attn, lora_config)
 
         self.enable_moe_block = getattr(layer, "enable_moe_block", False)
@@ -305,13 +305,13 @@ class Gemma4DecoderLayer(DecoderOnlyLayer):
         self,
         hidden_states: torch.Tensor,
         attention_mask: torch.Tensor,
-        seq_positions: Union[torch.LongTensor, Tuple[torch.LongTensor]],
-        past_key_values: Tuple[Tuple[torch.Tensor]],
-        cos: Optional[torch.Tensor] = None,
-        sin: Optional[torch.Tensor] = None,
-        block_tables: Optional[torch.Tensor] = None,
-        lora_int_id: Optional[torch.Tensor] = None,
-        per_layer_input: Optional[torch.Tensor] = None,
+        seq_positions: torch.LongTensor | tuple[torch.LongTensor],
+        past_key_values: tuple[tuple[torch.Tensor]],
+        cos: torch.Tensor | None = None,
+        sin: torch.Tensor | None = None,
+        block_tables: torch.Tensor | None = None,
+        lora_int_id: torch.Tensor | None = None,
+        per_layer_input: torch.Tensor | None = None,
     ):
         residual = hidden_states
         hidden_states = self.get_pre_attention_layernorm()(hidden_states)
@@ -389,8 +389,8 @@ class Gemma4TextAttention(DecoderOnlyAttention):
         return 1.0
 
     def projection(
-        self, hidden_states, lora_int_id: Optional[torch.Tensor] = None
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        self, hidden_states, lora_int_id: torch.Tensor | None = None
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         if self.lora_config:
             query_states = self.q_proj(hidden_states, lora_int_id)
             key_states = self.k_proj(hidden_states, lora_int_id)
@@ -407,11 +407,11 @@ class Gemma4TextAttention(DecoderOnlyAttention):
         hidden_states: torch.Tensor,
         attention_mask: torch.Tensor,
         seq_positions: torch.LongTensor,
-        past_key_values: Tuple[Tuple[torch.Tensor]],
-        cos: Optional[torch.Tensor] = None,
-        sin: Optional[torch.Tensor] = None,
-        block_tables: Optional[torch.Tensor] = None,
-        lora_int_id: Optional[torch.Tensor] = None,
+        past_key_values: tuple[tuple[torch.Tensor]],
+        cos: torch.Tensor | None = None,
+        sin: torch.Tensor | None = None,
+        block_tables: torch.Tensor | None = None,
+        lora_int_id: torch.Tensor | None = None,
     ):
         batch_size, query_length, _ = hidden_states.size()
 
@@ -472,12 +472,12 @@ class Gemma4ForCausalLM(DecoderOnlyForCausalLM):
         cache_position: torch.Tensor = None,
         position_ids: torch.Tensor = None,
         query_position: torch.Tensor = None,
-        past_key_values: Tuple[Tuple[torch.Tensor]] = None,
+        past_key_values: tuple[tuple[torch.Tensor]] = None,
         rotary_emb: nn.Module = None,
-        global_block_tables: Optional[torch.Tensor] = None,
-        local_block_tables: Optional[torch.Tensor] = None,
-        lora_int_id: Optional[torch.Tensor] = None,
-        output_hidden_states: Optional[bool] = None,
+        global_block_tables: torch.Tensor | None = None,
+        local_block_tables: torch.Tensor | None = None,
+        lora_int_id: torch.Tensor | None = None,
+        output_hidden_states: bool | None = None,
     ):
         # outputs
         hidden_states, all_hidden_states = self.model(
@@ -602,11 +602,11 @@ class Gemma4VisionAttention(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        position_embeddings: Tuple[torch.Tensor, torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.Tensor] = None,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
         **kwargs,
-    ) -> Tuple[torch.Tensor, None]:
+    ) -> tuple[torch.Tensor, None]:
         from transformers.models.gemma4.modeling_gemma4 import apply_multidimensional_rope
 
         input_shape = hidden_states.shape[:-1]

--- a/src/optimum/rbln/transformers/models/gemma4/gemma4_runtime_utils.py
+++ b/src/optimum/rbln/transformers/models/gemma4/gemma4_runtime_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 import rebel
 import torch
@@ -38,10 +38,10 @@ class RBLNGemma4RuntimeModel(RBLNDecoderOnlyChunkedMultimodalPrefillMixin, RBLNR
     def __init__(
         self,
         *args: Any,
-        image_prefills: Optional[Dict[int, rebel.Runtime]] = None,
-        embed_tokens_per_layer: Optional[torch.nn.Module] = None,
-        num_hidden_layers: Optional[int] = None,
-        hidden_size_per_layer_input: Optional[int] = None,
+        image_prefills: dict[int, rebel.Runtime] | None = None,
+        embed_tokens_per_layer: torch.nn.Module | None = None,
+        num_hidden_layers: int | None = None,
+        hidden_size_per_layer_input: int | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
@@ -54,7 +54,7 @@ class RBLNGemma4RuntimeModel(RBLNDecoderOnlyChunkedMultimodalPrefillMixin, RBLNR
         }
         self.prefill = RBLNPytorchRuntime(self.runtime) if self.phase == "prefill" else None
 
-    def compute_per_layer_inputs(self, input_ids: torch.Tensor) -> Optional[torch.Tensor]:
+    def compute_per_layer_inputs(self, input_ids: torch.Tensor) -> torch.Tensor | None:
         if not self.hidden_size_per_layer_input or self.embed_tokens_per_layer is None:
             return None
         clamped_ids = input_ids.clamp(min=0, max=self.embed_tokens_per_layer.num_embeddings - 1)
@@ -88,14 +88,14 @@ class RBLNGemma4RuntimeModel(RBLNDecoderOnlyChunkedMultimodalPrefillMixin, RBLNR
         self,
         runtime,
         input_chunk: torch.Tensor,
-        per_layer_chunk: Optional[torch.Tensor],
+        per_layer_chunk: torch.Tensor | None,
         cache_pos_chunk: torch.Tensor,
         block_tables: torch.Tensor,
-        local_block_tables: Optional[torch.Tensor],
+        local_block_tables: torch.Tensor | None,
         query_position: torch.Tensor,
         chunked_attention_mask: torch.Tensor,
-        position_ids_chunk: Optional[torch.Tensor],
-        lora_int_ids: Optional[torch.Tensor],
+        position_ids_chunk: torch.Tensor | None,
+        lora_int_ids: torch.Tensor | None,
     ):
         # Mirrors Gemma4ForCausalLMWrapper.prepare_forward_args: per_layer_inputs is the second
         # positional argument and an explicit None occupies the position_embed slot.
@@ -114,18 +114,18 @@ class RBLNGemma4RuntimeModel(RBLNDecoderOnlyChunkedMultimodalPrefillMixin, RBLNR
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.Tensor] = None,
-        per_layer_inputs: Optional[torch.Tensor] = None,
+        input_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        per_layer_inputs: torch.Tensor | None = None,
         cache_position: torch.Tensor = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        batch_idx: Optional[int] = None,
-        block_tables: Optional[torch.Tensor] = None,
-        position_embed: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.Tensor] = None,
-        token_type_ids: Optional[torch.Tensor] = None,
-        local_block_tables: Optional[torch.Tensor] = None,
-        lora_int_ids: Optional[torch.Tensor] = None,
+        attention_mask: torch.Tensor | None = None,
+        batch_idx: int | None = None,
+        block_tables: torch.Tensor | None = None,
+        position_embed: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        token_type_ids: torch.Tensor | None = None,
+        local_block_tables: torch.Tensor | None = None,
+        lora_int_ids: torch.Tensor | None = None,
     ):
         inputs = self.inputs_embeddings_if_needed(input_ids, inputs_embeds)
 
@@ -180,12 +180,12 @@ class RBLNGemma4RuntimeModel(RBLNDecoderOnlyChunkedMultimodalPrefillMixin, RBLNR
         cache_position: torch.Tensor = None,
         block_tables: torch.Tensor = None,
         is_external_block_tables: bool = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_embed: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.Tensor] = None,
-        local_block_tables: Optional[torch.Tensor] = None,
-        lora_int_ids: Optional[torch.Tensor] = None,
-        per_layer_inputs: Optional[torch.Tensor] = None,
+        attention_mask: torch.Tensor | None = None,
+        position_embed: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        local_block_tables: torch.Tensor | None = None,
+        lora_int_ids: torch.Tensor | None = None,
+        per_layer_inputs: torch.Tensor | None = None,
     ) -> torch.FloatTensor:
         if self.rbln_config.use_lora and lora_int_ids is None:
             if self.lora_int_ids is None:

--- a/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
@@ -14,8 +14,9 @@
 
 import importlib
 import inspect
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import torch
 from transformers import (
@@ -127,10 +128,10 @@ class RBLNGemma4VisionModel(RBLNModel):
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
-        model: Optional[PreTrainedModel] = None,
-        model_config: Optional[PretrainedConfig] = None,
-        rbln_config: Optional[RBLNGemma4VisionModelConfig] = None,
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
+        model: PreTrainedModel | None = None,
+        model_config: PretrainedConfig | None = None,
+        rbln_config: RBLNGemma4VisionModelConfig | None = None,
     ) -> RBLNGemma4VisionModelConfig:
         if rbln_config.pooling_kernel_size is None:
             rbln_config.pooling_kernel_size = model_config.pooling_kernel_size
@@ -278,10 +279,10 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]] = None,
-        model: Optional[PreTrainedModel] = None,
-        model_config: Optional[PretrainedConfig] = None,
-        rbln_config: Optional[RBLNGemma4ForCausalLMConfig] = None,
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None = None,
+        model: PreTrainedModel | None = None,
+        model_config: PretrainedConfig | None = None,
+        rbln_config: RBLNGemma4ForCausalLMConfig | None = None,
     ) -> RBLNGemma4ForCausalLMConfig:
         if rbln_config.max_seq_len is None:
             rbln_config.max_seq_len = getattr(model_config, "max_position_embeddings", None) or getattr(
@@ -490,7 +491,7 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             **common_kwargs,
         )
 
-        self.decoders: Dict[int, RBLNGemma4RuntimeModel] = {}
+        self.decoders: dict[int, RBLNGemma4RuntimeModel] = {}
         if self.can_generate():
             for i, batch_size in enumerate(self.rbln_config.decoder_batch_sizes):
                 self.decoders[batch_size] = RBLNGemma4RuntimeModel(
@@ -574,7 +575,7 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         cls,
         model: "PreTrainedModel",
         rbln_config: RBLNModelConfig,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
     ):
         if rbln_config.image_prefill_chunk_size is None:
             rbln_config.image_prefill_chunk_size = [rbln_config.prefill_chunk_size]
@@ -687,10 +688,10 @@ class RBLNGemma4ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
-        rbln_config: Optional[RBLNModelConfig] = None,
+        rbln_config: RBLNModelConfig | None = None,
     ) -> RBLNModelConfig:
         vision_cfg = model_config.vision_config
         vt_cfg = rbln_config.vision_tower
@@ -758,9 +759,9 @@ class RBLNGemma4ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
     def _update_model_kwargs_for_generation(
         self,
         outputs: RBLNDecoderOnlyOutput,
-        model_kwargs: Dict[str, Any],
+        model_kwargs: dict[str, Any],
         **kwargs,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         model_kwargs["generate_idx"] = outputs.generate_idx
         model_kwargs["padded_cache_lengths"] = outputs.padded_cache_lengths
         return model_kwargs
@@ -835,12 +836,12 @@ class RBLNGemma4ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
 
     def _preprocess_prefill(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        pixel_values: Optional[torch.FloatTensor] = None,
-        image_position_ids: Optional[torch.LongTensor] = None,
-        pixel_values_videos: Optional[torch.FloatTensor] = None,
-        video_position_ids: Optional[torch.LongTensor] = None,
+        input_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        pixel_values: torch.FloatTensor | None = None,
+        image_position_ids: torch.LongTensor | None = None,
+        pixel_values_videos: torch.FloatTensor | None = None,
+        video_position_ids: torch.LongTensor | None = None,
         **kwargs,
     ):
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -894,19 +895,19 @@ class RBLNGemma4ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
         token_type_ids: torch.Tensor = None,
         pixel_values: torch.FloatTensor = None,
         image_position_ids: torch.LongTensor = None,
-        cache_position: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        generate_idx: Optional[torch.Tensor] = None,
-        padded_cache_lengths: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.Tensor] = None,
-        mm_token_type_ids: Optional[torch.Tensor] = None,
-        output_hidden_states: Optional[bool] = None,
-        pixel_values_videos: Optional[torch.Tensor] = None,
-        video_position_ids: Optional[torch.Tensor] = None,
-        input_features: Optional[torch.Tensor] = None,
-        input_features_mask: Optional[torch.Tensor] = None,
-        **lm_kwargs: Dict[str, Any],
-    ) -> Union[Tuple, RBLNDecoderOnlyOutput]:
+        cache_position: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        generate_idx: torch.Tensor | None = None,
+        padded_cache_lengths: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        mm_token_type_ids: torch.Tensor | None = None,
+        output_hidden_states: bool | None = None,
+        pixel_values_videos: torch.Tensor | None = None,
+        video_position_ids: torch.Tensor | None = None,
+        input_features: torch.Tensor | None = None,
+        input_features_mask: torch.Tensor | None = None,
+        **lm_kwargs: dict[str, Any],
+    ) -> tuple | RBLNDecoderOnlyOutput:
         self._reject_unsupported_modalities(input_features, input_features_mask)
 
         output_hidden_states = (

--- a/src/optimum/rbln/transformers/models/gpt2/gpt2_architecture.py
+++ b/src/optimum/rbln/transformers/models/gpt2/gpt2_architecture.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from typing import TYPE_CHECKING, Tuple, Union
+from typing import TYPE_CHECKING, Union
 
 import torch
 import torch.nn as nn
@@ -49,7 +49,7 @@ class GPT2Attention(DecoderOnlyAttention):
         self.split_size = self_attn.split_size
         self.num_key_value_heads = self_attn.num_heads
 
-    def projection(self, hidden_states, lora_int_id) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def projection(self, hidden_states, lora_int_id) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         if lora_int_id is not None:
             raise NotImplementedError("LoRA is not supported for GPT2Attention")
 

--- a/src/optimum/rbln/transformers/models/gpt_oss/gpt_oss_architecture.py
+++ b/src/optimum/rbln/transformers/models/gpt_oss/gpt_oss_architecture.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 
-from typing import Optional
-
 import torch
 import torch.nn.functional as F
 from torch import nn
@@ -34,7 +32,7 @@ class RBLNGptOssWrapper(DecoderOnlyWrapper):
 
 
 class RBLNGptOssLayer(DecoderOnlyLayer):
-    def __init__(self, layer, self_attn: DecoderOnlyAttention, lora_config: Optional[RBLNLoRAConfig] = None):
+    def __init__(self, layer, self_attn: DecoderOnlyAttention, lora_config: RBLNLoRAConfig | None = None):
         super().__init__(layer, self_attn, lora_config)
         self.mlp = RBLNGptOssMLP(layer.mlp)
 
@@ -53,7 +51,7 @@ class RBLNGptOssTopKRouter(nn.Module):
 
 
 class RBLNGptOssExperts(nn.Module):
-    def __init__(self, model, top_k: Optional[int] = None):
+    def __init__(self, model, top_k: int | None = None):
         super().__init__()
         self.intermediate_size = model.intermediate_size
         self.num_experts = model.num_experts

--- a/src/optimum/rbln/transformers/models/gpt_oss/modeling_gpt_oss.py
+++ b/src/optimum/rbln/transformers/models/gpt_oss/modeling_gpt_oss.py
@@ -100,7 +100,7 @@ class RBLNGptOssForCausalLM(RBLNDecoderOnlyModelForCausalLM):
     _decoder_wrapper_cls = RBLNGptOssWrapper
 
     @staticmethod
-    def _get_dtype(dtype: Union[str, torch.dtype] = None, torch_dtype: Union[str, torch.dtype] = None):
+    def _get_dtype(dtype: str | torch.dtype = None, torch_dtype: str | torch.dtype = None):
         # For BC on torch_dtype argument
         if torch_dtype is not None:
             logger.warning_once("`torch_dtype` is deprecated! Use `dtype` instead!")
@@ -118,10 +118,10 @@ class RBLNGptOssForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         cls,
         model_id: str,
         *args,
-        rbln_config: Optional[RBLNDecoderOnlyModelConfig] = None,
-        dtype: Union[str, torch.dtype] = None,
-        torch_dtype: Union[str, torch.dtype] = None,
-        config: Optional[PretrainedConfig] = None,
+        rbln_config: RBLNDecoderOnlyModelConfig | None = None,
+        dtype: str | torch.dtype = None,
+        torch_dtype: str | torch.dtype = None,
+        config: PretrainedConfig | None = None,
         **kwargs,
     ) -> PreTrainedModel:
         dtype = cls._get_dtype(dtype, torch_dtype)
@@ -154,10 +154,10 @@ class RBLNGptOssForCausalLM(RBLNDecoderOnlyModelForCausalLM):
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]] = None,
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None = None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
-        rbln_config: Optional[RBLNDecoderOnlyModelForCausalLMConfig] = None,
+        rbln_config: RBLNDecoderOnlyModelForCausalLMConfig | None = None,
     ) -> RBLNDecoderOnlyModelForCausalLMConfig:
         rbln_config = super()._update_rbln_config(preprocessors, model, model_config, rbln_config)
 

--- a/src/optimum/rbln/transformers/models/grounding_dino/configuration_grounding_dino.py
+++ b/src/optimum/rbln/transformers/models/grounding_dino/configuration_grounding_dino.py
@@ -26,8 +26,8 @@ class RBLNGroundingDinoTextModelConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for text processing. Defaults to 1.
-            max_text_len (Optional[int]): Maximum text sequence length. Defaults to the
+            batch_size (int | None): The batch size for text processing. Defaults to 1.
+            max_text_len (int | None): Maximum text sequence length. Defaults to the
                 parent GroundingDino config's `max_text_len`.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
         """
@@ -59,13 +59,13 @@ class RBLNGroundingDinoForObjectDetectionConfig(RBLNImageModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for image and text processing. Defaults to 1.
-            encoder (Optional["RBLNModelConfig"]): The encoder configuration. Defaults to None.
-            decoder (Optional["RBLNModelConfig"]): The decoder configuration. Defaults to None.
-            text_backbone (Optional["RBLNModelConfig"]): The text backbone configuration. Defaults to None.
-            backbone (Optional["RBLNModelConfig"]): The backbone configuration. Defaults to None.
-            output_attentions (Optional[bool]): Whether to output attentions. Defaults to None.
-            output_hidden_states (Optional[bool]): Whether to output hidden states. Defaults to None.
+            batch_size (int | None): The batch size for image and text processing. Defaults to 1.
+            encoder ("RBLNModelConfig" | None): The encoder configuration. Defaults to None.
+            decoder ("RBLNModelConfig" | None): The decoder configuration. Defaults to None.
+            text_backbone ("RBLNModelConfig" | None): The text backbone configuration. Defaults to None.
+            backbone ("RBLNModelConfig" | None): The backbone configuration. Defaults to None.
+            output_attentions (bool | None): Whether to output attentions. Defaults to None.
+            output_hidden_states (bool | None): Whether to output hidden states. Defaults to None.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/transformers/models/grounding_dino/configuration_grounding_dino.py
+++ b/src/optimum/rbln/transformers/models/grounding_dino/configuration_grounding_dino.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Optional
 
 import torch
 
@@ -20,8 +20,8 @@ from ...configuration_generic import RBLNImageModelConfig, RBLNModelConfig
 class RBLNGroundingDinoTextModelConfig(RBLNModelConfig):
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        max_text_len: Optional[int] = None,
+        batch_size: int | None = None,
+        max_text_len: int | None = None,
         **kwargs: Any,
     ):
         """
@@ -48,13 +48,13 @@ class RBLNGroundingDinoForObjectDetectionConfig(RBLNImageModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
+        batch_size: int | None = None,
         encoder: Optional["RBLNGroundingDinoEncoderConfig"] = None,
         decoder: Optional["RBLNGroundingDinoDecoderConfig"] = None,
         text_backbone: Optional["RBLNModelConfig"] = None,
         backbone: Optional["RBLNModelConfig"] = None,
-        output_attentions: Optional[bool] = None,
-        output_hidden_states: Optional[bool] = None,
+        output_attentions: bool | None = None,
+        output_hidden_states: bool | None = None,
         **kwargs: Any,
     ):
         """
@@ -89,11 +89,11 @@ class RBLNGroundingDinoForObjectDetectionConfig(RBLNImageModelConfig):
 class RBLNGroundingDinoComponentConfig(RBLNImageModelConfig):
     def __init__(
         self,
-        image_size: Optional[Union[int, Tuple[int, int]]] = None,
-        batch_size: Optional[int] = None,
-        spatial_shapes_list: Optional[List[Tuple[int, int]]] = None,
-        output_attentions: Optional[bool] = False,
-        output_hidden_states: Optional[bool] = False,
+        image_size: int | tuple[int, int] | None = None,
+        batch_size: int | None = None,
+        spatial_shapes_list: list[tuple[int, int]] | None = None,
+        output_attentions: bool | None = False,
+        output_hidden_states: bool | None = False,
         **kwargs: Any,
     ):
         super().__init__(image_size=image_size, batch_size=batch_size, **kwargs)

--- a/src/optimum/rbln/transformers/models/grounding_dino/grounding_dino_architecture.py
+++ b/src/optimum/rbln/transformers/models/grounding_dino/grounding_dino_architecture.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import math
 from functools import wraps
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING
 
 import torch
 import torch.nn.functional as F
@@ -135,10 +135,10 @@ class _GroundingDinoEncoder(torch.nn.Module):
         vision_features: torch.Tensor,
         vision_attention_mask: torch.Tensor,
         vision_position_embedding: torch.Tensor,
-        text_features: Optional[torch.Tensor] = None,
-        text_attention_mask: Optional[torch.Tensor] = None,
-        text_self_attention_masks: Optional[torch.Tensor] = None,
-        reference_points: Optional[torch.Tensor] = None,
+        text_features: torch.Tensor | None = None,
+        text_attention_mask: torch.Tensor | None = None,
+        text_self_attention_masks: torch.Tensor | None = None,
+        reference_points: torch.Tensor | None = None,
     ):
         output_attentions = self.rbln_config.output_attentions
         output_hidden_states = self.rbln_config.output_hidden_states
@@ -328,15 +328,15 @@ class _GroundingDinoEncoderLayer(torch.nn.Module):
         vision_features: Tensor,
         vision_position_embedding: Tensor,
         spatial_shapes: Tensor,
-        spatial_shapes_list: List[Tuple[int, int]],
+        spatial_shapes_list: list[tuple[int, int]],
         level_start_index: Tensor,
         key_padding_mask: Tensor,
         reference_points: Tensor,
-        text_features: Optional[Tensor] = None,
-        text_attention_mask: Optional[Tensor] = None,
-        text_position_embedding: Optional[Tensor] = None,
-        text_self_attention_masks: Optional[Tensor] = None,
-        text_position_ids: Optional[Tensor] = None,
+        text_features: Tensor | None = None,
+        text_attention_mask: Tensor | None = None,
+        text_position_embedding: Tensor | None = None,
+        text_self_attention_masks: Tensor | None = None,
+        text_position_ids: Tensor | None = None,
     ):
         text_position_embedding = self.get_text_position_embeddings(
             text_features, text_position_embedding, text_position_ids
@@ -379,10 +379,10 @@ class _GroundingDinoMultiscaleDeformableAttention(torch.nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
+        attention_mask: torch.Tensor | None = None,
         encoder_hidden_states=None,
         encoder_attention_mask=None,
-        position_embeddings: Optional[torch.Tensor] = None,
+        position_embeddings: torch.Tensor | None = None,
         reference_points=None,
         spatial_shapes=None,
         spatial_shapes_list=None,
@@ -462,9 +462,9 @@ class _GroundingDinoBiMultiHeadAttention(torch.nn.Module):
         self,
         vision_features: torch.FloatTensor,
         text_features: torch.FloatTensor,
-        vision_attention_mask: Optional[torch.BoolTensor] = None,
-        text_attention_mask: Optional[torch.BoolTensor] = None,
-    ) -> Tuple[Tuple[torch.FloatTensor, torch.FloatTensor], Tuple[torch.FloatTensor, torch.FloatTensor]]:
+        vision_attention_mask: torch.BoolTensor | None = None,
+        text_attention_mask: torch.BoolTensor | None = None,
+    ) -> tuple[tuple[torch.FloatTensor, torch.FloatTensor], tuple[torch.FloatTensor, torch.FloatTensor]]:
         batch_size, tgt_len, _ = vision_features.size()
 
         vision_query_states = self.vision_proj(vision_features) * self.scale
@@ -562,7 +562,7 @@ class _MultiScaleDeformableAttention(torch.nn.Module):
         self,
         value: Tensor,
         value_spatial_shapes: Tensor,
-        value_spatial_shapes_list: List[Tuple],
+        value_spatial_shapes_list: list[tuple],
         level_start_index: Tensor,
         sampling_grids: Tensor,
         attention_weights: Tensor,

--- a/src/optimum/rbln/transformers/models/grounding_dino/modeling_grounding_dino.py
+++ b/src/optimum/rbln/transformers/models/grounding_dino/modeling_grounding_dino.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import torch
 from torch import Tensor, nn
@@ -75,7 +75,7 @@ class RBLNGroundingDinoTextModel(RBLNBertModel):
         preprocessors=None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
-        rbln_config: Optional[RBLNGroundingDinoTextModelConfig] = None,
+        rbln_config: RBLNGroundingDinoTextModelConfig | None = None,
     ) -> RBLNGroundingDinoTextModelConfig:
         if rbln_config.max_text_len is None:
             raise ValueError("`max_text_len` should be specified for the GroundingDino text backbone!")
@@ -272,7 +272,7 @@ class RBLNGroundingDinoForObjectDetection(RBLNModel):
         preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"],
         model: Optional["PreTrainedModel"] = None,
         model_config: RBLNGroundingDinoForObjectDetectionConfig = None,
-        rbln_config: Optional[RBLNGroundingDinoForObjectDetectionConfig] = None,
+        rbln_config: RBLNGroundingDinoForObjectDetectionConfig | None = None,
     ) -> RBLNGroundingDinoForObjectDetectionConfig:
         input_info = [
             (
@@ -295,9 +295,9 @@ class RBLNGroundingDinoForObjectDetection(RBLNModel):
         self,
         pixel_values: Tensor,
         input_ids: Tensor,
-        token_type_ids: Optional[Tensor] = None,
-        attention_mask: Optional[Tensor] = None,
-        pixel_mask: Optional[Tensor] = None,
+        token_type_ids: Tensor | None = None,
+        attention_mask: Tensor | None = None,
+        pixel_mask: Tensor | None = None,
         encoder_outputs=None,
         output_attentions=None,
         output_hidden_states=None,
@@ -561,8 +561,8 @@ class RBLNGroundingDinoForObjectDetection(RBLNModel):
     def pad_text_to_rbln_config(
         self,
         input_ids: torch.LongTensor,
-        token_type_ids: Optional[torch.LongTensor] = None,
-        attention_mask: Optional[torch.LongTensor] = None,
+        token_type_ids: torch.LongTensor | None = None,
+        attention_mask: torch.LongTensor | None = None,
     ):
         batch_size, seq_len = input_ids.shape
         max_text_len = self.config.max_text_len
@@ -579,15 +579,15 @@ class RBLNGroundingDinoForObjectDetection(RBLNModel):
         self,
         pixel_values: torch.FloatTensor,
         input_ids: torch.LongTensor,
-        token_type_ids: Optional[torch.LongTensor] = None,
-        attention_mask: Optional[torch.LongTensor] = None,
-        pixel_mask: Optional[torch.BoolTensor] = None,
-        encoder_outputs: Optional[Union[GroundingDinoEncoderOutput, Tuple]] = None,
-        output_attentions: Optional[bool] = None,
-        output_hidden_states: Optional[bool] = None,
-        return_dict: Optional[bool] = None,
+        token_type_ids: torch.LongTensor | None = None,
+        attention_mask: torch.LongTensor | None = None,
+        pixel_mask: torch.BoolTensor | None = None,
+        encoder_outputs: GroundingDinoEncoderOutput | tuple | None = None,
+        output_attentions: bool | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
         **kwargs,
-    ) -> Union[GroundingDinoObjectDetectionOutput, Tuple]:
+    ) -> GroundingDinoObjectDetectionOutput | tuple:
         """
         Forward pass for the RBLN-optimized GroundingDinoForObjectDetection model.
 
@@ -747,7 +747,7 @@ class RBLNGroundingDinoEncoder(RBLNModel):
         cls,
         model: "PreTrainedModel",
         rbln_config: RBLNModelConfig,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
     ):
         for processor in preprocessors:
             if rbln_config.image_size is None and hasattr(processor, "image_processor"):
@@ -773,7 +773,7 @@ class RBLNGroundingDinoEncoder(RBLNModel):
         preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"],
         model: Optional["PreTrainedModel"] = None,
         model_config: RBLNGroundingDinoEncoderConfig = None,
-        rbln_config: Optional[RBLNGroundingDinoEncoderConfig] = None,
+        rbln_config: RBLNGroundingDinoEncoderConfig | None = None,
     ) -> RBLNGroundingDinoEncoderConfig:
         if rbln_config.image_size is None:
             raise ValueError("RBLN config must have image_size set for RBLN optimized GroundingDinoDecoder.")
@@ -870,17 +870,17 @@ class RBLNGroundingDinoEncoder(RBLNModel):
         vision_attention_mask: Tensor,
         vision_position_embedding: Tensor,
         spatial_shapes: Tensor,
-        spatial_shapes_list: List[Tuple[int, int]],
+        spatial_shapes_list: list[tuple[int, int]],
         level_start_index: Tensor,
-        valid_ratios: Optional[Tensor] = None,
-        text_features: Optional[Tensor] = None,
-        text_attention_mask: Optional[Tensor] = None,
-        text_position_embedding: Optional[Tensor] = None,
-        text_self_attention_masks: Optional[Tensor] = None,
-        text_position_ids: Optional[Tensor] = None,
-        output_attentions: Optional[bool] = None,
-        output_hidden_states: Optional[bool] = None,
-        return_dict: Optional[bool] = None,
+        valid_ratios: Tensor | None = None,
+        text_features: Tensor | None = None,
+        text_attention_mask: Tensor | None = None,
+        text_position_embedding: Tensor | None = None,
+        text_self_attention_masks: Tensor | None = None,
+        text_position_ids: Tensor | None = None,
+        output_attentions: bool | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
     ):
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
@@ -944,7 +944,7 @@ class RBLNGroundingDinoDecoder(RBLNModel):
         cls,
         model: "PreTrainedModel",
         rbln_config: RBLNModelConfig,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
     ):
         for processor in preprocessors:
             if rbln_config.image_size is None and hasattr(processor, "image_processor"):
@@ -971,7 +971,7 @@ class RBLNGroundingDinoDecoder(RBLNModel):
         preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"],
         model: Optional["PreTrainedModel"] = None,
         model_config: RBLNGroundingDinoDecoderConfig = None,
-        rbln_config: Optional[RBLNGroundingDinoEncoderConfig] = None,
+        rbln_config: RBLNGroundingDinoEncoderConfig | None = None,
     ) -> RBLNGroundingDinoEncoderConfig:
         if rbln_config.image_size is None:
             raise ValueError("RBLN config must have image_size set for RBLN optimized GroundingDinoDecoder.")

--- a/src/optimum/rbln/transformers/models/idefics3/configuration_idefics3.py
+++ b/src/optimum/rbln/transformers/models/idefics3/configuration_idefics3.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....utils.logging import get_logger
@@ -31,7 +31,7 @@ class RBLNIdefics3VisionTransformerConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
+        batch_size: int | None = None,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)
@@ -55,9 +55,9 @@ class RBLNIdefics3ForConditionalGenerationConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        vision_model: Optional[RBLNModelConfig] = None,
-        text_model: Optional[RBLNModelConfig] = None,
+        batch_size: int | None = None,
+        vision_model: RBLNModelConfig | None = None,
+        text_model: RBLNModelConfig | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/transformers/models/idefics3/configuration_idefics3.py
+++ b/src/optimum/rbln/transformers/models/idefics3/configuration_idefics3.py
@@ -48,7 +48,7 @@ class RBLNIdefics3ForConditionalGenerationConfig(RBLNModelConfig):
     It allows configuration of the batch size and separate configurations for the vision and text submodules.
 
     Attributes:
-        submodules (List[str]): List of submodules included in the model. Defaults to `["vision_model", "text_model"]`.
+        submodules (list[str]): List of submodules included in the model. Defaults to `["vision_model", "text_model"]`.
     """
 
     submodules = ["vision_model", "text_model"]
@@ -62,11 +62,11 @@ class RBLNIdefics3ForConditionalGenerationConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            vision_model (Optional[RBLNModelConfig]): Configuration for the vision transformer component.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            vision_model (RBLNModelConfig | None): Configuration for the vision transformer component.
                 This can include settings specific to the vision encoder, such as input resolution or other vision-related parameters.
                 If not provided, default settings will be used.
-            text_model (Optional[RBLNModelConfig]): Configuration for the text model component.
+            text_model (RBLNModelConfig | None): Configuration for the text model component.
                 This can include settings specific to the language model, such as tensor parallelism or other text-related parameters.
                 If not provided, default settings will be used.
             kwargs: Additional arguments passed to the parent `RBLNModelConfig`.

--- a/src/optimum/rbln/transformers/models/idefics3/modeling_idefics3.py
+++ b/src/optimum/rbln/transformers/models/idefics3/modeling_idefics3.py
@@ -14,8 +14,9 @@
 
 import importlib
 import inspect
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import rebel
 import torch
@@ -58,8 +59,8 @@ class RBLNRuntimeVisionModel(RBLNPytorchRuntime):
     def forward(
         self,
         pixel_values,
-        patch_attention_mask: Optional[torch.BoolTensor] = None,
-        return_dict: Optional[bool] = None,
+        patch_attention_mask: torch.BoolTensor | None = None,
+        return_dict: bool | None = None,
         **kwargs,
     ):
         batch_size = pixel_values.size(0)
@@ -117,7 +118,7 @@ class RBLNIdefics3VisionTransformer(RBLNModel):
                 self.encoder = model.encoder
                 self.post_layernorm = model.post_layernorm
 
-            def forward(self, hidden_states, patch_attention_mask: Optional[torch.BoolTensor] = None):
+            def forward(self, hidden_states, patch_attention_mask: torch.BoolTensor | None = None):
                 encoder_outputs = self.encoder(
                     inputs_embeds=hidden_states,
                     attention_mask=patch_attention_mask,
@@ -131,10 +132,10 @@ class RBLNIdefics3VisionTransformer(RBLNModel):
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
-        rbln_config: Optional[RBLNModelConfig] = None,
+        rbln_config: RBLNModelConfig | None = None,
     ) -> RBLNModelConfig:
         input_info = [
             (
@@ -155,10 +156,10 @@ class RBLNIdefics3VisionTransformer(RBLNModel):
     def forward(
         self,
         pixel_values,
-        patch_attention_mask: Optional[torch.BoolTensor] = None,
-        return_dict: Optional[bool] = None,
+        patch_attention_mask: torch.BoolTensor | None = None,
+        return_dict: bool | None = None,
         **kwargs,
-    ) -> Union[Tuple, BaseModelOutput]:
+    ) -> tuple | BaseModelOutput:
         last_hidden_state_size = [
             pixel_values.shape[0],
             (self.config.image_size // self.config.patch_size) ** 2,
@@ -275,10 +276,10 @@ class RBLNIdefics3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationM
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
-        rbln_config: Optional[RBLNModelConfig] = None,
+        rbln_config: RBLNModelConfig | None = None,
     ) -> RBLNModelConfig:
         input_info = [
             (
@@ -357,8 +358,8 @@ class RBLNIdefics3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationM
     def inputs_merger(
         self,
         input_ids: torch.LongTensor,
-        inputs_embeds: Optional[torch.Tensor],
-        image_hidden_states: Optional[torch.Tensor],
+        inputs_embeds: torch.Tensor | None,
+        image_hidden_states: torch.Tensor | None,
     ):
         num_images, _, vision_hidden_size = image_hidden_states.shape
         special_image_token_mask = input_ids == self.config.image_token_id
@@ -371,7 +372,7 @@ class RBLNIdefics3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationM
     def get_image_features(
         self,
         pixel_values: torch.FloatTensor,
-        pixel_attention_mask: Optional[torch.BoolTensor] = None,
+        pixel_attention_mask: torch.BoolTensor | None = None,
         **kwargs,
     ) -> torch.Tensor:
         batch_size, num_images, num_channels, height, width = pixel_values.shape
@@ -414,10 +415,10 @@ class RBLNIdefics3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationM
     def _preprocess_prefill(
         self,
         input_ids: torch.LongTensor = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        pixel_values: Optional[torch.FloatTensor] = None,
-        pixel_attention_mask: Optional[torch.BoolTensor] = None,
-        image_hidden_states: Optional[torch.FloatTensor] = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        pixel_values: torch.FloatTensor | None = None,
+        pixel_attention_mask: torch.BoolTensor | None = None,
+        image_hidden_states: torch.FloatTensor | None = None,
         **kwargs,
     ):
         if input_ids is not None:
@@ -454,16 +455,16 @@ class RBLNIdefics3ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationM
     def forward(
         self,
         input_ids: torch.LongTensor = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        pixel_values: Optional[torch.FloatTensor] = None,
-        pixel_attention_mask: Optional[torch.BoolTensor] = None,
-        image_hidden_states: Optional[torch.FloatTensor] = None,
+        attention_mask: torch.Tensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        pixel_values: torch.FloatTensor | None = None,
+        pixel_attention_mask: torch.BoolTensor | None = None,
+        image_hidden_states: torch.FloatTensor | None = None,
         cache_position: torch.Tensor = None,
-        generate_idx: Optional[torch.Tensor] = None,
-        return_dict: Optional[bool] = None,
+        generate_idx: torch.Tensor | None = None,
+        return_dict: bool | None = None,
         **kwargs,
-    ) -> Union[Tuple, Idefics3CausalLMOutputWithPast]:
+    ) -> tuple | Idefics3CausalLMOutputWithPast:
         # Prefill
         if cache_position is None:
             inputs_embeds = self._preprocess_prefill(

--- a/src/optimum/rbln/transformers/models/llava/configuration_llava.py
+++ b/src/optimum/rbln/transformers/models/llava/configuration_llava.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....utils.logging import get_logger
@@ -34,9 +34,9 @@ class RBLNLlavaForConditionalGenerationConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        vision_tower: Optional[RBLNModelConfig] = None,
-        language_model: Optional[RBLNModelConfig] = None,
+        batch_size: int | None = None,
+        vision_tower: RBLNModelConfig | None = None,
+        language_model: RBLNModelConfig | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/transformers/models/llava/configuration_llava.py
+++ b/src/optimum/rbln/transformers/models/llava/configuration_llava.py
@@ -41,11 +41,11 @@ class RBLNLlavaForConditionalGenerationConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            vision_tower (Optional[RBLNModelConfig]): Configuration for the vision encoder component.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            vision_tower (RBLNModelConfig | None): Configuration for the vision encoder component.
                 This can include settings specific to the vision encoder, such as input resolution or other vision-related parameters.
                 If not provided, default settings will be used.
-            language_model (Optional[RBLNModelConfig]): Configuration for the language model component.
+            language_model (RBLNModelConfig | None): Configuration for the language model component.
                 This can include settings specific to the language model, such as tensor parallelism or other text-related parameters.
                 If not provided, default settings will be used.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.

--- a/src/optimum/rbln/transformers/models/llava/modeling_llava.py
+++ b/src/optimum/rbln/transformers/models/llava/modeling_llava.py
@@ -14,7 +14,8 @@
 
 import importlib
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import torch
 from transformers import AutoModelForImageTextToText, LlavaForConditionalGeneration, PretrainedConfig, PreTrainedModel
@@ -220,10 +221,10 @@ class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
-        rbln_config: Optional[RBLNModelConfig] = None,
+        rbln_config: RBLNModelConfig | None = None,
     ) -> RBLNModelConfig:
         # support for pixtral that needs padding
         if hasattr(rbln_config.vision_tower, "max_image_size"):
@@ -311,7 +312,7 @@ class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
     def get_image_features(
         self,
         pixel_values: torch.FloatTensor,
-        vision_feature_layer: Union[int, List[int]],
+        vision_feature_layer: int | list[int],
         vision_feature_select_strategy: str,
         **kwargs,
     ):
@@ -396,13 +397,13 @@ class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
 
     def _preprocess_prefill(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        pixel_values: Optional[torch.FloatTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        vision_feature_layer: Optional[Union[int, List[int]]] = None,
-        vision_feature_select_strategy: Optional[str] = None,
-        return_dict: Optional[bool] = None,
-        image_sizes: Optional[torch.Tensor] = None,
+        input_ids: torch.LongTensor | None = None,
+        pixel_values: torch.FloatTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        vision_feature_layer: int | list[int] | None = None,
+        vision_feature_select_strategy: str | None = None,
+        return_dict: bool | None = None,
+        image_sizes: torch.Tensor | None = None,
         **lm_kwargs,
     ):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
@@ -442,16 +443,16 @@ class RBLNLlavaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixi
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        pixel_values: Optional[torch.FloatTensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        return_dict: Optional[bool] = None,
-        cache_position: Optional[torch.LongTensor] = None,
-        image_sizes: Optional[torch.Tensor] = None,
-        generate_idx: Optional[torch.Tensor] = None,
+        input_ids: torch.LongTensor | None = None,
+        pixel_values: torch.FloatTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        return_dict: bool | None = None,
+        cache_position: torch.LongTensor | None = None,
+        image_sizes: torch.Tensor | None = None,
+        generate_idx: torch.Tensor | None = None,
         **kwargs,
-    ) -> Union[Tuple, LlavaCausalLMOutputWithPast]:
+    ) -> tuple | LlavaCausalLMOutputWithPast:
         # Prefill
         if cache_position is None:
             inputs_embeds = self._preprocess_prefill(

--- a/src/optimum/rbln/transformers/models/llava_next/configuration_llava_next.py
+++ b/src/optimum/rbln/transformers/models/llava_next/configuration_llava_next.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....utils.logging import get_logger
@@ -34,9 +34,9 @@ class RBLNLlavaNextForConditionalGenerationConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        vision_tower: Optional[RBLNModelConfig] = None,
-        language_model: Optional[RBLNModelConfig] = None,
+        batch_size: int | None = None,
+        vision_tower: RBLNModelConfig | None = None,
+        language_model: RBLNModelConfig | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/transformers/models/llava_next/configuration_llava_next.py
+++ b/src/optimum/rbln/transformers/models/llava_next/configuration_llava_next.py
@@ -41,9 +41,9 @@ class RBLNLlavaNextForConditionalGenerationConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            vision_tower (Optional[RBLNModelConfig]): Configuration for the vision encoder component.
-            language_model (Optional[RBLNModelConfig]): Configuration for the language model component.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            vision_tower (RBLNModelConfig | None): Configuration for the vision encoder component.
+            language_model (RBLNModelConfig | None): Configuration for the language model component.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/transformers/models/llava_next/modeling_llava_next.py
+++ b/src/optimum/rbln/transformers/models/llava_next/modeling_llava_next.py
@@ -14,8 +14,9 @@
 
 import importlib
 import inspect
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import numpy as np
 import torch
@@ -201,10 +202,10 @@ class RBLNLlavaNextForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
-        rbln_config: Optional[RBLNModelConfig] = None,
+        rbln_config: RBLNModelConfig | None = None,
     ) -> RBLNModelConfig:
         feature_size = model_config.vision_config.hidden_size
 
@@ -284,7 +285,7 @@ class RBLNLlavaNextForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
         self,
         pixel_values: torch.FloatTensor,
         image_sizes: torch.Tensor,
-        vision_feature_layer: Union[int, List[int]],
+        vision_feature_layer: int | list[int],
         vision_feature_select_strategy: str,
     ):
         # ! infer image_num_patches from image_sizes
@@ -399,10 +400,10 @@ class RBLNLlavaNextForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
         self,
         input_ids: torch.LongTensor = None,
         pixel_values: torch.FloatTensor = None,
-        image_sizes: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        vision_feature_layer: Optional[int] = None,
-        vision_feature_select_strategy: Optional[str] = None,
+        image_sizes: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        vision_feature_layer: int | None = None,
+        vision_feature_select_strategy: str | None = None,
         **kwargs,
     ):
         vision_feature_layer = (
@@ -454,13 +455,13 @@ class RBLNLlavaNextForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
         input_ids: torch.LongTensor = None,
         attention_mask: torch.LongTensor = None,
         pixel_values: torch.FloatTensor = None,
-        image_sizes: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
+        image_sizes: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
         cache_position: torch.Tensor = None,
-        generate_idx: Optional[torch.Tensor] = None,
-        return_dict: Optional[bool] = None,
+        generate_idx: torch.Tensor | None = None,
+        return_dict: bool | None = None,
         **kwargs,
-    ) -> Union[Tuple, RBLNDecoderOnlyOutput]:
+    ) -> tuple | RBLNDecoderOnlyOutput:
         # Prefill
         if cache_position is None:
             inputs_embeds = self._preprocess_prefill(

--- a/src/optimum/rbln/transformers/models/midm/midm_architecture.py
+++ b/src/optimum/rbln/transformers/models/midm/midm_architecture.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING
 
 import torch
 import torch.nn as nn
@@ -130,7 +130,7 @@ class MidmAttention(DecoderOnlyAttention):
         self.split_size = self_attn.split_size
         self.num_key_value_heads = self_attn.num_heads
 
-    def projection(self, hidden_states, lora_int_id) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def projection(self, hidden_states, lora_int_id) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         if lora_int_id is not None:
             raise NotImplementedError("LoRA is not supported for MidmAttention")
 

--- a/src/optimum/rbln/transformers/models/midm/modeling_midm.py
+++ b/src/optimum/rbln/transformers/models/midm/modeling_midm.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import inspect
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any
 
 from transformers import AutoModelForCausalLM
 from transformers.generation.utils import GenerationMixin
@@ -95,11 +96,11 @@ class RBLNMidmLMHeadModel(RBLNDecoderOnlyModelForCausalLM):
     @classmethod
     def from_pretrained(
         cls,
-        model_id: Union[str, Path],
+        model_id: str | Path,
         *,
-        export: Optional[bool] = None,
-        rbln_config: Optional[Union[Dict, RBLNModelConfig]] = None,
-        trust_remote_code: Optional[bool] = None,
+        export: bool | None = None,
+        rbln_config: dict | RBLNModelConfig | None = None,
+        trust_remote_code: bool | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/transformers/models/midm/modeling_midm.py
+++ b/src/optimum/rbln/transformers/models/midm/modeling_midm.py
@@ -108,11 +108,11 @@ class RBLNMidmLMHeadModel(RBLNDecoderOnlyModelForCausalLM):
         User can use this function to load a pre-trained model from the HuggingFace library and convert it to a RBLN model to be run on RBLN NPUs.
 
         Args:
-            model_id (Union[str, Path]): The model id of the pre-trained model to be loaded.
+            model_id (str | Path): The model id of the pre-trained model to be loaded.
                 It can be downloaded from the HuggingFace model hub or a local path, or a model id of a compiled model using the RBLN Compiler.
-            export (Optional[bool]): A boolean flag to indicate whether the model should be compiled.
+            export (bool | None): A boolean flag to indicate whether the model should be compiled.
                 If None, it will be determined based on the existence of the compiled model files in the model_id.
-            rbln_config (Optional[Union[Dict, RBLNModelConfig]]): Configuration for RBLN model compilation and runtime.
+            rbln_config (dict | RBLNModelConfig | None): Configuration for RBLN model compilation and runtime.
                 This can be provided as a dictionary or an instance of the model's configuration class (e.g., `RBLNMidmLMHeadModelConfig` for Mi:dm models).
                 For detailed configuration options, see the specific model's configuration class documentation.
             trust_remote_code (bool): Whether or not to trust the remote code when loading a model from the Hub.

--- a/src/optimum/rbln/transformers/models/mixtral/mixtral_architecture.py
+++ b/src/optimum/rbln/transformers/models/mixtral/mixtral_architecture.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
 
 import torch
 from torch import nn
@@ -30,7 +29,7 @@ class MixtralWrapper(DecoderOnlyWrapper):
 class MixtralLayer(DecoderOnlyLayer):
     _MLP_ATTR = None
 
-    def __init__(self, layer, self_attn: DecoderOnlyAttention, lora_config: Optional[RBLNLoRAConfig] = None):
+    def __init__(self, layer, self_attn: DecoderOnlyAttention, lora_config: RBLNLoRAConfig | None = None):
         super().__init__(layer, self_attn, lora_config)
         self.mlp = MixtralSparseMoeBlock(layer.mlp)
 

--- a/src/optimum/rbln/transformers/models/opt/modeling_opt.py
+++ b/src/optimum/rbln/transformers/models/opt/modeling_opt.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 
 class MLP(nn.Module):
     def __init__(self, fc1, fc2, activation_fn):
-        super(MLP, self).__init__()
+        super().__init__()
         self.fc1 = fc1
         self.fc2 = fc2
         self.activation_fn = activation_fn

--- a/src/optimum/rbln/transformers/models/paligemma/configuration_paligemma.py
+++ b/src/optimum/rbln/transformers/models/paligemma/configuration_paligemma.py
@@ -42,14 +42,14 @@ class RBLNPaliGemmaForConditionalGenerationConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            vision_tower (Optional[RBLNModelConfig]): Configuration for the vision encoder component.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            vision_tower (RBLNModelConfig | None): Configuration for the vision encoder component.
                 This can include settings specific to the vision encoder, such as input resolution or other vision-related parameters.
                 If not provided, default settings will be used.
-            language_model (Optional[RBLNModelConfig]): Configuration for the language model component.
+            language_model (RBLNModelConfig | None): Configuration for the language model component.
                 This can include settings specific to the language model, such as tensor parallelism or other text-related parameters.
                 If not provided, default settings will be used.
-            output_hidden_states (Optional[bool]): Whether to output the hidden states of the decoder. Defaults to False.
+            output_hidden_states (bool | None): Whether to output the hidden states of the decoder. Defaults to False.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
         Raises:
             ValueError: If `batch_size` is not a positive integer.
@@ -92,14 +92,14 @@ class RBLNPaliGemmaModelConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            vision_tower (Optional[RBLNModelConfig]): Configuration for the vision encoder component.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            vision_tower (RBLNModelConfig | None): Configuration for the vision encoder component.
                 This can include settings specific to the vision encoder, such as input resolution or other vision-related parameters.
                 If not provided, default settings will be used.
-            language_model (Optional[RBLNModelConfig]): Configuration for the language model component.
+            language_model (RBLNModelConfig | None): Configuration for the language model component.
                 This can include settings specific to the language model, such as tensor parallelism or other text-related parameters.
                 If not provided, default settings will be used.
-            output_hidden_states (Optional[bool]): Whether to output the hidden states of the decoder. Defaults to False.
+            output_hidden_states (bool | None): Whether to output the hidden states of the decoder. Defaults to False.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
         Raises:
             ValueError: If `batch_size` is not a positive integer.

--- a/src/optimum/rbln/transformers/models/paligemma/configuration_paligemma.py
+++ b/src/optimum/rbln/transformers/models/paligemma/configuration_paligemma.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....utils.logging import get_logger
@@ -34,10 +34,10 @@ class RBLNPaliGemmaForConditionalGenerationConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        vision_tower: Optional[RBLNModelConfig] = None,
-        language_model: Optional[RBLNModelConfig] = None,
-        output_hidden_states: Optional[bool] = None,
+        batch_size: int | None = None,
+        vision_tower: RBLNModelConfig | None = None,
+        language_model: RBLNModelConfig | None = None,
+        output_hidden_states: bool | None = None,
         **kwargs: Any,
     ):
         """
@@ -84,10 +84,10 @@ class RBLNPaliGemmaModelConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        vision_tower: Optional[RBLNModelConfig] = None,
-        language_model: Optional[RBLNModelConfig] = None,
-        output_hidden_states: Optional[bool] = None,
+        batch_size: int | None = None,
+        vision_tower: RBLNModelConfig | None = None,
+        language_model: RBLNModelConfig | None = None,
+        output_hidden_states: bool | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
@@ -14,8 +14,9 @@
 
 import importlib
 import inspect
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import torch
 from transformers import (
@@ -115,11 +116,11 @@ class RBLNPaliGemmaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
     def _update_submodule_rbln_config(
         cls,
         submodule_name: str,
-        submodule_cls: Type["RBLNModel"],
+        submodule_cls: type["RBLNModel"],
         model: "PreTrainedModel",
         submodule_config: PretrainedConfig,
         submodule_rbln_config: RBLNModelConfig,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
     ):
         if submodule_name == "language_model":
             submodule_config.use_sliding_window = False
@@ -284,9 +285,9 @@ class RBLNPaliGemmaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
 
     def _preprocess_prefill(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        pixel_values: Optional[torch.FloatTensor] = None,
+        input_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        pixel_values: torch.FloatTensor | None = None,
         **kwargs,
     ):
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -319,12 +320,12 @@ class RBLNPaliGemmaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
         attention_mask: torch.LongTensor = None,
         position_ids: torch.LongTensor = None,
         token_type_ids: torch.LongTensor = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
+        inputs_embeds: torch.FloatTensor | None = None,
         cache_position: torch.Tensor = None,
-        generate_idx: Optional[torch.Tensor] = None,
-        return_dict: Optional[bool] = None,
+        generate_idx: torch.Tensor | None = None,
+        return_dict: bool | None = None,
         **kwargs,
-    ) -> Union[Tuple, RBLNDecoderOnlyOutput]:
+    ) -> tuple | RBLNDecoderOnlyOutput:
         # Prefill
         if cache_position is None:
             inputs_embeds = self._preprocess_prefill(
@@ -433,11 +434,11 @@ class RBLNPaliGemmaModel(RBLNModel):
     def _update_submodule_rbln_config(
         cls,
         submodule_name: str,
-        submodule_cls: Type["RBLNModel"],
+        submodule_cls: type["RBLNModel"],
         model: "PreTrainedModel",
         submodule_config: PretrainedConfig,
         submodule_rbln_config: RBLNModelConfig,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
     ):
         if submodule_name == "language_model":
             submodule_config.use_sliding_window = False
@@ -507,9 +508,9 @@ class RBLNPaliGemmaModel(RBLNModel):
 
     def _preprocess_prefill(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        pixel_values: Optional[torch.FloatTensor] = None,
+        input_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        pixel_values: torch.FloatTensor | None = None,
         **kwargs,
     ):
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -538,16 +539,16 @@ class RBLNPaliGemmaModel(RBLNModel):
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        pixel_values: Optional[torch.FloatTensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.LongTensor] = None,
-        token_type_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        output_hidden_states: Optional[bool] = None,
-        return_dict: Optional[bool] = None,
+        input_ids: torch.LongTensor | None = None,
+        pixel_values: torch.FloatTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        token_type_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
         **kwargs,
-    ) -> Union[Tuple, PaligemmaModelOutputWithPast]:
+    ) -> tuple | PaligemmaModelOutputWithPast:
         """
         Forward pass for the RBLN-optimized PaliGemmaModel model.
 

--- a/src/optimum/rbln/transformers/models/pegasus/modeling_pegasus.py
+++ b/src/optimum/rbln/transformers/models/pegasus/modeling_pegasus.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import inspect
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from transformers import PegasusForConditionalGeneration, PreTrainedModel
 

--- a/src/optimum/rbln/transformers/models/pegasus/pegasus_architecture.py
+++ b/src/optimum/rbln/transformers/models/pegasus/pegasus_architecture.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple
 
 import torch
 from torch import nn
@@ -143,7 +142,7 @@ class PegasusSelfAttention(Seq2SeqSelfAttention):
         else:
             self.attn_decode = torch.ops.rbln_custom_ops.paged_causal_attn_decode
 
-    def projection(self, hidden_states) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def projection(self, hidden_states) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         query_states = self.q_proj(hidden_states) * self.scaling
         key_states = self.k_proj(hidden_states)
         value_states = self.v_proj(hidden_states)

--- a/src/optimum/rbln/transformers/models/phi/phi_architecture.py
+++ b/src/optimum/rbln/transformers/models/phi/phi_architecture.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Union
 
 import torch
 from transformers import PhiForCausalLM
@@ -54,7 +54,7 @@ class PhiAttention(DecoderOnlyAttention):
         self.q_layernorm = getattr(self_attn, "q_layernorm", None)
         self.k_layernorm = getattr(self_attn, "k_layernorm", None)
 
-    def projection(self, hidden_states, lora_int_id) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def projection(self, hidden_states, lora_int_id) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         if lora_int_id is not None:
             raise NotImplementedError("LoRA is not supported for PhiAttention")
 
@@ -80,11 +80,11 @@ class PhiLayer(DecoderOnlyLayer):
         hidden_states: torch.Tensor,
         attention_mask: torch.Tensor,
         seq_positions: torch.LongTensor,
-        past_key_values: Tuple[Tuple[torch.Tensor]],
-        cos: Optional[torch.Tensor] = None,
-        sin: Optional[torch.Tensor] = None,
-        block_tables: Optional[torch.Tensor] = None,
-        lora_int_id: Optional[torch.Tensor] = None,
+        past_key_values: tuple[tuple[torch.Tensor]],
+        cos: torch.Tensor | None = None,
+        sin: torch.Tensor | None = None,
+        block_tables: torch.Tensor | None = None,
+        lora_int_id: torch.Tensor | None = None,
     ):
         residual = hidden_states
 

--- a/src/optimum/rbln/transformers/models/pixtral/configuration_pixtral.py
+++ b/src/optimum/rbln/transformers/models/pixtral/configuration_pixtral.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Tuple
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 
@@ -20,9 +20,9 @@ from ....configuration_utils import RBLNModelConfig
 class RBLNPixtralVisionModelConfig(RBLNModelConfig):
     def __init__(
         self,
-        max_image_size: Tuple = None,
-        batch_size: Optional[int] = None,
-        output_hidden_states: Optional[bool] = None,
+        max_image_size: tuple = None,
+        batch_size: int | None = None,
+        output_hidden_states: bool | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/transformers/models/pixtral/configuration_pixtral.py
+++ b/src/optimum/rbln/transformers/models/pixtral/configuration_pixtral.py
@@ -28,7 +28,7 @@ class RBLNPixtralVisionModelConfig(RBLNModelConfig):
         """
         Args:
             max_image_size (Tuple): The size of max input images. A tuple (max_height, max_width)
-            batch_size (Optional[int]): The batch size for image processing. Defaults to 1.
+            batch_size (int | None): The batch size for image processing. Defaults to 1.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/transformers/models/pixtral/modeling_pixtral.py
+++ b/src/optimum/rbln/transformers/models/pixtral/modeling_pixtral.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import rebel
 import torch
@@ -58,8 +58,8 @@ class RBLNRuntimePixtralVisionModel(RBLNPytorchRuntime):
         self,
         pixel_values: torch.Tensor,
         image_sizes: torch.Tensor,
-        output_hidden_states: Optional[bool] = None,
-        return_dict: Optional[bool] = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
         **kwargs,
     ):
         if pixel_values.shape[2] > self.max_image_size[0] or pixel_values.shape[3] > self.max_image_size[1]:
@@ -247,7 +247,7 @@ class RBLNPixtralVisionModel(RBLNModel):
         preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"],
         model: Optional["PreTrainedModel"] = None,
         model_config: "PixtralVisionConfig" = None,
-        rbln_config: Optional[RBLNPixtralVisionModelConfig] = None,
+        rbln_config: RBLNPixtralVisionModelConfig | None = None,
     ) -> RBLNPixtralVisionModelConfig:
         if rbln_config.max_image_size is None:
             rbln_config.max_image_size = (model_config.image_size, model_config.image_size)
@@ -291,12 +291,12 @@ class RBLNPixtralVisionModel(RBLNModel):
 
     def forward(
         self,
-        pixel_values: Optional[torch.FloatTensor] = None,
-        image_sizes: Optional[torch.FloatTensor] = None,
-        output_hidden_states: Optional[bool] = None,
+        pixel_values: torch.FloatTensor | None = None,
+        image_sizes: torch.FloatTensor | None = None,
+        output_hidden_states: bool | None = None,
         return_dict: bool = True,
         **kwargs,
-    ) -> Union[Tuple, BaseModelOutput]:
+    ) -> tuple | BaseModelOutput:
         """
         Forward pass for the RBLN-optimized Pixtral vision model.
 

--- a/src/optimum/rbln/transformers/models/pixtral/pixtral_architecture.py
+++ b/src/optimum/rbln/transformers/models/pixtral/pixtral_architecture.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -41,9 +40,9 @@ class PixtralAttention(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
-        output_attentions: Optional[bool] = False,
+        attention_mask: torch.Tensor | None = None,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+        output_attentions: bool | None = False,
         **kwargs,
     ):
         batch_size, patches, _ = hidden_states.size()

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/configuration_qwen2_5_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/configuration_qwen2_5_vl.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, List, Optional, Union
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....utils.deprecation import deprecate_kwarg
@@ -33,7 +33,7 @@ class RBLNQwen2_5_VLForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausal
     def __init__(
         self,
         use_inputs_embeds: bool = True,
-        visual: Optional[RBLNModelConfig] = None,
+        visual: RBLNModelConfig | None = None,
         **kwargs: Any,
     ):
         """
@@ -64,7 +64,7 @@ class RBLNQwen2_5_VLModelConfig(RBLNDecoderOnlyModelConfig):
 
     submodules = ["visual"]
 
-    def __init__(self, visual: Optional[RBLNModelConfig] = None, **kwargs: Any):
+    def __init__(self, visual: RBLNModelConfig | None = None, **kwargs: Any):
         super().__init__(**kwargs)
         self.visual = self.initialize_submodule_config(submodule_config=visual)
 
@@ -79,7 +79,7 @@ class RBLNQwen2_5_VisionTransformerPretrainedModelConfig(RBLNModelConfig):
     """
 
     @deprecate_kwarg(old_name="max_seq_lens", new_name="max_seq_len", version="0.11.0")
-    def __init__(self, max_seq_len: Union[int, List[int]] = None, **kwargs: Any):
+    def __init__(self, max_seq_len: int | list[int] = None, **kwargs: Any):
         """
         Args:
             max_seq_len (Optional[Union[int, List[int]]]): Maximum sequence lengths for Vision

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/configuration_qwen2_5_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/configuration_qwen2_5_vl.py
@@ -39,7 +39,7 @@ class RBLNQwen2_5_VLForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausal
         """
         Args:
             use_inputs_embeds (bool): Whether or not to use `inputs_embeds` as input. Defaults to `True`.
-            visual (Optional[RBLNModelConfig]): Configuration for the vision encoder component.
+            visual (RBLNModelConfig | None): Configuration for the vision encoder component.
             kwargs: Additional arguments passed to the parent `RBLNDecoderOnlyModelForCausalLMConfig`.
 
         Raises:
@@ -82,7 +82,7 @@ class RBLNQwen2_5_VisionTransformerPretrainedModelConfig(RBLNModelConfig):
     def __init__(self, max_seq_len: int | list[int] = None, **kwargs: Any):
         """
         Args:
-            max_seq_len (Optional[Union[int, List[int]]]): Maximum sequence lengths for Vision
+            max_seq_len (int | list[int] | None): Maximum sequence lengths for Vision
                 Transformer attention. Can be an integer or list of integers, each indicating
                 the number of patches in a sequence for an image or video. For example, an image
                 of 224x196 pixels with patch size 14 and window size 112 has its width padded to

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import inspect
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import torch
 from transformers import (
@@ -116,7 +117,7 @@ class RBLNQwen2_5_VisionTransformerPretrainedModel(RBLNModel):
         preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"],
         model: Optional["PreTrainedModel"] = None,
         model_config: "PretrainedConfig" = None,
-        rbln_config: Optional[RBLNQwen2_5_VisionTransformerPretrainedModelConfig] = None,
+        rbln_config: RBLNQwen2_5_VisionTransformerPretrainedModelConfig | None = None,
     ) -> RBLNQwen2_5_VisionTransformerPretrainedModelConfig:
         window_size = model_config.window_size
         patch_size = model_config.patch_size
@@ -160,9 +161,9 @@ class RBLNQwen2_5_VisionTransformerPretrainedModel(RBLNModel):
 
     @staticmethod
     def _pad_for_window_attn_layers(
-        window_indice: List[int],
+        window_indice: list[int],
         hidden_states: torch.Tensor,
-        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
         window_seq_len: int,
         max_seq_len: int,
     ):
@@ -435,7 +436,7 @@ class RBLNQwen2_5_VLModel(RBLNDecoderOnlyModel):
         image_grid_thw: torch.LongTensor = None,
         video_grid_thw: torch.LongTensor = None,
         second_per_grid_ts: torch.Tensor = None,
-        mm_token_type_ids: Optional[torch.IntTensor] = None,
+        mm_token_type_ids: torch.IntTensor | None = None,
     ):
         batch_size = input_ids.shape[0]
         inputs_embeds = self.embed_tokens(input_ids).to(self.rbln_config.dtype)
@@ -521,18 +522,18 @@ class RBLNQwen2_5_VLModel(RBLNDecoderOnlyModel):
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        pixel_values: Optional[torch.Tensor] = None,
-        pixel_values_videos: Optional[torch.FloatTensor] = None,
-        image_grid_thw: Optional[torch.LongTensor] = None,
-        video_grid_thw: Optional[torch.LongTensor] = None,
-        cache_position: Optional[torch.LongTensor] = None,
-        second_per_grid_ts: Optional[torch.Tensor] = None,
-        output_hidden_states: Optional[bool] = None,
-        return_dict: Optional[bool] = None,
-        mm_token_type_ids: Optional[torch.IntTensor] = None,
+        input_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        pixel_values_videos: torch.FloatTensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        video_grid_thw: torch.LongTensor | None = None,
+        cache_position: torch.LongTensor | None = None,
+        second_per_grid_ts: torch.Tensor | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
+        mm_token_type_ids: torch.IntTensor | None = None,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
         inputs_embeds, position_embed, rope_deltas = self._preprocess_prefill(
@@ -654,9 +655,9 @@ class RBLNQwen2_5_VLForConditionalGeneration(RBLNQwen2_5_VLModel, RBLNDecoderOnl
     def prepare_inputs_for_generation(
         self,
         input_ids: torch.LongTensor,
-        generate_idx: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.Tensor] = None,
+        generate_idx: torch.Tensor | None = None,
+        attention_mask: torch.LongTensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
         pixel_values=None,
         pixel_values_videos=None,
         image_grid_thw=None,
@@ -724,19 +725,19 @@ class RBLNQwen2_5_VLForConditionalGeneration(RBLNQwen2_5_VLModel, RBLNDecoderOnl
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        pixel_values: Optional[torch.Tensor] = None,
-        pixel_values_videos: Optional[torch.FloatTensor] = None,
-        image_grid_thw: Optional[torch.LongTensor] = None,
-        video_grid_thw: Optional[torch.LongTensor] = None,
-        cache_position: Optional[torch.LongTensor] = None,
-        second_per_grid_ts: Optional[torch.Tensor] = None,
-        generate_idx: Optional[torch.Tensor] = None,
-        return_dict: Optional[bool] = None,
-        output_hidden_states: Optional[bool] = None,
-        mm_token_type_ids: Optional[torch.IntTensor] = None,
+        input_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        pixel_values_videos: torch.FloatTensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        video_grid_thw: torch.LongTensor | None = None,
+        cache_position: torch.LongTensor | None = None,
+        second_per_grid_ts: torch.Tensor | None = None,
+        generate_idx: torch.Tensor | None = None,
+        return_dict: bool | None = None,
+        output_hidden_states: bool | None = None,
+        mm_token_type_ids: torch.IntTensor | None = None,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/qwen2_5_vl_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/qwen2_5_vl_architecture.py
@@ -1,5 +1,4 @@
 import math
-from typing import Tuple
 
 import torch
 import torch.nn as nn
@@ -74,7 +73,7 @@ class Qwen2_5_VLVisionBlock(torch.nn.Module):
         self,
         hidden_states: torch.Tensor,
         attn_masks: torch.Tensor,
-        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
     ) -> torch.Tensor:
         hidden_states = hidden_states + self.attn(
             self.norm1(hidden_states),
@@ -100,7 +99,7 @@ class Qwen2_5_VLVisionFullAttention(nn.Module):
         self,
         hidden_states: torch.Tensor,
         attn_masks: torch.Tensor,
-        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
         hidden_states = hidden_states.unsqueeze(0)
@@ -140,7 +139,7 @@ class Qwen2_5_VLVisionWindowAttention(nn.Module):
         self,
         hidden_states: torch.Tensor,
         attn_masks: torch.Tensor,
-        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
         num_windows = seq_length // self.window_seq_len

--- a/src/optimum/rbln/transformers/models/qwen2_moe/qwen2_moe_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen2_moe/qwen2_moe_architecture.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
 
 import torch
 from torch import nn
@@ -28,7 +27,7 @@ class Qwen2MoeWrapper(DecoderOnlyWrapper):
 
 
 class Qwen2MoeLayer(DecoderOnlyLayer):
-    def __init__(self, layer, self_attn: DecoderOnlyAttention, lora_config: Optional[RBLNLoRAConfig] = None):
+    def __init__(self, layer, self_attn: DecoderOnlyAttention, lora_config: RBLNLoRAConfig | None = None):
         super().__init__(layer, self_attn, lora_config)
         self.mlp = (
             Qwen2MoeSparseMoeBlock(layer.mlp)

--- a/src/optimum/rbln/transformers/models/qwen2_vl/configuration_qwen2_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_vl/configuration_qwen2_vl.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....utils.deprecation import deprecate_kwarg
@@ -25,8 +25,8 @@ class RBLNQwen2VLForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausalLMC
     def __init__(
         self,
         use_inputs_embeds: bool = True,
-        visual: Optional[RBLNModelConfig] = None,
-        **kwargs: Dict[str, Any],
+        visual: RBLNModelConfig | None = None,
+        **kwargs: dict[str, Any],
     ):
         """
         Args:
@@ -56,14 +56,14 @@ class RBLNQwen2VLModelConfig(RBLNDecoderOnlyModelConfig):
 
     submodules = ["visual"]
 
-    def __init__(self, visual: Optional[RBLNModelConfig] = None, **kwargs: Dict[str, Any]):
+    def __init__(self, visual: RBLNModelConfig | None = None, **kwargs: dict[str, Any]):
         super().__init__(**kwargs)
         self.visual = self.initialize_submodule_config(submodule_config=visual)
 
 
 class RBLNQwen2VisionTransformerPretrainedModelConfig(RBLNModelConfig):
     @deprecate_kwarg(old_name="max_seq_lens", new_name="max_seq_len", version="0.11.0")
-    def __init__(self, max_seq_len: Union[int, List[int]] = None, **kwargs: Dict[str, Any]):
+    def __init__(self, max_seq_len: int | list[int] = None, **kwargs: dict[str, Any]):
         """
         Args:
             max_seq_len (Optional[Union[int, List[int]]]): Maximum sequence lengths for Vision

--- a/src/optimum/rbln/transformers/models/qwen2_vl/configuration_qwen2_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_vl/configuration_qwen2_vl.py
@@ -31,7 +31,7 @@ class RBLNQwen2VLForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausalLMC
         """
         Args:
             use_inputs_embeds (bool): Whether or not to use `inputs_embeds` as input. Defaults to `True`.
-            visual (Optional[RBLNModelConfig]): Configuration for the vision encoder component.
+            visual (RBLNModelConfig | None): Configuration for the vision encoder component.
             kwargs: Additional arguments passed to the parent `RBLNDecoderOnlyModelForCausalLMConfig`.
 
         Raises:
@@ -66,7 +66,7 @@ class RBLNQwen2VisionTransformerPretrainedModelConfig(RBLNModelConfig):
     def __init__(self, max_seq_len: int | list[int] = None, **kwargs: dict[str, Any]):
         """
         Args:
-            max_seq_len (Optional[Union[int, List[int]]]): Maximum sequence lengths for Vision
+            max_seq_len (int | list[int] | None): Maximum sequence lengths for Vision
                 Transformer attention. Can be an integer or list of integers, each indicating
                 the number of patches in a sequence for an image or video. For example, an image
                 of 224x224 pixels with patch size 14 results in (224/14) * (224/14) = 256 patches,

--- a/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import inspect
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import torch
 from transformers import (
@@ -117,7 +118,7 @@ class RBLNQwen2VisionTransformerPretrainedModel(RBLNModel):
         preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"],
         model: Optional["PreTrainedModel"] = None,
         model_config: "PretrainedConfig" = None,
-        rbln_config: Optional[RBLNQwen2VisionTransformerPretrainedModelConfig] = None,
+        rbln_config: RBLNQwen2VisionTransformerPretrainedModelConfig | None = None,
     ) -> RBLNQwen2VisionTransformerPretrainedModelConfig:
         hidden_size = model_config.embed_dim
         num_heads = model_config.num_heads
@@ -327,7 +328,7 @@ class RBLNQwen2VLModel(RBLNDecoderOnlyModel):
         pixel_values_videos: torch.FloatTensor = None,
         image_grid_thw: torch.LongTensor = None,
         video_grid_thw: torch.LongTensor = None,
-        mm_token_type_ids: Optional[torch.IntTensor] = None,
+        mm_token_type_ids: torch.IntTensor | None = None,
     ):
         batch_size = input_ids.shape[0]
         inputs_embeds = self.embed_tokens(input_ids).to(self.rbln_config.dtype)
@@ -410,17 +411,17 @@ class RBLNQwen2VLModel(RBLNDecoderOnlyModel):
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        pixel_values: Optional[torch.Tensor] = None,
-        pixel_values_videos: Optional[torch.FloatTensor] = None,
-        image_grid_thw: Optional[torch.LongTensor] = None,
-        video_grid_thw: Optional[torch.LongTensor] = None,
-        cache_position: Optional[torch.LongTensor] = None,
-        output_hidden_states: Optional[bool] = None,
-        return_dict: Optional[bool] = None,
-        mm_token_type_ids: Optional[torch.IntTensor] = None,
+        input_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        pixel_values_videos: torch.FloatTensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        video_grid_thw: torch.LongTensor | None = None,
+        cache_position: torch.LongTensor | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
+        mm_token_type_ids: torch.IntTensor | None = None,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
         inputs_embeds, position_embed, rope_deltas = self._preprocess_prefill(
@@ -542,9 +543,9 @@ class RBLNQwen2VLForConditionalGeneration(RBLNQwen2VLModel, RBLNDecoderOnlyModel
     def prepare_inputs_for_generation(
         self,
         input_ids: torch.LongTensor,
-        generate_idx: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.Tensor] = None,
+        generate_idx: torch.Tensor | None = None,
+        attention_mask: torch.LongTensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
         pixel_values=None,
         pixel_values_videos=None,
         image_grid_thw=None,
@@ -610,18 +611,18 @@ class RBLNQwen2VLForConditionalGeneration(RBLNQwen2VLModel, RBLNDecoderOnlyModel
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        pixel_values: Optional[torch.Tensor] = None,
-        pixel_values_videos: Optional[torch.FloatTensor] = None,
-        image_grid_thw: Optional[torch.LongTensor] = None,
-        video_grid_thw: Optional[torch.LongTensor] = None,
-        cache_position: Optional[torch.LongTensor] = None,
-        generate_idx: Optional[torch.Tensor] = None,
-        return_dict: Optional[bool] = None,
-        output_hidden_states: Optional[bool] = None,
-        mm_token_type_ids: Optional[torch.IntTensor] = None,
+        input_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        pixel_values_videos: torch.FloatTensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        video_grid_thw: torch.LongTensor | None = None,
+        cache_position: torch.LongTensor | None = None,
+        generate_idx: torch.Tensor | None = None,
+        return_dict: bool | None = None,
+        output_hidden_states: bool | None = None,
+        mm_token_type_ids: torch.IntTensor | None = None,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)

--- a/src/optimum/rbln/transformers/models/qwen2_vl/qwen2_vl_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen2_vl/qwen2_vl_architecture.py
@@ -1,5 +1,4 @@
 import math
-from typing import Tuple
 
 import torch
 import torch.nn as nn
@@ -58,7 +57,7 @@ class Qwen2VLVisionBlock(torch.nn.Module):
         self,
         hidden_states: torch.Tensor,
         attn_masks: torch.Tensor,
-        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
     ) -> torch.Tensor:
         hidden_states = hidden_states + self.attn(
             self.norm1(hidden_states),
@@ -84,7 +83,7 @@ class VisionAttention(nn.Module):
         self,
         hidden_states: torch.Tensor,
         attn_masks: torch.Tensor,
-        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
         hidden_states = hidden_states.unsqueeze(0)

--- a/src/optimum/rbln/transformers/models/qwen3_moe/qwen3_moe_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen3_moe/qwen3_moe_architecture.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
 
 import torch
 from torch import nn
@@ -41,7 +40,7 @@ class Qwen3MoeAttention(DecoderOnlyAttention):
 
 
 class Qwen3MoeLayer(DecoderOnlyLayer):
-    def __init__(self, layer, self_attn: DecoderOnlyAttention, lora_config: Optional[RBLNLoRAConfig] = None):
+    def __init__(self, layer, self_attn: DecoderOnlyAttention, lora_config: RBLNLoRAConfig | None = None):
         super().__init__(layer, self_attn, lora_config)
         self.mlp = (
             Qwen3MoeSparseMoeBlock(layer.mlp)

--- a/src/optimum/rbln/transformers/models/qwen3_vl/configuration_qwen3_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/configuration_qwen3_vl.py
@@ -41,7 +41,7 @@ class RBLNQwen3VLForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausalLMC
         """
         Args:
             use_inputs_embeds (bool): Whether or not to use `inputs_embeds` as input. Defaults to `True`.
-            visual (Optional[RBLNModelConfig]): Configuration for the vision encoder component.
+            visual (RBLNModelConfig | None): Configuration for the vision encoder component.
             _load_visual_runtime (bool): Whether to create runtime for the visual encoder submodule.
                 Set to ``False`` on decoder-only nodes in a disaggregated encoder setup to skip
                 loading the visual encoder's compiled model (.rbln) and torch artifacts entirely.
@@ -93,7 +93,7 @@ class RBLNQwen3VLVisionModelConfig(RBLNModelConfig):
     def __init__(self, max_seq_len: int | list[int] = None, **kwargs: Any):
         """
         Args:
-            max_seq_len (Optional[Union[int, List[int]]]): Maximum sequence lengths for Vision
+            max_seq_len (int | list[int] | None): Maximum sequence lengths for Vision
                 Transformer attention. Can be an integer or list of integers, each indicating
                 the number of patches in a sequence for an image or video. For example, an image
                 of 224x224 pixels with patch size 16 and spatial_merge_size 2 yields

--- a/src/optimum/rbln/transformers/models/qwen3_vl/configuration_qwen3_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/configuration_qwen3_vl.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, List, Optional, Union
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....utils.deprecation import deprecate_kwarg
@@ -34,7 +34,7 @@ class RBLNQwen3VLForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausalLMC
     def __init__(
         self,
         use_inputs_embeds: bool = True,
-        visual: Optional[RBLNModelConfig] = None,
+        visual: RBLNModelConfig | None = None,
         _load_visual_runtime: bool = True,
         **kwargs: Any,
     ):
@@ -68,7 +68,7 @@ class RBLNQwen3VLModelConfig(RBLNDecoderOnlyModelConfig):
     submodules = ["visual"]
     subclass_non_save_attributes = ["_load_visual_runtime"]
 
-    def __init__(self, visual: Optional[RBLNModelConfig] = None, _load_visual_runtime: bool = True, **kwargs: Any):
+    def __init__(self, visual: RBLNModelConfig | None = None, _load_visual_runtime: bool = True, **kwargs: Any):
         super().__init__(**kwargs)
         if not getattr(self, "use_inputs_embeds", True):
             raise ValueError(
@@ -90,7 +90,7 @@ class RBLNQwen3VLVisionModelConfig(RBLNModelConfig):
     """
 
     @deprecate_kwarg(old_name="max_seq_lens", new_name="max_seq_len", version="0.11.0")
-    def __init__(self, max_seq_len: Union[int, List[int]] = None, **kwargs: Any):
+    def __init__(self, max_seq_len: int | list[int] = None, **kwargs: Any):
         """
         Args:
             max_seq_len (Optional[Union[int, List[int]]]): Maximum sequence lengths for Vision

--- a/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import inspect
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import torch
 from transformers import (
@@ -119,7 +120,7 @@ class RBLNQwen3VLVisionModel(RBLNModel):
         preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"],
         model: Optional["PreTrainedModel"] = None,
         model_config: "PretrainedConfig" = None,
-        rbln_config: Optional[RBLNQwen3VLVisionModelConfig] = None,
+        rbln_config: RBLNQwen3VLVisionModelConfig | None = None,
     ) -> RBLNQwen3VLVisionModelConfig:
         hidden_size = model_config.hidden_size
         num_heads = model_config.num_heads
@@ -242,9 +243,9 @@ class RBLNQwen3VLVisionModel(RBLNModel):
     @staticmethod
     def _pad_hidden_states(
         hidden_states: torch.Tensor,
-        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
         max_seq_len: int,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int]:
         seq_len = hidden_states.shape[0]
         valid_len = seq_len
 
@@ -266,7 +267,7 @@ class RBLNQwen3VLVisionModel(RBLNModel):
 
         return hidden_states, position_embeddings, attn_mask, valid_len
 
-    def forward(self, hidden_states: torch.Tensor, grid_thw: torch.Tensor) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+    def forward(self, hidden_states: torch.Tensor, grid_thw: torch.Tensor) -> tuple[torch.Tensor, list[torch.Tensor]]:
         hidden_states = self.patch_embed(hidden_states).to(self.rbln_config.dtype)
         pos_embeds = self.fast_pos_embed_interpolate(grid_thw)
         hidden_states = hidden_states + pos_embeds.to(hidden_states.dtype)
@@ -490,11 +491,11 @@ class RBLNQwen3VLModel(RBLNDecoderOnlyModel):
         pixel_values_videos: torch.FloatTensor = None,
         image_grid_thw: torch.LongTensor = None,
         video_grid_thw: torch.LongTensor = None,
-        image_embeds: Optional[torch.Tensor] = None,
-        video_embeds: Optional[torch.Tensor] = None,
-        deepstack_image_embeds: Optional[List[torch.Tensor]] = None,
-        deepstack_video_embeds: Optional[List[torch.Tensor]] = None,
-        mm_token_type_ids: Optional[torch.IntTensor] = None,
+        image_embeds: torch.Tensor | None = None,
+        video_embeds: torch.Tensor | None = None,
+        deepstack_image_embeds: list[torch.Tensor] | None = None,
+        deepstack_video_embeds: list[torch.Tensor] | None = None,
+        mm_token_type_ids: torch.IntTensor | None = None,
     ):
         batch_size = input_ids.shape[0]
         inputs_embeds = self.embed_tokens(input_ids).to(self.rbln_config.dtype)
@@ -611,10 +612,10 @@ class RBLNQwen3VLModel(RBLNDecoderOnlyModel):
 
     def _prepare_deepstack(
         self,
-        image_mask: Optional[torch.Tensor],
-        video_mask: Optional[torch.Tensor],
-        deepstack_image_embeds: Optional[List[torch.Tensor]],
-        deepstack_video_embeds: Optional[List[torch.Tensor]],
+        image_mask: torch.Tensor | None,
+        video_mask: torch.Tensor | None,
+        deepstack_image_embeds: list[torch.Tensor] | None,
+        deepstack_video_embeds: list[torch.Tensor] | None,
     ):
         if image_mask is None and video_mask is None:
             return None, None
@@ -684,21 +685,21 @@ class RBLNQwen3VLModel(RBLNDecoderOnlyModel):
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        pixel_values: Optional[torch.Tensor] = None,
-        pixel_values_videos: Optional[torch.FloatTensor] = None,
-        image_grid_thw: Optional[torch.LongTensor] = None,
-        video_grid_thw: Optional[torch.LongTensor] = None,
-        image_embeds: Optional[torch.Tensor] = None,
-        video_embeds: Optional[torch.Tensor] = None,
-        deepstack_image_embeds: Optional[List[torch.Tensor]] = None,
-        deepstack_video_embeds: Optional[List[torch.Tensor]] = None,
-        cache_position: Optional[torch.LongTensor] = None,
-        output_hidden_states: Optional[bool] = None,
-        return_dict: Optional[bool] = None,
-        mm_token_type_ids: Optional[torch.IntTensor] = None,
+        input_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        pixel_values_videos: torch.FloatTensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        video_grid_thw: torch.LongTensor | None = None,
+        image_embeds: torch.Tensor | None = None,
+        video_embeds: torch.Tensor | None = None,
+        deepstack_image_embeds: list[torch.Tensor] | None = None,
+        deepstack_video_embeds: list[torch.Tensor] | None = None,
+        cache_position: torch.LongTensor | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
+        mm_token_type_ids: torch.IntTensor | None = None,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
         inputs_embeds, position_embed, rope_deltas, visual_pos_mask, deepstack_visual_embeds = (
@@ -829,10 +830,10 @@ class RBLNQwen3VLForConditionalGeneration(RBLNQwen3VLModel, RBLNDecoderOnlyModel
 
     def encode(
         self,
-        pixel_values: Optional[torch.Tensor] = None,
-        pixel_values_videos: Optional[torch.FloatTensor] = None,
-        image_grid_thw: Optional[torch.LongTensor] = None,
-        video_grid_thw: Optional[torch.LongTensor] = None,
+        pixel_values: torch.Tensor | None = None,
+        pixel_values_videos: torch.FloatTensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        video_grid_thw: torch.LongTensor | None = None,
     ) -> dict:
         if self.visual is None:
             raise RuntimeError(
@@ -854,9 +855,9 @@ class RBLNQwen3VLForConditionalGeneration(RBLNQwen3VLModel, RBLNDecoderOnlyModel
     def prepare_inputs_for_generation(
         self,
         input_ids: torch.LongTensor,
-        generate_idx: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.Tensor] = None,
+        generate_idx: torch.Tensor | None = None,
+        attention_mask: torch.LongTensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
         pixel_values=None,
         pixel_values_videos=None,
         image_grid_thw=None,
@@ -939,22 +940,22 @@ class RBLNQwen3VLForConditionalGeneration(RBLNQwen3VLModel, RBLNDecoderOnlyModel
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        pixel_values: Optional[torch.Tensor] = None,
-        pixel_values_videos: Optional[torch.FloatTensor] = None,
-        image_grid_thw: Optional[torch.LongTensor] = None,
-        video_grid_thw: Optional[torch.LongTensor] = None,
-        image_embeds: Optional[torch.Tensor] = None,
-        video_embeds: Optional[torch.Tensor] = None,
-        deepstack_image_embeds: Optional[List[torch.Tensor]] = None,
-        deepstack_video_embeds: Optional[List[torch.Tensor]] = None,
-        cache_position: Optional[torch.LongTensor] = None,
-        generate_idx: Optional[torch.Tensor] = None,
-        return_dict: Optional[bool] = None,
-        output_hidden_states: Optional[bool] = None,
-        mm_token_type_ids: Optional[torch.IntTensor] = None,
+        input_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        pixel_values_videos: torch.FloatTensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        video_grid_thw: torch.LongTensor | None = None,
+        image_embeds: torch.Tensor | None = None,
+        video_embeds: torch.Tensor | None = None,
+        deepstack_image_embeds: list[torch.Tensor] | None = None,
+        deepstack_video_embeds: list[torch.Tensor] | None = None,
+        cache_position: torch.LongTensor | None = None,
+        generate_idx: torch.Tensor | None = None,
+        return_dict: bool | None = None,
+        output_hidden_states: bool | None = None,
+        mm_token_type_ids: torch.IntTensor | None = None,
         **kwargs,
     ) -> RBLNDecoderOnlyOutput:
         output_hidden_states = _validate_output_hidden_states(output_hidden_states, self.rbln_config)

--- a/src/optimum/rbln/transformers/models/qwen3_vl/qwen3_vl_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/qwen3_vl_architecture.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 
 import torch
 import torch.nn as nn
@@ -92,7 +92,7 @@ class Qwen3VLVisionBlock(torch.nn.Module):
         self,
         hidden_states: torch.Tensor,
         attn_mask: torch.Tensor,
-        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
     ) -> torch.Tensor:
         hidden_states = hidden_states + self.attn(
             self.norm1(hidden_states),
@@ -118,7 +118,7 @@ class Qwen3VLVisionAttention(nn.Module):
         self,
         hidden_states: torch.Tensor,
         attn_mask: torch.Tensor,
-        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
     ) -> torch.Tensor:
         seq_length = hidden_states.shape[0]
         hidden_states = hidden_states.unsqueeze(0)
@@ -308,14 +308,14 @@ class Qwen3VLDecoderOnlyForCausalLM(DecoderOnlyForCausalLM):
         cache_position: torch.Tensor = None,
         position_ids: torch.Tensor = None,
         query_position: torch.Tensor = None,
-        past_key_values: Tuple[Tuple[torch.Tensor]] = None,
+        past_key_values: tuple[tuple[torch.Tensor]] = None,
         rotary_emb: nn.Module = None,
-        global_block_tables: Optional[torch.Tensor] = None,
-        local_block_tables: Optional[torch.Tensor] = None,
-        lora_int_id: Optional[torch.Tensor] = None,
-        output_hidden_states: Optional[bool] = None,
-        visual_pos_mask: Optional[torch.Tensor] = None,
-        deepstack_visual_embeds: Optional[torch.Tensor] = None,
+        global_block_tables: torch.Tensor | None = None,
+        local_block_tables: torch.Tensor | None = None,
+        lora_int_id: torch.Tensor | None = None,
+        output_hidden_states: bool | None = None,
+        visual_pos_mask: torch.Tensor | None = None,
+        deepstack_visual_embeds: torch.Tensor | None = None,
     ):
         hidden_states, all_hidden_states = self.model(
             input_ids=input_ids,
@@ -365,19 +365,19 @@ class Qwen3VLDecoderOnlyModel(DecoderOnlyModel):
     def forward(
         self,
         input_ids: torch.Tensor = None,
-        inputs_embeds: Optional[torch.Tensor] = None,
+        inputs_embeds: torch.Tensor | None = None,
         attention_mask: torch.Tensor = None,
         cache_position: torch.Tensor = None,
         position_ids: torch.Tensor = None,
         query_position: torch.Tensor = None,
-        past_key_values: Tuple[Tuple[torch.Tensor]] = None,
-        rotary_emb: Optional[Union[nn.Module, torch.Tensor]] = None,
-        global_block_tables: Optional[torch.Tensor] = None,
-        local_block_tables: Optional[torch.Tensor] = None,
-        lora_int_id: Optional[torch.Tensor] = None,
-        output_hidden_states: Optional[bool] = None,
-        visual_pos_mask: Optional[torch.Tensor] = None,
-        deepstack_visual_embeds: Optional[torch.Tensor] = None,
+        past_key_values: tuple[tuple[torch.Tensor]] = None,
+        rotary_emb: nn.Module | torch.Tensor | None = None,
+        global_block_tables: torch.Tensor | None = None,
+        local_block_tables: torch.Tensor | None = None,
+        lora_int_id: torch.Tensor | None = None,
+        output_hidden_states: bool | None = None,
+        visual_pos_mask: torch.Tensor | None = None,
+        deepstack_visual_embeds: torch.Tensor | None = None,
     ):
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError(

--- a/src/optimum/rbln/transformers/models/qwen3_vl/qwen3_vl_runtime_utils.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/qwen3_vl_runtime_utils.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional
 
 import torch
 import torch.nn.functional as F
@@ -29,13 +28,13 @@ class RBLNQwen3VLRuntimeModel(RBLNRuntimeModel):
     def _prepare_prefill_inputs(
         self,
         inputs: torch.Tensor,
-        cache_position: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.Tensor] = None,
-        position_embed: Optional[torch.Tensor] = None,
-        token_type_ids: Optional[torch.Tensor] = None,
-        visual_pos_mask: Optional[torch.Tensor] = None,
-        deepstack_embeds: Optional[List[torch.Tensor]] = None,
+        cache_position: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        position_embed: torch.Tensor | None = None,
+        token_type_ids: torch.Tensor | None = None,
+        visual_pos_mask: torch.Tensor | None = None,
+        deepstack_embeds: list[torch.Tensor] | None = None,
     ):
         (
             inputs,
@@ -76,19 +75,19 @@ class RBLNQwen3VLRuntimeModel(RBLNRuntimeModel):
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        inputs_embeds: Optional[torch.Tensor] = None,
+        input_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
         cache_position: torch.Tensor = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        batch_idx: Optional[int] = None,
-        block_tables: Optional[torch.Tensor] = None,
-        position_embed: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.Tensor] = None,
-        token_type_ids: Optional[torch.Tensor] = None,
-        local_block_tables: Optional[torch.Tensor] = None,
-        lora_int_ids: Optional[torch.Tensor] = None,
-        visual_pos_mask: Optional[torch.Tensor] = None,
-        deepstack_embeds: Optional[List[torch.Tensor]] = None,
+        attention_mask: torch.Tensor | None = None,
+        batch_idx: int | None = None,
+        block_tables: torch.Tensor | None = None,
+        position_embed: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        token_type_ids: torch.Tensor | None = None,
+        local_block_tables: torch.Tensor | None = None,
+        lora_int_ids: torch.Tensor | None = None,
+        visual_pos_mask: torch.Tensor | None = None,
+        deepstack_embeds: list[torch.Tensor] | None = None,
     ):
         inputs = self.inputs_embeddings_if_needed(input_ids, inputs_embeds)
         block_tables, local_block_tables, is_external_block_tables = (
@@ -133,18 +132,18 @@ class RBLNQwen3VLRuntimeModel(RBLNRuntimeModel):
     def prefill_forward(
         self,
         inputs: torch.Tensor,
-        cache_position: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        batch_idx: Optional[int] = None,
-        block_tables: Optional[torch.Tensor] = None,
-        is_external_block_tables: Optional[bool] = None,
-        position_ids: Optional[torch.Tensor] = None,
-        position_embed: Optional[torch.Tensor] = None,
-        token_type_ids: Optional[torch.Tensor] = None,
-        local_block_tables: Optional[torch.Tensor] = None,
-        lora_int_ids: Optional[torch.Tensor] = None,
-        visual_pos_mask: Optional[torch.Tensor] = None,
-        deepstack_embeds: Optional[List[torch.Tensor]] = None,
+        cache_position: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        batch_idx: int | None = None,
+        block_tables: torch.Tensor | None = None,
+        is_external_block_tables: bool | None = None,
+        position_ids: torch.Tensor | None = None,
+        position_embed: torch.Tensor | None = None,
+        token_type_ids: torch.Tensor | None = None,
+        local_block_tables: torch.Tensor | None = None,
+        lora_int_ids: torch.Tensor | None = None,
+        visual_pos_mask: torch.Tensor | None = None,
+        deepstack_embeds: list[torch.Tensor] | None = None,
     ) -> torch.FloatTensor:
         if self.rbln_config.use_lora and lora_int_ids is None:
             if self.lora_int_ids is None:

--- a/src/optimum/rbln/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import inspect
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 import torch
 from transformers import AutoModelForImageTextToText, PreTrainedModel, Qwen3VLMoeConfig

--- a/src/optimum/rbln/transformers/models/qwen3_vl_moe/qwen3_vl_moe_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl_moe/qwen3_vl_moe_architecture.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -43,7 +42,7 @@ class Qwen3VLMoeAttention(Qwen3VLAttention):
 
 
 class Qwen3VLMoeLayer(DecoderOnlyLayer):
-    def __init__(self, layer, self_attn: DecoderOnlyAttention, lora_config: Optional[RBLNLoRAConfig] = None):
+    def __init__(self, layer, self_attn: DecoderOnlyAttention, lora_config: RBLNLoRAConfig | None = None):
         super().__init__(layer, self_attn, lora_config)
         self.mlp = (
             Qwen3VLMoeSparseMoeBlock(layer.mlp)

--- a/src/optimum/rbln/transformers/models/resnet/configuration_resnet.py
+++ b/src/optimum/rbln/transformers/models/resnet/configuration_resnet.py
@@ -35,9 +35,9 @@ class RBLNResNetForImageClassificationConfig(RBLNModelForImageClassificationConf
     ):
         """
         Args:
-            image_size (Optional[Union[int, Tuple[int, int]]]): The size of input images.
+            image_size (int | tuple[int, int] | None): The size of input images.
                 Can be an integer for square images or a tuple (height, width).
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
             output_hidden_states (bool, optional): Whether or not to return the hidden states of all layers.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 

--- a/src/optimum/rbln/transformers/models/resnet/configuration_resnet.py
+++ b/src/optimum/rbln/transformers/models/resnet/configuration_resnet.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import Any, Optional, Tuple, Union
+from typing import Any
 
 from ...configuration_generic import RBLNModelForImageClassificationConfig
 
@@ -28,9 +28,9 @@ class RBLNResNetForImageClassificationConfig(RBLNModelForImageClassificationConf
 
     def __init__(
         self,
-        image_size: Optional[Union[int, Tuple[int, int]]] = None,
-        batch_size: Optional[int] = None,
-        output_hidden_states: Optional[bool] = None,
+        image_size: int | tuple[int, int] | None = None,
+        batch_size: int | None = None,
+        output_hidden_states: bool | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/transformers/models/resnet/modeling_resnet.py
+++ b/src/optimum/rbln/transformers/models/resnet/modeling_resnet.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import torch
 from transformers.modeling_outputs import ImageClassifierOutputWithNoAttention
@@ -38,7 +38,7 @@ class RBLNResNetForImageClassification(RBLNModelForImageClassification):
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]] = None,
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None = None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
         rbln_config: Optional["RBLNResNetForImageClassificationConfig"] = None,
@@ -73,7 +73,7 @@ class RBLNResNetForImageClassification(RBLNModelForImageClassification):
 
     def forward(
         self, pixel_values: torch.Tensor, output_hidden_states: bool = None, return_dict: bool = None, **kwargs
-    ) -> Union[Tuple, ImageClassifierOutputWithNoAttention]:
+    ) -> tuple | ImageClassifierOutputWithNoAttention:
         """
         Foward pass for the RBLN-optimized ResNet model for image classification.
 

--- a/src/optimum/rbln/transformers/models/roberta/modeling_roberta.py
+++ b/src/optimum/rbln/transformers/models/roberta/modeling_roberta.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, Union
 
 import torch
 from transformers.modeling_outputs import MaskedLMOutput, SequenceClassifierOutput
@@ -31,7 +30,7 @@ class RBLNRobertaForMaskedLM(RBLNModelForMaskedLM):
 
     rbln_model_input_names = ["input_ids", "attention_mask"]
 
-    def forward(self, input_ids: torch.Tensor, attention_mask: torch.Tensor, **kwargs) -> Union[Tuple, MaskedLMOutput]:
+    def forward(self, input_ids: torch.Tensor, attention_mask: torch.Tensor, **kwargs) -> tuple | MaskedLMOutput:
         """
         Forward pass for the RBLN-optimized RoBERTa model for masked language modeling tasks.
 
@@ -58,7 +57,7 @@ class RBLNRobertaForSequenceClassification(RBLNModelForSequenceClassification):
 
     def forward(
         self, input_ids: torch.Tensor, attention_mask: torch.Tensor, **kwargs
-    ) -> Union[Tuple, SequenceClassifierOutput]:
+    ) -> tuple | SequenceClassifierOutput:
         """
         Forward pass for the RBLN-optimized RoBERTa model for sequence classification tasks.
 

--- a/src/optimum/rbln/transformers/models/seq2seq/configuration_seq2seq.py
+++ b/src/optimum/rbln/transformers/models/seq2seq/configuration_seq2seq.py
@@ -38,13 +38,13 @@ class RBLNModelForSeq2SeqLMConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            enc_max_seq_len (Optional[int]): Maximum sequence length for the encoder.
-            dec_max_seq_len (Optional[int]): Maximum sequence length for the decoder.
-            use_attention_mask (Optional[bool]): Whether to use attention masks during inference.
-            kvcache_num_blocks (Optional[int]): The total number of blocks to allocate for the
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            enc_max_seq_len (int | None): Maximum sequence length for the encoder.
+            dec_max_seq_len (int | None): Maximum sequence length for the decoder.
+            use_attention_mask (bool | None): Whether to use attention masks during inference.
+            kvcache_num_blocks (int | None): The total number of blocks to allocate for the
                 PagedAttention KV cache for the SelfAttention. Defaults to batch_size.
-            kvcache_block_size (Optional[int]): Sets the size (in number of tokens) of each block
+            kvcache_block_size (int | None): Sets the size (in number of tokens) of each block
                 in the PagedAttention KV cache for the SelfAttention. Defaults to dec_max_seq_len.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 

--- a/src/optimum/rbln/transformers/models/seq2seq/configuration_seq2seq.py
+++ b/src/optimum/rbln/transformers/models/seq2seq/configuration_seq2seq.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 from ....utils.deprecation import deprecate_kwarg
@@ -28,12 +28,12 @@ class RBLNModelForSeq2SeqLMConfig(RBLNModelConfig):
     @deprecate_kwarg(old_name="pad_token_id", version="0.10.0")
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        enc_max_seq_len: Optional[int] = None,
-        dec_max_seq_len: Optional[int] = None,
-        use_attention_mask: Optional[bool] = None,
-        kvcache_num_blocks: Optional[int] = None,
-        kvcache_block_size: Optional[int] = None,
+        batch_size: int | None = None,
+        enc_max_seq_len: int | None = None,
+        dec_max_seq_len: int | None = None,
+        use_attention_mask: bool | None = None,
+        kvcache_num_blocks: int | None = None,
+        kvcache_block_size: int | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/transformers/models/seq2seq/modeling_seq2seq.py
+++ b/src/optimum/rbln/transformers/models/seq2seq/modeling_seq2seq.py
@@ -14,7 +14,7 @@
 
 import inspect
 from abc import ABC
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import rebel
 import torch
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 class RBLNRuntimeEncoder(RBLNPytorchRuntime):
     mandatory_members = ["main_input_name"]
 
-    def forward(self, *args: List[torch.Tensor], **kwargs: torch.Tensor):
+    def forward(self, *args: list[torch.Tensor], **kwargs: torch.Tensor):
         output = super().forward(*args, **kwargs)
         return BaseModelOutput(last_hidden_state=output)
 
@@ -53,7 +53,7 @@ class RBLNRuntimeDecoder(RBLNPytorchRuntime):
         runtime: rebel.Runtime,
         batch_size: int,
         dec_max_seq_len: int,
-        use_attention_mask: Optional[bool] = None,
+        use_attention_mask: bool | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(runtime, **kwargs)
@@ -64,13 +64,13 @@ class RBLNRuntimeDecoder(RBLNPytorchRuntime):
 
     def forward(
         self,
-        decoder_input_ids: Optional[torch.LongTensor] = None,
-        attention_mask: Optional[torch.FloatTensor] = None,
-        decoder_attention_mask: Optional[torch.BoolTensor] = None,
-        cache_position: Optional[torch.Tensor] = None,
-        block_tables: Optional[torch.Tensor] = None,
+        decoder_input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.FloatTensor | None = None,
+        decoder_attention_mask: torch.BoolTensor | None = None,
+        cache_position: torch.Tensor | None = None,
+        block_tables: torch.Tensor | None = None,
         **kwargs,
-    ) -> Tuple[torch.FloatTensor]:
+    ) -> tuple[torch.FloatTensor]:
         batch_size = decoder_input_ids.shape[0]
         if batch_size != self.batch_size:
             raise RuntimeError(
@@ -205,7 +205,7 @@ class RBLNModelForSeq2SeqLM(RBLNModel, GenerationMixin, ABC):
         preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"],
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
-        rbln_config: Optional[RBLNModelForSeq2SeqLMConfig] = None,
+        rbln_config: RBLNModelForSeq2SeqLMConfig | None = None,
     ) -> RBLNModelForSeq2SeqLMConfig:
         if not cls.support_causal_attn:
             rbln_config.use_attention_mask = True
@@ -331,9 +331,9 @@ class RBLNModelForSeq2SeqLM(RBLNModel, GenerationMixin, ABC):
     @classmethod
     def _create_runtimes(
         cls,
-        compiled_models: List[rebel.RBLNCompiledModel],
+        compiled_models: list[rebel.RBLNCompiledModel],
         rbln_config: RBLNModelForSeq2SeqLMConfig,
-    ) -> List[rebel.Runtime]:
+    ) -> list[rebel.Runtime]:
         if any(model_name not in rbln_config.device_map for model_name in ["encoder", "decoder"]):
             cls._raise_missing_compiled_file_error(["encoder", "decoder"])
 
@@ -388,9 +388,9 @@ class RBLNModelForSeq2SeqLM(RBLNModel, GenerationMixin, ABC):
     def forward(
         self,
         decoder_input_ids: torch.LongTensor = None,
-        cache_position: Union[List[torch.Tensor], torch.Tensor] = None,
+        cache_position: list[torch.Tensor] | torch.Tensor = None,
         **kwargs,
-    ) -> Tuple[torch.FloatTensor]:
+    ) -> tuple[torch.FloatTensor]:
         # common decoder
         cache_position = torch.full((self.rbln_config.batch_size, 1), cache_position, dtype=torch.int32)
         logits = self.decoder(decoder_input_ids=decoder_input_ids, cache_position=cache_position, **kwargs).logits
@@ -403,9 +403,9 @@ class RBLNModelForSeq2SeqLM(RBLNModel, GenerationMixin, ABC):
         self,
         inputs_tensor: torch.Tensor,
         model_kwargs,
-        model_input_name: Optional[str] = None,
+        model_input_name: str | None = None,
         generation_config: Optional["GenerationConfig"] = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         # 1. get encoder
         encoder = self.get_encoder()
 
@@ -455,10 +455,10 @@ class RBLNModelForSeq2SeqLM(RBLNModel, GenerationMixin, ABC):
     def generate(
         self,
         input_ids: torch.LongTensor,
-        attention_mask: Optional[torch.LongTensor] = None,
-        generation_config: Optional[GenerationConfig] = None,
+        attention_mask: torch.LongTensor | None = None,
+        generation_config: GenerationConfig | None = None,
         **kwargs,
-    ) -> Union[ModelOutput, torch.LongTensor]:
+    ) -> ModelOutput | torch.LongTensor:
         """
         The generate function is utilized in its standard form as in the HuggingFace transformers library. User can use this function to generate text from the model.
         Check the [HuggingFace transformers documentation](https://huggingface.co/docs/transformers/v4.57.1/en/main_classes/text_generation#transformers.GenerationMixin.generate) for more details.

--- a/src/optimum/rbln/transformers/models/seq2seq/seq2seq_architecture.py
+++ b/src/optimum/rbln/transformers/models/seq2seq/seq2seq_architecture.py
@@ -264,7 +264,7 @@ class Seq2SeqDecoder(torch.nn.Module):
 
     Args:
         model: Original Huggingface model to adapt
-        layers (List[Seq2SeqDecoderLayer]): Modified transformer layers optimized for RBLN
+        layers (list[Seq2SeqDecoderLayer]): Modified transformer layers optimized for RBLN
     """
 
     has_pos_emb = True
@@ -340,7 +340,7 @@ class Seq2SeqDecoderLayer(torch.nn.Module):
 
     Args:
         model: Original Huggingface model to adapt
-        layers (List[DecoderOnlyLayer]): Modified transformer layers optimized for RBLN
+        layers (list[DecoderOnlyLayer]): Modified transformer layers optimized for RBLN
         self_attn (Seq2SeqSelfAttention): Modified self-attention layer optimized for RBLN
     """
 

--- a/src/optimum/rbln/transformers/models/seq2seq/seq2seq_architecture.py
+++ b/src/optimum/rbln/transformers/models/seq2seq/seq2seq_architecture.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Tuple
 
 import torch
 from torch import nn
@@ -84,8 +83,8 @@ class Seq2SeqEncoderWrapper(nn.Module):
         input_ids: torch.Tensor,
         attention_mask: torch.Tensor,
         b_idx: torch.Tensor,
-        *cross_key_values: Tuple[torch.Tensor],
-    ) -> Tuple[torch.Tensor]:
+        *cross_key_values: tuple[torch.Tensor],
+    ) -> tuple[torch.Tensor]:
         # 1. get encoder last_hidden_states
         # TODO: make this to use `create_bidirectional_mask` in transformers v5
         from transformers.modeling_attn_mask_utils import _prepare_4d_attention_mask
@@ -163,7 +162,7 @@ class Seq2SeqDecoderWrapper(nn.Module):
     def forward(
         self,
         *args,
-    ) -> Tuple[torch.FloatTensor, Tuple[torch.FloatTensor]]:
+    ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor]]:
         if self.use_attention_mask:
             (
                 input_ids,
@@ -240,7 +239,7 @@ class Seq2SeqForConditionalGeneration(nn.Module):
         self_past_key_values,
         cross_past_key_values,
         cache_position,
-        block_tables: Optional[torch.Tensor] = None,
+        block_tables: torch.Tensor | None = None,
     ):
         hidden_states = self.decoder(
             input_ids=input_ids,
@@ -305,7 +304,7 @@ class Seq2SeqDecoder(torch.nn.Module):
         self_past_key_values: torch.Tensor,
         cross_past_key_values: torch.Tensor,
         cache_position: torch.Tensor,
-        block_tables: Optional[torch.Tensor] = None,
+        block_tables: torch.Tensor | None = None,
     ):
         # embedding
         hidden_states = self.get_embedding()(input_ids)
@@ -383,11 +382,11 @@ class Seq2SeqDecoderLayer(torch.nn.Module):
         hidden_states: torch.Tensor,
         attention_mask: torch.Tensor,
         encoder_attention_mask: torch.Tensor,
-        self_past_key_value: Tuple[torch.Tensor],
-        cross_past_key_value: Tuple[torch.Tensor],
+        self_past_key_value: tuple[torch.Tensor],
+        cross_past_key_value: tuple[torch.Tensor],
         cache_position: torch.Tensor,
-        block_tables: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, Tuple[torch.Tensor]]:
+        block_tables: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, tuple[torch.Tensor]]:
         dummy_encoder_hidden_states = torch.zeros(1, encoder_attention_mask.shape[-1])
 
         # Self Attention Block
@@ -437,7 +436,7 @@ class Seq2SeqSelfAttention(nn.Module):
     def _shape(self, tensor: torch.Tensor, seq_len: int, bsz: int) -> torch.Tensor:
         return tensor.view(bsz, seq_len, 1, self.num_heads, self.head_dim).transpose(1, 3)
 
-    def projection(self, hidden_states) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def projection(self, hidden_states) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Projects input hidden states into query, key, and value representations.
 
         Args:
@@ -454,11 +453,11 @@ class Seq2SeqSelfAttention(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        past_key_value: Tuple[torch.Tensor],
+        past_key_value: tuple[torch.Tensor],
         attention_mask: torch.Tensor,
         cache_position: torch.Tensor,
-        block_tables: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, Tuple[torch.Tensor]]:
+        block_tables: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, tuple[torch.Tensor]]:
         bsz, tgt_len, _ = hidden_states.size()
 
         query_states, key_states, value_states = self.projection(hidden_states=hidden_states)
@@ -508,8 +507,8 @@ class Seq2SeqCrossAttention(nn.Module):
         self,
         hidden_states: torch.Tensor,
         key_value_states: torch.Tensor = None,
-        past_key_value: Optional[object] = None,
-        attention_mask: Optional[torch.Tensor] = None,
+        past_key_value: object | None = None,
+        attention_mask: torch.Tensor | None = None,
     ):
         bsz, tgt_len, _ = hidden_states.size()
         query_states = self.q_proj(hidden_states).view(bsz, -1, self.num_heads, self.head_dim).transpose(1, 2)

--- a/src/optimum/rbln/transformers/models/siglip/configuration_siglip.py
+++ b/src/optimum/rbln/transformers/models/siglip/configuration_siglip.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
 
 from ....configuration_utils import RBLNModelConfig
 
@@ -27,11 +26,11 @@ class RBLNSiglipVisionModelConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        image_size: Optional[int] = None,
-        interpolate_pos_encoding: Optional[bool] = None,
-        output_hidden_states: Optional[bool] = None,
-        output_attentions: Optional[bool] = None,
+        batch_size: int | None = None,
+        image_size: int | None = None,
+        interpolate_pos_encoding: bool | None = None,
+        output_hidden_states: bool | None = None,
+        output_attentions: bool | None = None,
         **kwargs,
     ):
         """

--- a/src/optimum/rbln/transformers/models/siglip/configuration_siglip.py
+++ b/src/optimum/rbln/transformers/models/siglip/configuration_siglip.py
@@ -35,12 +35,12 @@ class RBLNSiglipVisionModelConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for image processing. Defaults to 1.
-            image_size (Optional[int]): The size of input images. Can be an integer for square images,
+            batch_size (int | None): The batch size for image processing. Defaults to 1.
+            image_size (int | None): The size of input images. Can be an integer for square images,
                 a tuple/list (height, width), or a dictionary with 'height' and 'width' keys.
-            interpolate_pos_encoding (Optional[bool]): Whether to interpolate the position encoding.
-            output_hidden_states: (Optional[bool]): Whether to return hidden states.
-            output_attentions: (Optional[bool]): Whether to return attentions.
+            interpolate_pos_encoding (bool | None): Whether to interpolate the position encoding.
+            output_hidden_states: (bool | None): Whether to return hidden states.
+            output_attentions: (bool | None): Whether to return attentions.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/transformers/models/siglip/modeling_siglip.py
+++ b/src/optimum/rbln/transformers/models/siglip/modeling_siglip.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import torch
 from transformers import SiglipVisionConfig, SiglipVisionModel
@@ -83,7 +83,7 @@ class RBLNSiglipVisionModel(RBLNModel):
         preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"],
         model: Optional["PreTrainedModel"] = None,
         model_config: "SiglipVisionConfig" = None,
-        rbln_config: Optional[RBLNSiglipVisionModelConfig] = None,
+        rbln_config: RBLNSiglipVisionModelConfig | None = None,
     ) -> RBLNSiglipVisionModelConfig:
         if rbln_config.image_size is None:
             rbln_config.image_size = getattr(model_config, "image_size", None)
@@ -124,7 +124,7 @@ class RBLNSiglipVisionModel(RBLNModel):
         output_hidden_states: bool = None,
         interpolate_pos_encoding: bool = False,
         **kwargs: Any,
-    ) -> Union[Tuple, BaseModelOutputWithPooling]:
+    ) -> tuple | BaseModelOutputWithPooling:
         """
         Forward pass for the RBLN-optimized SigLIP vision model.
 

--- a/src/optimum/rbln/transformers/models/swin/configuration_swin.py
+++ b/src/optimum/rbln/transformers/models/swin/configuration_swin.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Tuple, Union
+from typing import Any
 
 from ...configuration_generic import RBLNModelForImageClassificationConfig
 
@@ -18,10 +18,10 @@ from ...configuration_generic import RBLNModelForImageClassificationConfig
 class RBLNSwinBackboneConfig(RBLNModelForImageClassificationConfig):
     def __init__(
         self,
-        image_size: Optional[Union[int, Tuple[int, int]]] = None,
-        batch_size: Optional[int] = None,
-        output_hidden_states: Optional[bool] = None,
-        output_attentions: Optional[bool] = None,
+        image_size: int | tuple[int, int] | None = None,
+        batch_size: int | None = None,
+        output_hidden_states: bool | None = None,
+        output_attentions: bool | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/transformers/models/swin/configuration_swin.py
+++ b/src/optimum/rbln/transformers/models/swin/configuration_swin.py
@@ -26,7 +26,7 @@ class RBLNSwinBackboneConfig(RBLNModelForImageClassificationConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for text processing. Defaults to 1.
+            batch_size (int | None): The batch size for text processing. Defaults to 1.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/transformers/models/swin/modeling_swin.py
+++ b/src/optimum/rbln/transformers/models/swin/modeling_swin.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import types
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import torch
 import torch.nn.functional as F
@@ -74,7 +74,7 @@ def get_attn_mask(self, height, width, dtype, device):
         mask_windows = window_partition(img_mask, self.window_size)
         mask_windows = mask_windows.view(-1, self.window_size * self.window_size)
         attn_mask = mask_windows.unsqueeze(1) - mask_windows.unsqueeze(2)
-        attn_mask = attn_mask.masked_fill(attn_mask != 0, float(-100.0)).masked_fill(attn_mask == 0, float(0.0))
+        attn_mask = attn_mask.masked_fill(attn_mask != 0, (-100.0)).masked_fill(attn_mask == 0, 0.0)
     else:
         attn_mask = None
     return attn_mask
@@ -88,13 +88,13 @@ class _SwinEncoder(torch.nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        input_dimensions: Tuple[int, int],
-        head_mask: Optional[torch.FloatTensor] = None,
-        output_attentions: Optional[bool] = False,
-        output_hidden_states: Optional[bool] = False,
-        output_hidden_states_before_downsampling: Optional[bool] = False,
-        always_partition: Optional[bool] = False,
-        return_dict: Optional[bool] = True,
+        input_dimensions: tuple[int, int],
+        head_mask: torch.FloatTensor | None = None,
+        output_attentions: bool | None = False,
+        output_hidden_states: bool | None = False,
+        output_hidden_states_before_downsampling: bool | None = False,
+        always_partition: bool | None = False,
+        return_dict: bool | None = True,
     ):
         all_hidden_states = () if output_hidden_states else None
         all_reshaped_hidden_states = () if output_hidden_states else None
@@ -215,7 +215,7 @@ class RBLNSwinBackbone(RBLNModel):
         cls,
         model: "PreTrainedModel",
         rbln_config: RBLNModelConfig,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
     ):
         for processor in preprocessors:
             if rbln_config.image_size is None and hasattr(processor, "image_processor"):
@@ -241,7 +241,7 @@ class RBLNSwinBackbone(RBLNModel):
         preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"],
         model: Optional["PreTrainedModel"] = None,
         model_config: "SwinConfig" = None,
-        rbln_config: Optional[RBLNSwinBackboneConfig] = None,
+        rbln_config: RBLNSwinBackboneConfig | None = None,
     ) -> RBLNSwinBackboneConfig:
         if rbln_config.image_size is None:
             for processor in preprocessors:
@@ -268,12 +268,12 @@ class RBLNSwinBackbone(RBLNModel):
 
     def forward(
         self,
-        pixel_values: Optional[torch.FloatTensor] = None,
+        pixel_values: torch.FloatTensor | None = None,
         return_dict: bool = True,
         output_attentions: bool = None,
         output_hidden_states: bool = None,
         **kwargs,
-    ) -> Union[Tuple, BackboneOutput]:
+    ) -> tuple | BackboneOutput:
         """
         Forward pass for the RBLN-optimized Swin backbone model.
 

--- a/src/optimum/rbln/transformers/models/t5/modeling_t5.py
+++ b/src/optimum/rbln/transformers/models/t5/modeling_t5.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import inspect
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 import torch
 from transformers import AutoModelForTextEncoding, T5EncoderModel, T5ForConditionalGeneration

--- a/src/optimum/rbln/transformers/models/t5/t5_architecture.py
+++ b/src/optimum/rbln/transformers/models/t5/t5_architecture.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple
 
 import torch
 from torch import nn
@@ -77,7 +76,7 @@ class T5DecoderWrapper(Seq2SeqDecoderWrapper):
         cache_position,
         block_tables,
         *kv_cache,
-    ) -> Tuple[torch.FloatTensor, Tuple[torch.FloatTensor]]:
+    ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor]]:
         self_past_key_values = ()
         cross_past_key_values = ()
         self_kv_cache = kv_cache[self.num_layers * 2 :]
@@ -175,7 +174,7 @@ class T5LayerSelfAttention(Seq2SeqSelfAttention):
         self.head_dim = attn.key_value_proj_dim
         self.attn_decode = torch.ops.rbln_custom_ops.paged_add_softmax_attn_decode
 
-    def projection(self, hidden_states) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def projection(self, hidden_states) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         query_states = self.q_proj(hidden_states)
         key_states = self.k_proj(hidden_states)
         value_states = self.v_proj(hidden_states)
@@ -184,12 +183,12 @@ class T5LayerSelfAttention(Seq2SeqSelfAttention):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        past_key_value: Tuple[torch.Tensor],
+        past_key_value: tuple[torch.Tensor],
         attention_mask: torch.Tensor,
         cache_position: torch.Tensor,
         block_tables: torch.Tensor,
         **kwargs,
-    ) -> Tuple[torch.Tensor, Tuple[torch.Tensor]]:
+    ) -> tuple[torch.Tensor, tuple[torch.Tensor]]:
         bsz, tgt_len, _ = hidden_states.size()
 
         query_states, key_states, value_states = self.projection(hidden_states=hidden_states)

--- a/src/optimum/rbln/transformers/models/time_series_transformer/configuration_time_series_transformer.py
+++ b/src/optimum/rbln/transformers/models/time_series_transformer/configuration_time_series_transformer.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 
@@ -13,10 +13,10 @@ class RBLNTimeSeriesTransformerForPredictionConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        batch_size: Optional[int] = None,
-        enc_max_seq_len: Optional[int] = None,
-        dec_max_seq_len: Optional[int] = None,
-        num_parallel_samples: Optional[int] = None,
+        batch_size: int | None = None,
+        enc_max_seq_len: int | None = None,
+        dec_max_seq_len: int | None = None,
+        num_parallel_samples: int | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/optimum/rbln/transformers/models/time_series_transformer/configuration_time_series_transformer.py
+++ b/src/optimum/rbln/transformers/models/time_series_transformer/configuration_time_series_transformer.py
@@ -21,10 +21,10 @@ class RBLNTimeSeriesTransformerForPredictionConfig(RBLNModelConfig):
     ):
         """
         Args:
-            batch_size (Optional[int]): The batch size for inference. Defaults to 1.
-            enc_max_seq_len (Optional[int]): Maximum sequence length for the encoder.
-            dec_max_seq_len (Optional[int]): Maximum sequence length for the decoder.
-            num_parallel_samples (Optional[int]): Number of samples to generate in parallel during prediction.
+            batch_size (int | None): The batch size for inference. Defaults to 1.
+            enc_max_seq_len (int | None): Maximum sequence length for the encoder.
+            dec_max_seq_len (int | None): Maximum sequence length for the decoder.
+            num_parallel_samples (int | None): Number of samples to generate in parallel during prediction.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:

--- a/src/optimum/rbln/transformers/models/time_series_transformer/modeling_time_series_transformer.py
+++ b/src/optimum/rbln/transformers/models/time_series_transformer/modeling_time_series_transformer.py
@@ -23,8 +23,9 @@
 
 import inspect
 import logging
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import rebel
 import torch
@@ -63,11 +64,11 @@ class RBLNRuntimeEncoder(RBLNPytorchRuntime):
         self,
         past_values: torch.Tensor,
         past_time_features: torch.Tensor,
-        static_categorical_features: Optional[torch.Tensor] = None,
-        static_real_features: Optional[torch.Tensor] = None,
-        past_observed_mask: Optional[torch.Tensor] = None,
-        future_values: Optional[torch.Tensor] = None,
-        future_time_features: Optional[torch.Tensor] = None,
+        static_categorical_features: torch.Tensor | None = None,
+        static_real_features: torch.Tensor | None = None,
+        past_observed_mask: torch.Tensor | None = None,
+        future_values: torch.Tensor | None = None,
+        future_time_features: torch.Tensor | None = None,
     ):
         # preprocess
         transformer_inputs, loc, scale, static_feat = self._origin_model.create_network_inputs(
@@ -222,10 +223,10 @@ class RBLNTimeSeriesTransformerForPrediction(RBLNModel):
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]] = None,
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None = None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
-        rbln_config: Optional[RBLNTimeSeriesTransformerForPredictionConfig] = None,
+        rbln_config: RBLNTimeSeriesTransformerForPredictionConfig | None = None,
     ) -> RBLNTimeSeriesTransformerForPredictionConfig:
         rbln_config.num_parallel_samples = rbln_config.num_parallel_samples or model_config.num_parallel_samples
 
@@ -310,9 +311,9 @@ class RBLNTimeSeriesTransformerForPrediction(RBLNModel):
     @classmethod
     def _create_runtimes(
         cls,
-        compiled_models: List[rebel.RBLNCompiledModel],
+        compiled_models: list[rebel.RBLNCompiledModel],
         rbln_config: RBLNTimeSeriesTransformerForPredictionConfig,
-    ) -> List[rebel.Runtime]:
+    ) -> list[rebel.Runtime]:
         if any(model_name not in rbln_config.device_map for model_name in ["encoder", "decoder"]):
             cls._raise_missing_compiled_file_error(["encoder", "decoder"])
 
@@ -349,9 +350,9 @@ class RBLNTimeSeriesTransformerForPrediction(RBLNModel):
         past_values: torch.Tensor,
         past_time_features: torch.Tensor,
         future_time_features: torch.Tensor,
-        past_observed_mask: Optional[torch.Tensor] = None,
-        static_categorical_features: Optional[torch.Tensor] = None,
-        static_real_features: Optional[torch.Tensor] = None,
+        past_observed_mask: torch.Tensor | None = None,
+        static_categorical_features: torch.Tensor | None = None,
+        static_real_features: torch.Tensor | None = None,
         **kwargs,
     ) -> SampleTSPredictionOutput:
         """

--- a/src/optimum/rbln/transformers/models/time_series_transformer/time_series_transformers_architecture.py
+++ b/src/optimum/rbln/transformers/models/time_series_transformer/time_series_transformers_architecture.py
@@ -21,7 +21,6 @@
 # copied, modified, or distributed without prior written permission
 # from Rebellions Inc.
 
-from typing import Optional, Tuple, Union
 
 import torch
 from torch import nn
@@ -58,7 +57,7 @@ class TimeSeriesTransformersEncoderWrapper(torch.nn.Module):
         self,
         inputs_embeds: torch.Tensor,
         cross_key_values: torch.Tensor,  # n_layers, batch_size, num_heads, context_length, d_kv
-    ) -> Union[Tuple[torch.FloatTensor], BaseModelOutput]:
+    ) -> tuple[torch.FloatTensor] | BaseModelOutput:
         # 1. get encoder last_hidden_states
         encoder_outputs = self.encoder(inputs_embeds=inputs_embeds, attention_mask=None, return_dict=False)
         last_hidden_states = encoder_outputs[0]
@@ -110,7 +109,7 @@ class TimeSeriesTransformersDecoderWrapper(torch.nn.Module):
         block_tables: torch.Tensor,
         cross_kv_cache: torch.Tensor,  # batch_size, num_heads, context_length, d_kv
         *self_kv_cache: torch.Tensor,  # batch_size * num_parallel_samples, num_heads, prediction_length, d_kv
-    ) -> Union[Tuple[torch.FloatTensor], Seq2SeqLMOutput]:
+    ) -> tuple[torch.FloatTensor] | Seq2SeqLMOutput:
         # prepare past_key_values
         self_past_key_values = ()
         cross_past_key_values = ()
@@ -149,10 +148,10 @@ class TimeSeriesTransformersDecoder(nn.Module):
     def forward(
         self,
         inputs_embeds: torch.Tensor = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        self_past_key_values: Optional[torch.Tensor] = None,
-        cross_past_key_values: Optional[torch.Tensor] = None,
-        cache_position: Optional[torch.Tensor] = None,
+        attention_mask: torch.Tensor | None = None,
+        self_past_key_values: torch.Tensor | None = None,
+        cross_past_key_values: torch.Tensor | None = None,
+        cache_position: torch.Tensor | None = None,
         block_tables: torch.Tensor = None,
     ):
         input_shape = inputs_embeds.size()[:-1]
@@ -202,10 +201,10 @@ class TimeSeriesTransformersDecoderLayer(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
-        self_past_key_value: Optional[Tuple[torch.Tensor]] = None,
-        cross_past_key_value: Optional[Tuple[torch.Tensor]] = None,
-        cache_position: Optional[torch.Tensor] = None,
+        attention_mask: torch.Tensor | None = None,
+        self_past_key_value: tuple[torch.Tensor] | None = None,
+        cross_past_key_value: tuple[torch.Tensor] | None = None,
+        cache_position: torch.Tensor | None = None,
         block_tables: torch.Tensor = None,
     ) -> torch.Tensor:
         # Self Attention Block
@@ -264,11 +263,11 @@ class TimeSeriesTransformersSelfAttention(TimeSeriesTransformersAttention):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        past_key_value: Optional[Tuple[torch.Tensor]] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        cache_position: Optional[torch.Tensor] = None,
-        block_tables: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+        past_key_value: tuple[torch.Tensor] | None = None,
+        attention_mask: torch.Tensor | None = None,
+        cache_position: torch.Tensor | None = None,
+        block_tables: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, tuple[torch.Tensor] | None]:
         bsz, tgt_len, _ = hidden_states.size()
         query_states = self._shape(self.q_proj(hidden_states), tgt_len, bsz)
         query_states = query_states * self.scaling
@@ -302,8 +301,8 @@ class TimeSeriesTransformersCrossAttention(TimeSeriesTransformersSelfAttention):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        past_key_value: Optional[Tuple[torch.Tensor]] = None,
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+        past_key_value: tuple[torch.Tensor] | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, tuple[torch.Tensor] | None]:
         batch_size, query_len, _ = hidden_states.size()
         query_states = (
             self.q_proj(hidden_states)

--- a/src/optimum/rbln/transformers/models/vit/modeling_vit.py
+++ b/src/optimum/rbln/transformers/models/vit/modeling_vit.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, Union
 
 import torch
 from transformers.modeling_outputs import ImageClassifierOutput
@@ -29,7 +28,7 @@ class RBLNViTForImageClassification(RBLNModelForImageClassification):
     that process images as sequences of patches.
     """
 
-    def forward(self, pixel_values: torch.Tensor, **kwargs) -> Union[ImageClassifierOutput, Tuple]:
+    def forward(self, pixel_values: torch.Tensor, **kwargs) -> ImageClassifierOutput | tuple:
         """
         Forward pass for the RBLN-optimized Vision Transformer model for image classification.
 

--- a/src/optimum/rbln/transformers/models/wav2vec2/configuration_wav2vec2.py
+++ b/src/optimum/rbln/transformers/models/wav2vec2/configuration_wav2vec2.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
+from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
 
@@ -27,8 +27,8 @@ class RBLNWav2Vec2ForCTCConfig(RBLNModelConfig):
 
     def __init__(
         self,
-        max_seq_len: Optional[int] = None,
-        batch_size: Optional[int] = None,
+        max_seq_len: int | None = None,
+        batch_size: int | None = None,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)

--- a/src/optimum/rbln/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/optimum/rbln/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -63,7 +63,7 @@ class RBLNWav2Vec2ForCTC(RBLNModel):
         preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"],
         model: Optional["PreTrainedModel"] = None,
         model_config: "Wav2Vec2Config" = None,
-        rbln_config: Optional[RBLNWav2Vec2ForCTCConfig] = None,
+        rbln_config: RBLNWav2Vec2ForCTCConfig | None = None,
     ) -> RBLNWav2Vec2ForCTCConfig:
         if rbln_config.max_seq_len is None:
             for tokenizer in preprocessors:
@@ -89,9 +89,7 @@ class RBLNWav2Vec2ForCTC(RBLNModel):
         rbln_config.set_compile_cfgs([rbln_compile_config])
         return rbln_config
 
-    def forward(
-        self, input_values: torch.Tensor, return_dict: Optional[bool] = None, **kwargs
-    ) -> Union[CausalLMOutput, tuple]:
+    def forward(self, input_values: torch.Tensor, return_dict: bool | None = None, **kwargs) -> CausalLMOutput | tuple:
         """
         Forward pass for the RBLN-optimized Wav2Vec2 model for Connectionist Temporal Classification (CTC).
 

--- a/src/optimum/rbln/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/optimum/rbln/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -94,7 +94,7 @@ class RBLNWav2Vec2ForCTC(RBLNModel):
         Forward pass for the RBLN-optimized Wav2Vec2 model for Connectionist Temporal Classification (CTC).
 
         Args:
-            input_values (torch.FloatTensor of shape (batch_size, sequence_length)): Float values of input raw speech waveform. Values can be obtained by loading a .flac or .wav audio file into an array of type List[float] or a numpy.ndarray, e.g. via the soundfile library (pip install soundfile). To prepare the array into input_values, the AutoProcessor should be used for padding and conversion into a tensor of type torch.FloatTensor.
+            input_values (torch.FloatTensor of shape (batch_size, sequence_length)): Float values of input raw speech waveform. Values can be obtained by loading a .flac or .wav audio file into an array of type list[float] or a numpy.ndarray, e.g. via the soundfile library (pip install soundfile). To prepare the array into input_values, the AutoProcessor should be used for padding and conversion into a tensor of type torch.FloatTensor.
             return_dict (bool, optional): Whether or not to return a ModelOutput instead of a plain tuple.
 
         Returns:

--- a/src/optimum/rbln/transformers/models/whisper/generation_whisper.py
+++ b/src/optimum/rbln/transformers/models/whisper/generation_whisper.py
@@ -31,7 +31,7 @@ Generation utilities for Whisper.
 Modified from `transformers.models.whisper.generation_whisper.py`
 """
 
-from typing import Any, Dict, Optional, Union
+from typing import Any
 
 import torch
 from transformers import GenerationMixin
@@ -43,14 +43,14 @@ from transformers.models.whisper.generation_whisper import WhisperGenerationMixi
 class RBLNWhisperGenerationMixin(WhisperGenerationMixin, GenerationMixin):
     def generate(
         self,
-        input_features: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        generation_config: Optional[GenerationConfig] = None,
-        return_segments: Optional[bool] = None,
-        return_timestamps: Optional[bool] = None,
-        return_token_timestamps: Optional[bool] = None,
-        **kwargs: Optional[Dict[str, Any]],
-    ) -> Union[ModelOutput, Dict[str, Any], torch.LongTensor]:
+        input_features: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        generation_config: GenerationConfig | None = None,
+        return_segments: bool | None = None,
+        return_timestamps: bool | None = None,
+        return_token_timestamps: bool | None = None,
+        **kwargs: dict[str, Any] | None,
+    ) -> ModelOutput | dict[str, Any] | torch.LongTensor:
         """
         The generate function is utilized in its standard form as in the HuggingFace transformers library. User can use this function to generate text from the model.
         Check the [HuggingFace transformers documentation](https://huggingface.co/docs/transformers/v4.57.1/en/model_doc/whisper#transformers.WhisperForConditionalGeneration.generate) for more details.

--- a/src/optimum/rbln/transformers/models/whisper/modeling_whisper.py
+++ b/src/optimum/rbln/transformers/models/whisper/modeling_whisper.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import rebel
 import torch
@@ -46,7 +47,7 @@ if TYPE_CHECKING:
 class RBLNRuntimeEncoder(RBLNPytorchRuntime):
     mandatory_members = ["main_input_name"]
 
-    def forward(self, *args: List[torch.Tensor], **kwargs: torch.Tensor):
+    def forward(self, *args: list[torch.Tensor], **kwargs: torch.Tensor):
         output = super().forward(*args, **kwargs)
         return BaseModelOutput(last_hidden_state=output)
 
@@ -59,7 +60,7 @@ class RBLNRuntimeDecoder(RBLNPytorchRuntime):
         runtime: rebel.Runtime,
         batch_size: int,
         dec_max_seq_len: int,
-        use_attention_mask: Optional[bool] = None,
+        use_attention_mask: bool | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(runtime, **kwargs)
@@ -275,10 +276,10 @@ class RBLNWhisperForConditionalGeneration(RBLNModel, RBLNWhisperGenerationMixin)
     @classmethod
     def _update_rbln_config(
         cls,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]] = None,
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None = None,
         model: Optional["PreTrainedModel"] = None,
         model_config: Optional["PretrainedConfig"] = None,
-        rbln_config: Optional[RBLNWhisperForConditionalGenerationConfig] = None,
+        rbln_config: RBLNWhisperForConditionalGenerationConfig | None = None,
     ) -> RBLNWhisperForConditionalGenerationConfig:
         expected_seq_len = model_config.max_source_positions * 2
         num_mel_bins = model_config.num_mel_bins
@@ -358,9 +359,9 @@ class RBLNWhisperForConditionalGeneration(RBLNModel, RBLNWhisperGenerationMixin)
     @classmethod
     def _create_runtimes(
         cls,
-        compiled_models: List[rebel.RBLNCompiledModel],
+        compiled_models: list[rebel.RBLNCompiledModel],
         rbln_config: RBLNWhisperForConditionalGenerationConfig,
-    ) -> List[rebel.Runtime]:
+    ) -> list[rebel.Runtime]:
         if any(model_name not in rbln_config.device_map for model_name in ["encoder", "decoder"]):
             cls._raise_missing_compiled_file_error(["encoder", "decoder"])
 
@@ -384,8 +385,8 @@ class RBLNWhisperForConditionalGeneration(RBLNModel, RBLNWhisperGenerationMixin)
     def prepare_inputs_for_generation(
         self,
         input_ids,
-        cache_position: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,  # need for support transformers>=4.45.0
+        cache_position: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,  # need for support transformers>=4.45.0
         **kwargs,
     ):
         return {
@@ -398,10 +399,10 @@ class RBLNWhisperForConditionalGeneration(RBLNModel, RBLNWhisperGenerationMixin)
         self,
         inputs_tensor: torch.Tensor,
         model_kwargs,
-        model_input_name: Optional[str] = None,
+        model_input_name: str | None = None,
         generation_config: Optional["GenerationConfig"] = None,
         **kwargs,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         batch_size = inputs_tensor.shape[0]
         n_pad_to_batch = self.batch_size - batch_size
         if n_pad_to_batch > 0:
@@ -421,11 +422,11 @@ class RBLNWhisperForConditionalGeneration(RBLNModel, RBLNWhisperGenerationMixin)
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        cache_position: Optional[torch.Tensor] = None,
-        input_features: Optional[torch.Tensor] = None,
-        decoder_input_ids: Optional[torch.Tensor] = None,
-        encoder_outputs: Optional[Seq2SeqLMOutput] = None,
+        input_ids: torch.LongTensor | None = None,
+        cache_position: torch.Tensor | None = None,
+        input_features: torch.Tensor | None = None,
+        decoder_input_ids: torch.Tensor | None = None,
+        encoder_outputs: Seq2SeqLMOutput | None = None,
         **kwargs,
     ) -> Seq2SeqLMOutput:
         # default decoder pass

--- a/src/optimum/rbln/transformers/models/whisper/whisper_architecture.py
+++ b/src/optimum/rbln/transformers/models/whisper/whisper_architecture.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Tuple, Union
 
 import torch
 from torch import nn
@@ -48,10 +47,10 @@ class WhisperEncoderWrapper(torch.nn.Module):
 
     def forward(
         self,
-        input_features: Optional[torch.LongTensor],
+        input_features: torch.LongTensor | None,
         b_idx: torch.Tensor,
         cross_key_values: torch.Tensor,
-    ) -> Union[Tuple[torch.FloatTensor], BaseModelOutput]:
+    ) -> tuple[torch.FloatTensor] | BaseModelOutput:
         # 1. get encoder last_hidden_states
         encoder_outputs = self.encoder(input_features=input_features)
         last_hidden_states = encoder_outputs[0]
@@ -109,7 +108,7 @@ class WhisperDecoderWrapper(torch.nn.Module):
     def forward(
         self,
         *args,
-    ) -> Union[Tuple[torch.FloatTensor], Seq2SeqLMOutput]:
+    ) -> tuple[torch.FloatTensor] | Seq2SeqLMOutput:
         if self.use_attention_mask:
             (
                 decoder_input_ids,
@@ -161,12 +160,12 @@ class WhisperDecoder(nn.Module):
 
     def forward(
         self,
-        input_ids: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        self_past_key_values: Optional[torch.Tensor] = None,
-        cross_past_key_values: Optional[torch.Tensor] = None,
-        cache_position: Optional[torch.Tensor] = None,
-        block_tables: Optional[torch.Tensor] = None,
+        input_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        self_past_key_values: torch.Tensor | None = None,
+        cross_past_key_values: torch.Tensor | None = None,
+        cache_position: torch.Tensor | None = None,
+        block_tables: torch.Tensor | None = None,
     ):
         input_shape = input_ids.size()
         input_ids = input_ids.view(-1, input_shape[-1])
@@ -221,11 +220,11 @@ class WhisperDecoderLayer(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
-        self_past_key_value: Optional[Tuple[torch.Tensor]] = None,
-        cross_past_key_value: Optional[Tuple[torch.Tensor]] = None,
-        cache_position: Optional[torch.Tensor] = None,
-        block_tables: Optional[torch.Tensor] = None,
+        attention_mask: torch.Tensor | None = None,
+        self_past_key_value: tuple[torch.Tensor] | None = None,
+        cross_past_key_value: tuple[torch.Tensor] | None = None,
+        cache_position: torch.Tensor | None = None,
+        block_tables: torch.Tensor | None = None,
     ) -> torch.Tensor:
         # Self Attention Block
         residual = hidden_states
@@ -281,11 +280,11 @@ class WhisperSelfAttention(WhisperAttention):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        past_key_value: Optional[Tuple[torch.Tensor]] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        cache_position: Optional[torch.Tensor] = None,
-        block_tables: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+        past_key_value: tuple[torch.Tensor] | None = None,
+        attention_mask: torch.Tensor | None = None,
+        cache_position: torch.Tensor | None = None,
+        block_tables: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, tuple[torch.Tensor] | None]:
         bsz, tgt_len, _ = hidden_states.size()
         query_states = self._shape(self.q_proj(hidden_states), tgt_len, bsz)
         query_states = query_states * self.scaling
@@ -325,8 +324,8 @@ class WhisperCrossAttention(WhisperAttention):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        past_key_value: Optional[Tuple[torch.Tensor]] = None,
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+        past_key_value: tuple[torch.Tensor] | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, tuple[torch.Tensor] | None]:
         batch_size, query_len, _ = hidden_states.size()
         query_states = self._shape(self.q_proj(hidden_states), query_len, batch_size)
         query_states = query_states * self.scaling

--- a/src/optimum/rbln/transformers/models/xlm_roberta/modeling_xlm_roberta.py
+++ b/src/optimum/rbln/transformers/models/xlm_roberta/modeling_xlm_roberta.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Union
 
 import torch
 from transformers.modeling_outputs import BaseModelOutputWithPoolingAndCrossAttentions, SequenceClassifierOutput
@@ -27,11 +26,11 @@ class RBLNXLMRobertaModel(RBLNTransformerEncoderForFeatureExtraction):
 
     def forward(
         self,
-        input_ids: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        token_type_ids: Optional[torch.Tensor] = None,
+        input_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        token_type_ids: torch.Tensor | None = None,
         **kwargs,
-    ) -> Union[BaseModelOutputWithPoolingAndCrossAttentions, tuple]:
+    ) -> BaseModelOutputWithPoolingAndCrossAttentions | tuple:
         """
         Forward pass for the RBLN-optimized XLM-RoBERTa base model.
 
@@ -59,11 +58,11 @@ class RBLNXLMRobertaForSequenceClassification(RBLNModelForSequenceClassification
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        attention_mask: Optional[torch.FloatTensor] = None,
-        token_type_ids: Optional[torch.LongTensor] = None,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.FloatTensor | None = None,
+        token_type_ids: torch.LongTensor | None = None,
         **kwargs,
-    ) -> Union[SequenceClassifierOutput, tuple]:
+    ) -> SequenceClassifierOutput | tuple:
         """
         Forward pass for the RBLN-optimized XLM-RoBERTa model for sequence classification.
 

--- a/src/optimum/rbln/transformers/utils/qlinear.py
+++ b/src/optimum/rbln/transformers/utils/qlinear.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -8,10 +6,10 @@ import torch.nn.functional as F
 class QLinear(nn.Module):
     def __init__(
         self,
-        weight: Optional[torch.Tensor] = None,
-        bias: Optional[torch.Tensor] = None,
-        weight_scale: Optional[torch.Tensor] = None,
-        input_scale: Optional[torch.Tensor] = None,
+        weight: torch.Tensor | None = None,
+        bias: torch.Tensor | None = None,
+        weight_scale: torch.Tensor | None = None,
+        input_scale: torch.Tensor | None = None,
         dynamic: bool = False,
     ):
         super().__init__()

--- a/src/optimum/rbln/transformers/utils/rbln_quantization.py
+++ b/src/optimum/rbln/transformers/utils/rbln_quantization.py
@@ -14,16 +14,10 @@
 
 import glob
 import os
+from collections.abc import Iterable
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    Union,
 )
 
 import torch
@@ -57,7 +51,7 @@ QUANTIZED_WEIGHTS = {
 }
 
 # Common alias sets seen in community checkpoints
-VARIANT_ALIASES: Dict[str, List[str]] = {
+VARIANT_ALIASES: dict[str, list[str]] = {
     "weight_scale": ["weight_scale", "scales", "w_scale", "scale"],
     "input_scale": ["input_scale", "act_scale", "activation_scale", "a_scale"],
     "kv_scale": ["kv_scale", "kv_scales"],
@@ -75,13 +69,13 @@ class RBLNQuantizationConfig(RBLNSerializableConfigProtocol):
 
     def __init__(
         self,
-        format: Optional[str] = None,
-        weights: Optional[str] = None,
-        activations: Optional[str] = None,
-        kv_caches: Optional[str] = None,
-        dynamic: Optional[bool] = None,
+        format: str | None = None,
+        weights: str | None = None,
+        activations: str | None = None,
+        kv_caches: str | None = None,
+        dynamic: bool | None = None,
         *,
-        precision: Optional[str] = None,
+        precision: str | None = None,
     ):
         self.format = format or "rbln"
         if self.format not in self.SUPPORTED_FORMATS:
@@ -121,7 +115,7 @@ class RBLNQuantizationConfig(RBLNSerializableConfigProtocol):
         if self.weights == "fp16" and self.activations == "fp16":
             raise ValueError("weights and activations of QuantizationConfig cannot be both fp16. It is meaningless.")
 
-    def _prepare_for_serialization(self) -> Dict[str, Any]:
+    def _prepare_for_serialization(self) -> dict[str, Any]:
         return {
             "format": self.format,
             "weights": self.weights,
@@ -167,14 +161,14 @@ class QuantizedLayerFactory:
 
 
 def get_quantized_model(
-    hf_auto_model_class: Type["_BaseAutoModelClass"],
+    hf_auto_model_class: type["_BaseAutoModelClass"],
     model_id: str,
-    token: Optional[Union[bool, str]] = None,
-    revision: Optional[str] = None,
-    cache_dir: Optional[str] = None,
+    token: bool | str | None = None,
+    revision: str | None = None,
+    cache_dir: str | None = None,
     force_download: bool = False,
     local_files_only: bool = False,
-    rbln_quantization: Optional[RBLNQuantizationConfig] = None,
+    rbln_quantization: RBLNQuantizationConfig | None = None,
     **kwargs,
 ):
     """
@@ -248,12 +242,12 @@ def get_quantized_model(
 
 def load_weight_files(
     model_id: str,
-    token: Optional[Union[bool, str]] = None,
-    revision: Optional[str] = None,
-    cache_dir: Optional[str] = None,
+    token: bool | str | None = None,
+    revision: str | None = None,
+    cache_dir: str | None = None,
     force_download: bool = False,
     local_files_only: bool = False,
-    exception_keywords: Optional[List[str]] = None,
+    exception_keywords: list[str] | None = None,
 ) -> list[str]:
     """
     Discover and download safetensors files for the given model id.
@@ -301,7 +295,7 @@ def load_weight_files(
 def update_layers_to_quantize(
     module: torch.nn.Module,
     scale_dtype: torch.dtype,
-    rbln_quantization: Optional[RBLNQuantizationConfig] = None,
+    rbln_quantization: RBLNQuantizationConfig | None = None,
 ) -> None:
     """
     Updates specified linear layers to quantized (qlinear) layers in the given module.
@@ -397,7 +391,7 @@ def _coerce_per_out_channel_scale(scale: torch.Tensor, out_features: int) -> tor
     return v.reshape(1, 1).expand(out_features, 1).contiguous()
 
 
-def _kv_split_items(base_key: str, tensor: torch.Tensor) -> List[Tuple[str, torch.Tensor]]:
+def _kv_split_items(base_key: str, tensor: torch.Tensor) -> list[tuple[str, torch.Tensor]]:
     # base_key is the original key whose last token was 'kv_scale'
     # We produce keys with 'k_scale' and 'v_scale' at the self_attn level
     if tensor.ndim == 1 and tensor.numel() >= 2:
@@ -413,11 +407,11 @@ def _kv_split_items(base_key: str, tensor: torch.Tensor) -> List[Tuple[str, torc
 
 def canonicalize_checkpoint_items(
     model: torch.nn.Module,
-    items: Iterable[Tuple[str, torch.Tensor]],
-    rbln_quantization: Optional[RBLNQuantizationConfig],
-) -> List[Tuple[str, torch.Tensor]]:
+    items: Iterable[tuple[str, torch.Tensor]],
+    rbln_quantization: RBLNQuantizationConfig | None,
+) -> list[tuple[str, torch.Tensor]]:
     params = dict(model.named_parameters(recurse=True))
-    results: List[Tuple[str, torch.Tensor]] = []
+    results: list[tuple[str, torch.Tensor]] = []
 
     for key, value in items:
         t = value
@@ -485,8 +479,8 @@ def canonicalize_checkpoint_items(
 
 def load_weights_from_files(
     model: torch.nn.Module,
-    safetensors: List[Dict[str, torch.Tensor]],
-    rbln_quantization: Optional[RBLNQuantizationConfig] = None,
+    safetensors: list[dict[str, torch.Tensor]],
+    rbln_quantization: RBLNQuantizationConfig | None = None,
 ):
     """
     Load safetensor file data directly into the model from provided safetensor files.

--- a/src/optimum/rbln/transformers/utils/rbln_runtime_wrapper.py
+++ b/src/optimum/rbln/transformers/utils/rbln_runtime_wrapper.py
@@ -14,7 +14,7 @@
 
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from torch.nn import Module
 
@@ -67,13 +67,13 @@ class LoopProcessor(Module, ABC):
 
     @abstractmethod
     def _prepare_inputs_for_iteration(
-        self, index: int, common_inputs: Dict[str, Any], *args, **kwargs
-    ) -> Tuple[List[Any], Dict[str, Any]]:
+        self, index: int, common_inputs: dict[str, Any], *args, **kwargs
+    ) -> tuple[list[Any], dict[str, Any]]:
         pass
 
-    def _prepare_inputs_before_loop(self, *args, **kwargs) -> Dict[str, Any]:
+    def _prepare_inputs_before_loop(self, *args, **kwargs) -> dict[str, Any]:
         pass
 
     @abstractmethod
-    def _process_outputs(self, outputs: List[Any], **kwargs) -> Any:
+    def _process_outputs(self, outputs: list[Any], **kwargs) -> Any:
         pass

--- a/src/optimum/rbln/utils/deprecation.py
+++ b/src/optimum/rbln/utils/deprecation.py
@@ -21,9 +21,9 @@
 # **********************************************************************************
 
 import inspect
+from collections.abc import Callable
 from enum import Enum
 from functools import wraps
-from typing import Callable, Optional
 
 import packaging.version
 
@@ -34,7 +34,7 @@ from .logging import get_logger
 logger = get_logger(__name__)
 
 
-def warn_deprecated_npu(npu: Optional[str] = None):
+def warn_deprecated_npu(npu: str | None = None):
     import rebel
 
     npu = npu or rebel.get_npu_name()
@@ -77,12 +77,12 @@ def _at_or_past_deprecation(current: str, deprecated: str) -> bool:
 def deprecate_kwarg(
     old_name: str,
     version: str,
-    new_name: Optional[str] = None,
-    deprecated_type: Optional[type] = None,
-    value_replacer: Optional[Callable] = None,
+    new_name: str | None = None,
+    deprecated_type: type | None = None,
+    value_replacer: Callable | None = None,
     raise_if_greater_or_equal_version: bool = True,
     raise_if_both_names: bool = False,
-    additional_message: Optional[str] = None,
+    additional_message: str | None = None,
 ):
     """
     Function or method decorator to notify users about deprecated keyword arguments, replacing them with a new name if specified,
@@ -219,9 +219,9 @@ def deprecate_kwarg(
 
 def deprecate_method(
     version: str,
-    new_method: Optional[str] = None,
+    new_method: str | None = None,
     raise_if_greater_or_equal_version: bool = True,
-    additional_message: Optional[str] = None,
+    additional_message: str | None = None,
 ):
     """
     Decorator to mark a method as deprecated, optionally pointing to a replacement method.

--- a/src/optimum/rbln/utils/deprecation.py
+++ b/src/optimum/rbln/utils/deprecation.py
@@ -103,7 +103,7 @@ def deprecate_kwarg(
             Name of the deprecated keyword argument, or the argument with a deprecated value type.
         version (`str`):
             The version in which the keyword argument or value type was (or will be) deprecated.
-        new_name (`Optional[str]`, *optional*):
+        new_name (`str | None`, *optional*):
             The new name for the deprecated keyword argument. If specified, the deprecated keyword argument will be replaced with this new name (Scenario 'a').
         deprecated_type (`type`, *optional*):
             The deprecated type for the keyword argument specified by `old_name` (Scenario 'b').
@@ -115,7 +115,7 @@ def deprecate_kwarg(
             Whether to raise `ValueError` if current `optimum.rbln.` version is greater or equal to the deprecated version.
         raise_if_both_names (`bool`, *optional*, defaults to `False`):
             Whether to raise `ValueError` if both deprecated and new keyword arguments are set (only for Scenario 'a').
-        additional_message (`Optional[str]`, *optional*):
+        additional_message (`str | None`, *optional*):
             An additional message to append to the default deprecation message.
 
     Raises:
@@ -232,11 +232,11 @@ def deprecate_method(
     Parameters:
         version (`str`):
             The version in which the method was (or will be) deprecated.
-        new_method (`Optional[str]`, *optional*):
+        new_method (`str | None`, *optional*):
             The name of the new method to use instead. If specified, users will be directed to use this method.
         raise_if_greater_or_equal_version (`bool`, *optional*, defaults to `True`):
             Whether to raise `ValueError` if current `optimum.rbln` version is greater than or equal to the deprecated version.
-        additional_message (`Optional[str]`, *optional*):
+        additional_message (`str | None`, *optional*):
             An additional message to append to the default deprecation message.
     Returns:
         Callable:

--- a/src/optimum/rbln/utils/hub.py
+++ b/src/optimum/rbln/utils/hub.py
@@ -14,18 +14,17 @@
 
 import json
 from pathlib import Path
-from typing import List, Optional, Union
 
 from huggingface_hub import HfApi, get_token, hf_hub_download, try_to_load_from_cache
 from huggingface_hub.errors import LocalEntryNotFoundError
 
 
 def pull_compiled_model_from_hub(
-    model_id: Union[str, Path],
+    model_id: str | Path,
     subfolder: str,
-    token: Union[bool, str],
-    revision: Optional[str],
-    cache_dir: Optional[str],
+    token: bool | str,
+    revision: str | None,
+    cache_dir: str | None,
     force_download: bool,
     local_files_only: bool,
 ) -> Path:
@@ -154,8 +153,8 @@ def pull_compiled_model_from_hub(
 
 
 def validate_files(
-    files: List[Path],
-    config_files: List[Path],
+    files: list[Path],
+    config_files: list[Path],
     location: str,
 ):
     """Validate the presence and count of required files."""
@@ -166,7 +165,7 @@ def validate_files(
         raise FileExistsError(f"Multiple rbln_config.json files found in {location}. This is not expected.")
 
     try:
-        with open(config_files[0], "r") as f:
+        with open(config_files[0]) as f:
             config_data = json.load(f)
         compile_cfgs = config_data.get("_compile_cfgs", [])
         if len(compile_cfgs) == 0:
@@ -179,7 +178,7 @@ def validate_files(
         raise FileNotFoundError(f"Could not find any rbln model file in {location}")
 
 
-def _get_huggingface_token(token: Union[bool, str]) -> str:
+def _get_huggingface_token(token: bool | str) -> str:
     if isinstance(token, str):
         return token
     return get_token()

--- a/src/optimum/rbln/utils/logging.py
+++ b/src/optimum/rbln/utils/logging.py
@@ -35,11 +35,10 @@ import logging
 import os
 import sys
 import threading
-from typing import Optional
 
 
 _lock = threading.Lock()
-_default_handler: Optional[logging.Handler] = None
+_default_handler: logging.Handler | None = None
 
 
 log_levels = {
@@ -98,7 +97,7 @@ def _configure_library_root_logger() -> None:
         library_root_logger.propagate = False
 
 
-def get_logger(name: Optional[str] = None) -> logging.Logger:
+def get_logger(name: str | None = None) -> logging.Logger:
     """
     Return a logger with the specified name.
     """

--- a/src/optimum/rbln/utils/model_utils.py
+++ b/src/optimum/rbln/utils/model_utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import importlib
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:
@@ -53,7 +53,7 @@ def convert_rbln_to_hf_model_name(rbln_model_name: str):
     return rbln_model_name.removeprefix(RBLN_PREFIX)
 
 
-def get_rbln_model_cls(cls_name: str) -> Type["RBLNModel"]:
+def get_rbln_model_cls(cls_name: str) -> type["RBLNModel"]:
     cls = getattr(importlib.import_module("optimum.rbln"), cls_name, None)
     if cls is None:
         if cls_name in MODEL_MAPPING:

--- a/src/optimum/rbln/utils/runtime_utils.py
+++ b/src/optimum/rbln/utils/runtime_utils.py
@@ -16,7 +16,7 @@ import inspect
 import re
 import threading
 from functools import lru_cache
-from typing import Any, List, Optional, Union
+from typing import Any
 
 import rebel
 import torch
@@ -45,7 +45,7 @@ def is_compiler_supports_chiplet_alloc() -> bool:
     return hasattr(rebel.RBLNCompiledModel, "get_alloc_per_chiplet_by_key")
 
 
-def _resolve_npu(npu: Optional[str] = None) -> str:
+def _resolve_npu(npu: str | None = None) -> str:
     if npu is None:
         if not rebel.npu_is_available(0):
             raise RuntimeError("No NPU is available to get available DRAM size.")
@@ -62,7 +62,7 @@ def _dram_spec(npu: str) -> tuple[int, int]:
     raise ValueError(f"Unknown npu name: {npu}")
 
 
-def get_available_dram(npu: Optional[str] = None) -> int:
+def get_available_dram(npu: str | None = None) -> int:
     """
     Get the available DRAM size of the specified NPU at the node (device) level.
 
@@ -83,7 +83,7 @@ def get_available_dram(npu: Optional[str] = None) -> int:
     return dram_nbytes - sys_per_chiplet
 
 
-def get_available_dram_per_chiplet(num_chiplets: int, npu: Optional[str] = None) -> int:
+def get_available_dram_per_chiplet(num_chiplets: int, npu: str | None = None) -> int:
     """
     Get the available DRAM per chiplet. Device DRAM is physically partitioned across
     chiplets, so an allocation pinned to a chiplet must fit within this amount, not the
@@ -120,10 +120,10 @@ def normalize_npu(npu: str) -> str:
 
 
 def tp_and_devices_are_ok(
-    num_devices: Optional[int] = None,
-    device: Optional[Union[int, List[int]]] = None,
-    npu: Optional[str] = None,
-) -> Optional[str]:
+    num_devices: int | None = None,
+    device: int | list[int] | None = None,
+    npu: str | None = None,
+) -> str | None:
     if num_devices is None:
         num_devices = 1
 
@@ -173,7 +173,7 @@ class RBLNPytorchRuntime:
     def __call__(self, *args: Any, **kwds: Any) -> Any:
         return self.forward(*args, **kwds)
 
-    def forward(self, *args: List["torch.Tensor"], **kwargs: "torch.Tensor"):
+    def forward(self, *args: list["torch.Tensor"], **kwargs: "torch.Tensor"):
         # filtering useless args or kwarg such as None.
         args = list(filter(lambda arg: isinstance(arg, torch.Tensor), args))
         kwargs = dict(filter(lambda kwarg: isinstance(kwarg[1], torch.Tensor) or kwarg[0] == "out", kwargs.items()))
@@ -221,7 +221,7 @@ class UnavailableRuntime:
         """Returns an iterator with self as the only item."""
         return iter([self])
 
-    def forward(self, *args: List["torch.Tensor"], **kwargs: "torch.Tensor"):
+    def forward(self, *args: list["torch.Tensor"], **kwargs: "torch.Tensor"):
         """Raises a detailed RuntimeError explaining why inference cannot be performed."""
         raise RuntimeError(
             "Cannot perform inference: RBLN runtime is not available.\n\n"

--- a/src/optimum/rbln/utils/runtime_utils.py
+++ b/src/optimum/rbln/utils/runtime_utils.py
@@ -67,7 +67,7 @@ def get_available_dram(npu: str | None = None) -> int:
     Get the available DRAM size of the specified NPU at the node (device) level.
 
     Args:
-        npu : Optional[str], default=None
+        npu : str | None, default=None
             The NPU to get the available DRAM size.
             If None, the function will attempt to retrieve through `ensure_valid_npu()`
 
@@ -92,7 +92,7 @@ def get_available_dram_per_chiplet(num_chiplets: int, npu: str | None = None) ->
     Args:
         num_chiplets : int
             Number of chiplets the device DRAM is split across.
-        npu : Optional[str], default=None
+        npu : str | None, default=None
             The NPU to get the available DRAM size. Resolved from the local device if None.
 
     Returns:

--- a/src/optimum/rbln/utils/save_utils.py
+++ b/src/optimum/rbln/utils/save_utils.py
@@ -79,9 +79,9 @@ def maybe_save_preprocessors(
     Saves the tokenizer, the processor and the feature extractor when found in `src_dir` in `dest_dir`.
 
     Args:
-        src_dir (`Union[str, Path]`):
+        src_dir (`str | Path`):
             The source directory from which to copy the files.
-        dest_dir (`Union[str, Path]`):
+        dest_dir (`str | Path`):
             The destination directory to copy the files to.
         src_subfolder (`str`, defaults to `""`):
             In case the preprocessor files are located inside a subfolder of the model directory / repo on the Hugging

--- a/src/optimum/rbln/utils/save_utils.py
+++ b/src/optimum/rbln/utils/save_utils.py
@@ -31,7 +31,6 @@ Refer to huggingface/optimum/blob/4fdeea77d71e79451ba53e0c1f9d8f37e9704268/optim
 """
 
 from pathlib import Path
-from typing import List, Union
 
 from transformers import AutoFeatureExtractor, AutoProcessor, AutoTokenizer
 
@@ -42,8 +41,8 @@ logger = get_logger(__name__)
 
 
 def maybe_load_preprocessors(
-    src_name_or_path: Union[str, Path], subfolder: str = "", trust_remote_code: bool = False
-) -> List:
+    src_name_or_path: str | Path, subfolder: str = "", trust_remote_code: bool = False
+) -> list:
     preprocessors = []
     try:
         preprocessors.append(
@@ -71,8 +70,8 @@ def maybe_load_preprocessors(
 
 
 def maybe_save_preprocessors(
-    src_name_or_path: Union[str, Path],
-    dest_dir: Union[str, Path],
+    src_name_or_path: str | Path,
+    dest_dir: str | Path,
     src_subfolder: str = "",
     trust_remote_code: bool = False,
 ):

--- a/src/optimum/rbln/utils/submodule.py
+++ b/src/optimum/rbln/utils/submodule.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import torch
 from transformers import PretrainedConfig
@@ -36,9 +36,9 @@ class SubModulesMixin:
     ]
     """
 
-    _rbln_submodules: List[Dict[str, Any]] = []
+    _rbln_submodules: list[dict[str, Any]] = []
 
-    def __init__(self, *, rbln_submodules: Optional[List["RBLNModel"]] = None, **kwargs) -> None:
+    def __init__(self, *, rbln_submodules: list["RBLNModel"] | None = None, **kwargs) -> None:
         if rbln_submodules is None:
             rbln_submodules = []
         for submodule_meta, submodule in zip(self._rbln_submodules, rbln_submodules, strict=False):
@@ -46,8 +46,8 @@ class SubModulesMixin:
 
     @classmethod
     def _get_submodule_config_class(
-        cls, cls_name: str, submodule_rbln_config: Dict[str, Any]
-    ) -> Type[RBLNModelConfig]:
+        cls, cls_name: str, submodule_rbln_config: dict[str, Any]
+    ) -> type[RBLNModelConfig]:
         if isinstance(submodule_rbln_config, dict) and "cls_name" in submodule_rbln_config:
             config_cls_name = submodule_rbln_config["cls_name"]
             return get_rbln_config_class(config_cls_name)
@@ -58,7 +58,7 @@ class SubModulesMixin:
         cls,
         model: "PreTrainedModel",
         rbln_config: RBLNModelConfig,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
     ):
         return rbln_config
 
@@ -66,18 +66,18 @@ class SubModulesMixin:
     def _update_submodule_rbln_config(
         cls,
         submodule_name: str,
-        submodule_cls: Type["RBLNModel"],
+        submodule_cls: type["RBLNModel"],
         model: "PreTrainedModel",
         submodule_config: PretrainedConfig,
         submodule_rbln_config: RBLNModelConfig,
-        preprocessors: Optional[Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"]],
+        preprocessors: Union["AutoFeatureExtractor", "AutoProcessor", "AutoTokenizer"] | None,
     ):
         return submodule_rbln_config
 
     @classmethod
     def _export_submodules_from_model(
         cls, model: "PreTrainedModel", model_save_dir: str, rbln_config: RBLNModelConfig, **kwargs
-    ) -> List["RBLNModel"]:
+    ) -> list["RBLNModel"]:
         rbln_submodules = []
         submodule_prefix = getattr(cls, "_rbln_submodule_prefix", None)
         submodule_postfix = getattr(cls, "_rbln_submodule_postfix", None)
@@ -111,7 +111,7 @@ class SubModulesMixin:
                 filtered_kwargs["cls_name"] = submodule_config_cls.__name__
                 submodule_rbln_config = submodule_config_cls(**filtered_kwargs)
 
-            submodule_cls: Type["RBLNModel"] = get_rbln_model_cls(submodule_rbln_config.rbln_model_cls_name)
+            submodule_cls: type[RBLNModel] = get_rbln_model_cls(submodule_rbln_config.rbln_model_cls_name)
 
             submodule_rbln_config = cls._update_submodule_rbln_config(
                 submodule_name=submodule_name,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -4,9 +4,9 @@ import random
 import shutil
 import tempfile
 import unittest
+from collections.abc import Iterable
 from contextlib import nullcontext as does_not_raise
 from enum import Enum
-from typing import Iterable
 from unittest.mock import patch
 
 import pytest

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 import tempfile
-from typing import Optional, Tuple
 
 import pytest
 import rebel
@@ -295,7 +294,7 @@ def test_custom_class(model_id):
         return self.model[0](pixel_values)
 
     class RBLNResNetModelConfig(RBLNModelConfig):
-        def __init__(self, batch_size: int = None, image_size: Optional[Tuple[int, int]] = None, **kwargs):
+        def __init__(self, batch_size: int = None, image_size: tuple[int, int] | None = None, **kwargs):
             super().__init__(**kwargs)
             self.batch_size = batch_size or 1
             self.image_size = image_size or (64, 64)


### PR DESCRIPTION
# Pull Request Description

## Type of Change
- [x] Code refactoring

## Changes Overview
Modernizes type annotations across `src` and `tests` to Python 3.10+ native syntax (PEP 585 / PEP 604), enforced via ruff's pyupgrade ruleset.

- `Optional[X]` → `X | None` (UP045)
- `Union[X, Y]` → `X | Y` (UP007)
- `List` / `Dict` / `Tuple` / `Type` → `list` / `dict` / `tuple` / `type` (UP006)
- Drop now-deprecated `typing` imports (UP035, F401)
- `pyproject.toml`: add `UP` to ruff `select`, add `UP037` to `ignore`

161 files changed (+1837 / −1865).

**What this PR deliberately does NOT do:**
- It does **not** add `from __future__ import annotations`. The native syntax evaluates fine at runtime on the supported `>=3.10` range, so the import is unnecessary. Adding it repo-wide would also force the line into ~144 annotation-free files (e.g. `__init__.py`).
- It leaves quoted forward references (`-> "RBLNBaseModel"`, `Union["AutoProcessor", ...]`) intact. Without the future import these quotes are still required, so `UP037` (quote removal) is disabled in the ruff config. ruff correctly keeps `Union[...]` unconverted when its members are quoted forward refs (converting to `|` would apply the operator to `str` operands and raise `TypeError` at definition time).

## Motivation and Context
The project requires `python >=3.10,<3.14`, so the legacy `typing.Optional` / `typing.List` style is redundant. This unifies the codebase on the modern syntax and enables the ruff `UP` rules to prevent regressions.

## Verification
- `ruff check src tests` → all checks pass
- `ruff format` → clean
- Force-imported all 298 submodules to evaluate every function annotation at definition time → **0** annotation-related failures (`TypeError` / `NameError` / `SyntaxError`)
- `import optimum.rbln` → OK, version unchanged

## Related Issues
<!-- none -->

----
# Conventional commit
```
refactor: modernize type annotations to Python 3.10+ syntax
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)