### PR TITLE
other: Cleaner kv cache control

### DIFF
--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import os
 from collections import defaultdict
@@ -6,12 +7,7 @@ from typing import TYPE_CHECKING, Optional, Tuple
 import rebel
 
 from ..utils.logging import get_logger
-from ..utils.runtime_utils import (
-    get_available_dram,
-    get_available_dram_per_chiplet,
-    is_compiler_supports_buffer_resize,
-    is_compiler_supports_chiplet_alloc,
-)
+from ..utils.runtime_utils import get_available_dram_per_chiplet
 
 
 if TYPE_CHECKING:
@@ -177,6 +173,25 @@ class RBLNDecoderOnlyFlashAttentionMixin:
     def set_kvcache_num_blocks_after_compilation(
         cls, compiled_models: dict[str, rebel.RBLNCompiledModel], rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig"
     ):
+        def _log_memory_usage(compiled_models: dict[str, rebel.RBLNCompiledModel], prefix: str):
+            if not logger.isEnabledFor(logging.DEBUG):
+                return
+            for phase, compiled_model in compiled_models.items():
+                logger.debug(f"{prefix} Memory usage of compiled_model[{phase}]:")
+                for key, alloc_per_chiplet in compiled_model.get_alloc_per_chiplet_by_key().items():
+                    logger.debug(
+                        f"  {key}: {[[format_byte_size(size) for size in sizes_at_chiplet] for sizes_at_chiplet in alloc_per_chiplet]}"
+                    )
+
+                logger.debug(f"{prefix} DramTensor sizes in compiled_model[{phase}]:")
+                logger.debug("Please note that the sizes are not aligned. (alignment is not considered)")
+                for key, sizes_at_node in compiled_model.exp_get_dram_tensor_sizes().items():
+                    logger.debug(f"  {key}:")
+                    for node_id, sizes_at_chiplet in enumerate(sizes_at_node):
+                        logger.debug(f"    - node {node_id}: {[format_byte_size(size) for size in sizes_at_chiplet]}")
+
+        _log_memory_usage(compiled_models, "Before adjusting kvcache_num_blocks:")
+
         rbln_config.kvcache_num_blocks = cls.estimate_num_kvcache_blocks(
             compiled_models=compiled_models, rbln_config=rbln_config
         )
@@ -189,12 +204,13 @@ class RBLNDecoderOnlyFlashAttentionMixin:
             compiled_models=compiled_models, rbln_config=rbln_config, multiplier=rbln_config.kvcache_num_blocks
         )
 
+        _log_memory_usage(compiled_models, "After adjusting kvcache_num_blocks:")
+
     @classmethod
     def estimate_num_kvcache_blocks(
         cls,
         compiled_models: dict[str, rebel.RBLNCompiledModel],
         rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
-        available_dram: Optional[int] = None,
     ) -> int:
         if "prefill" not in rbln_config.phases:
             logger.warning(
@@ -206,7 +222,7 @@ class RBLNDecoderOnlyFlashAttentionMixin:
         # total can still OOM a single chiplet; the search below bounds blocks by the
         # tightest chiplet.
         alloc_without_dram, kvcache_tensor_sizes, available_per_chiplet, chiplets = (
-            cls._collect_chiplet_kvcache_inputs(compiled_models, rbln_config, available_dram)
+            cls._collect_chiplet_kvcache_inputs(compiled_models, rbln_config)
         )
         return cls._search_num_kvcache_blocks(
             rbln_config, alloc_without_dram, kvcache_tensor_sizes, available_per_chiplet, chiplets
@@ -217,53 +233,30 @@ class RBLNDecoderOnlyFlashAttentionMixin:
         cls,
         compiled_models: dict[str, rebel.RBLNCompiledModel],
         rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
-        available_dram: Optional[int] = None,
     ) -> Tuple[dict[Tuple[int, int], int], dict[str, list[list[int]]], int, set[Tuple[int, int]]]:
-        # Returns non-KV alloc, KV sizes, per-bucket DRAM budget, and the (node, chiplet)
+        # Returns non-KV alloc, KV sizes, per-chiplet DRAM budget, and the (node, chiplet)
         # buckets to check. ATOM reports one chiplet, so it shares the per-chiplet path.
         alloc_without_dram: dict[Tuple[int, int], int] = defaultdict(int)
         chiplets: set[Tuple[int, int]] = set()
 
-        if is_compiler_supports_chiplet_alloc():
-            for compiled_model in compiled_models.values():
-                for key, alloc_per_chiplet in compiled_model.get_alloc_per_chiplet_by_key().items():
-                    if key == "DramTensor":
-                        continue
-                    for node_id, sizes_at_chiplet in enumerate(alloc_per_chiplet):
-                        for chiplet_id, size in enumerate(sizes_at_chiplet):
-                            alloc_without_dram[(node_id, chiplet_id)] += size
-                            chiplets.add((node_id, chiplet_id))
-
-            # kvcache_tensor_sizes[key][node_id][chiplet_id] = alloc_size
-            kvcache_tensor_sizes: dict[str, list[list[int]]] = compiled_models["prefill"].exp_get_dram_tensor_sizes()
-            for sizes_at_node in kvcache_tensor_sizes.values():
-                for node_id, sizes_at_chiplet in enumerate(sizes_at_node):
-                    for chiplet_id in range(len(sizes_at_chiplet)):
-                        chiplets.add((node_id, chiplet_id))
-
-            num_chiplets = max((chiplet_id for _, chiplet_id in chiplets), default=0) + 1
-            available_per_chiplet = get_available_dram_per_chiplet(num_chiplets, rbln_config.npu)
-            return alloc_without_dram, kvcache_tensor_sizes, available_per_chiplet, chiplets
-
-        # Legacy compiler exposes only node totals, so collapse each node into one bucket
-        # with the whole-node budget; the search then reduces to the node-level check.
         for compiled_model in compiled_models.values():
-            for key, alloc_per_node in compiled_model.get_alloc_per_node_by_key().items():
+            for key, alloc_per_chiplet in compiled_model.get_alloc_per_chiplet_by_key().items():
                 if key == "DramTensor":
                     continue
-                for node_id, size in enumerate(alloc_per_node):
-                    alloc_without_dram[(node_id, 0)] += size
-                    chiplets.add((node_id, 0))
+                for node_id, sizes_at_chiplet in enumerate(alloc_per_chiplet):
+                    for chiplet_id, size in enumerate(sizes_at_chiplet):
+                        alloc_without_dram[(node_id, chiplet_id)] += size
+                        chiplets.add((node_id, chiplet_id))
 
-        # Sum the per-chiplet KV sizes into the single bucket to match alloc's shape.
-        raw_kvcache: dict[str, list[list[int]]] = compiled_models["prefill"].exp_get_dram_tensor_sizes()
-        kvcache_tensor_sizes = {}
-        for key, sizes_at_node in raw_kvcache.items():
-            kvcache_tensor_sizes[key] = [[sum(sizes_at_chiplet)] for sizes_at_chiplet in sizes_at_node]
-            for node_id in range(len(sizes_at_node)):
-                chiplets.add((node_id, 0))
+        # kvcache_tensor_sizes[key][node_id][chiplet_id] = alloc_size
+        kvcache_tensor_sizes: dict[str, list[list[int]]] = compiled_models["prefill"].exp_get_dram_tensor_sizes()
+        for sizes_at_node in kvcache_tensor_sizes.values():
+            for node_id, sizes_at_chiplet in enumerate(sizes_at_node):
+                for chiplet_id in range(len(sizes_at_chiplet)):
+                    chiplets.add((node_id, chiplet_id))
 
-        available_per_chiplet = available_dram if available_dram is not None else get_available_dram(rbln_config.npu)
+        num_chiplets = max((chiplet_id for _, chiplet_id in chiplets), default=0) + 1
+        available_per_chiplet = get_available_dram_per_chiplet(num_chiplets, rbln_config.npu)
         return alloc_without_dram, kvcache_tensor_sizes, available_per_chiplet, chiplets
 
     @classmethod
@@ -339,13 +332,6 @@ class RBLNDecoderOnlyFlashAttentionMixin:
         rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
         multiplier: int,
     ):
-        if not is_compiler_supports_buffer_resize():
-            raise RuntimeError(
-                "The installed version of rebel-compiler does not support automatic kv cache size determination. "
-                "Please upgrade rebel-compiler to a version that supports this feature, "
-                "or explicitly set 'kvcache_num_blocks' in rbln_config to manually specify the cache size."
-            )
-
         for compiled_model in compiled_models.values():
             compiled_model.exp_multiply_buffer_size(
                 {

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -26,7 +26,6 @@ from transformers.modeling_outputs import BaseModelOutputWithPast
 from ....configuration_utils import RBLNCompileConfig
 from ....modeling import RBLNModel
 from ....utils.logging import get_logger
-from ....utils.runtime_utils import is_compiler_supports_buffer_resize
 from ...modeling_attention_utils import (
     RBLNDecoderOnlyFlashAttentionMixin,
     set_default_values,
@@ -328,8 +327,6 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
                 compiled_models[f"decoder_batch_{batch_size}"] = compiled_decoder
 
         if rbln_config.is_auto_num_blocks:
-            if not is_compiler_supports_buffer_resize():
-                raise RuntimeError("`kvcache_num_blocks` must be set.")
             cls.set_kvcache_num_blocks_after_compilation(compiled_models, rbln_config)
 
         return compiled_models

--- a/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
@@ -31,7 +31,6 @@ from transformers.modeling_outputs import BaseModelOutputWithPooling
 from ....configuration_utils import RBLNCompileConfig, RBLNModelConfig
 from ....modeling import RBLNModel
 from ....utils.logging import get_logger
-from ....utils.runtime_utils import is_compiler_supports_buffer_resize
 from ...modeling_attention_utils import validate_sliding_window
 from ...modeling_outputs import RBLNDecoderOnlyOutput
 from ...utils.rbln_runtime_wrapper import LoopProcessor
@@ -403,8 +402,6 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
                 )
 
         if rbln_config.is_auto_num_blocks:
-            if not is_compiler_supports_buffer_resize():
-                raise RuntimeError("`kvcache_num_blocks` must be set.")
             cls.set_kvcache_num_blocks_after_compilation(compiled_models, rbln_config)
 
         return compiled_models

--- a/src/optimum/rbln/utils/runtime_utils.py
+++ b/src/optimum/rbln/utils/runtime_utils.py
@@ -37,14 +37,6 @@ def compiler_num_devices_kwarg() -> str:
     return "num_devices" if "num_devices" in params else "tensor_parallel_size"
 
 
-def is_compiler_supports_buffer_resize() -> bool:
-    return hasattr(rebel.RBLNCompiledModel, "exp_multiply_buffer_size")
-
-
-def is_compiler_supports_chiplet_alloc() -> bool:
-    return hasattr(rebel.RBLNCompiledModel, "get_alloc_per_chiplet_by_key")
-
-
 def _resolve_npu(npu: Optional[str] = None) -> str:
     if npu is None:
         if not rebel.npu_is_available(0):
@@ -60,27 +52,6 @@ def _dram_spec(npu: str) -> tuple[int, int]:
     elif npu.startswith("RBLN-CA"):
         return 16 * 2**30, 288 * 2**20
     raise ValueError(f"Unknown npu name: {npu}")
-
-
-def get_available_dram(npu: Optional[str] = None) -> int:
-    """
-    Get the available DRAM size of the specified NPU at the node (device) level.
-
-    Args:
-        npu : Optional[str], default=None
-            The NPU to get the available DRAM size.
-            If None, the function will attempt to retrieve through `ensure_valid_npu()`
-
-    Returns:
-        int
-            The available DRAM size in bytes.
-    """
-    npu = _resolve_npu(npu)
-    dram_nbytes, sys_per_chiplet = _dram_spec(npu)
-    # Node total = full DRAM minus the per-chiplet system reservation on every chiplet.
-    if npu.startswith("RBLN-CR"):
-        return dram_nbytes - sys_per_chiplet * 4
-    return dram_nbytes - sys_per_chiplet
 
 
 def get_available_dram_per_chiplet(num_chiplets: int, npu: Optional[str] = None) -> int:


### PR DESCRIPTION
# Pull Request Description

> **⚠️ Important: Branch Target**
> - **New features, enhancements, and non-critical fixes**: Merge to `dev` branch
> - **Critical hotfixes only**: Merge to `main` branch (must also merge to `dev`)
> 
> Please ensure you've selected the correct base branch before submitting!

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Release (dev → main merge for production release)
- [ ] New Model Support
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Other (please describe):

## Changes Overview
- Removed `is_compiler_supports_buffer_resize` and `is_compiler_supports_chiplet_alloc` capability checks, which are now always `True` on the supported compiler.
- In `modeling_attention_utils.py`, dropped the legacy node-totals fallback in `_collect_chiplet_kvcache_inputs`, keeping only the per-chiplet allocation path. Removed the `RuntimeError` guard in `multiply_kv_cache_num_blocks`.
- Removed the now-unused `available_dram` parameters from `estimate_num_kvcache_blocks` and `_collect_chiplet_kvcache_inputs`.
- In `decoderonly/modeling_decoderonly.py` and `gemma4/modeling_gemma4.py`, removed the `is_compiler_supports_buffer_resize` import and the `kvcache_num_blocks must be set` guard under `is_auto_num_blocks`.
- Removed the unused `get_available_dram` helper from `runtime_utils.py` (only the legacy path used it; `get_available_dram_per_chiplet` remains).

## Motivation and Context
These capability flags existed to support older `rebel-compiler` versions that lacked `exp_multiply_buffer_size` and `get_alloc_per_chiplet_by_key`. Since the minimum supported compiler now always provides both, the conditional branches and fallback logic are dead code that obscures the active per-chiplet KV cache sizing path. Removing them simplifies the code and reduces maintenance surface.

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Release
    - `release`: Merging dev to main for production release
      - ex) Release v1.2.0
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update