### PR TITLE
performance: post-compilation kvcache_num_blocks CLI and memory_budget for estimation

### DIFF
--- a/src/optimum/rbln/cli.py
+++ b/src/optimum/rbln/cli.py
@@ -16,6 +16,7 @@
 import argparse
 import inspect
 import json
+import shutil
 import sys
 from pathlib import Path
 from typing import Optional
@@ -423,19 +424,22 @@ def _infer_rbln_class_from_model_id(
     return None
 
 
-def _handle_kvcache_num_blocks(model_id: str, get: bool, set_value: Optional[int]) -> None:
+def _handle_kvcache_num_blocks(
+    model_id: str, get: bool, set_value: Optional[int], output_dir: Optional[str] = None
+) -> None:
     """Read or set kvcache_num_blocks on an already-compiled local artifact directory.
 
     `get` prints the current block count from rbln_config.json. `set` rescales the
-    kv-cache buffers in every `*.rbln` to `set_value` blocks and rewrites both the
-    `.rbln` files and rbln_config.json. Stateless: rbln_config.json is the source of
-    truth for the current block count.
+    kv-cache buffers in every `*.rbln` to `set_value` blocks and writes both the
+    `.rbln` files and rbln_config.json. With `output_dir` the source artifact is left
+    untouched and a full resized copy is written there; otherwise the edit is in place.
+    Stateless: rbln_config.json is the source of truth for the current block count.
     """
     from .transformers.modeling_attention_utils import RBLNDecoderOnlyFlashAttentionMixin
     from .transformers.models.decoderonly.configuration_decoderonly import KVCacheMeta
 
-    local_dir = Path(model_id)
-    if not (local_dir.exists() and local_dir.is_dir()):
+    src_dir = Path(model_id)
+    if not (src_dir.exists() and src_dir.is_dir()):
         raise ValueError(
             f"--model-id must be a local compiled-artifact directory for this operation, got '{model_id}'."
         )
@@ -452,21 +456,32 @@ def _handle_kvcache_num_blocks(model_id: str, get: bool, set_value: Optional[int
         print(rbln_config.kvcache_num_blocks)
         return
 
-    rbln_config.kvcache_metas = [
-        m if isinstance(m, KVCacheMeta) else KVCacheMeta(**m) for m in rbln_config.kvcache_metas
-    ]
-    compiled_models = {p.stem: rebel.RBLNCompiledModel(p) for p in sorted(local_dir.glob("*.rbln"))}
+    compiled_models = {p.stem: rebel.RBLNCompiledModel(p) for p in sorted(src_dir.glob("*.rbln"))}
     if not compiled_models:
         raise FileNotFoundError(f"No .rbln compiled models found in '{model_id}'.")
 
+    dst_dir = src_dir if output_dir is None else Path(output_dir)
+    if dst_dir.resolve() != src_dir.resolve():
+        dst_dir.mkdir(parents=True, exist_ok=True)
+        for item in src_dir.iterdir():
+            if item.suffix == ".rbln" or item.name == "rbln_config.json":
+                continue
+            if item.is_dir():
+                shutil.copytree(item, dst_dir / item.name, dirs_exist_ok=True)
+            else:
+                shutil.copy2(item, dst_dir / item.name)
+
+    rbln_config.kvcache_metas = [
+        m if isinstance(m, KVCacheMeta) else KVCacheMeta(**m) for m in rbln_config.kvcache_metas
+    ]
     RBLNDecoderOnlyFlashAttentionMixin.rescale_kvcache_num_blocks(
         compiled_models=compiled_models, rbln_config=rbln_config, target=set_value
     )
     for name, compiled_model in compiled_models.items():
-        compiled_model.save(local_dir / f"{name}.rbln")
+        compiled_model.save(dst_dir / f"{name}.rbln")
     rbln_config.kvcache_num_blocks = set_value
-    rbln_config.save(str(local_dir))
-    print(f"Set kvcache_num_blocks to {set_value} for artifact at {local_dir.absolute()}")
+    rbln_config.save(str(dst_dir))
+    print(f"Set kvcache_num_blocks to {set_value} for artifact at {dst_dir.absolute()}")
 
 
 def main():
@@ -581,7 +596,8 @@ def main():
         type=int,
         default=None,
         metavar="N",
-        help="Resize the kv-cache of the compiled artifact at --model-id to N blocks and exit (no compilation)",
+        help="Resize the kv-cache of the compiled artifact at --model-id to N blocks and exit (no compilation). "
+        "Edits in place unless --output-dir is given, in which case a resized copy is written there.",
     )
 
     # Standard --version that integrates with argparse (works after full parse)
@@ -639,8 +655,13 @@ def main():
 
     # Post-compilation kv-cache block-count operations short-circuit the compile flow.
     if args.get_kvcache_num_blocks or args.set_kvcache_num_blocks is not None:
+        # --output-dir has a compile default; only honor it here when explicitly passed.
+        explicit_output = "--output-dir" in sys.argv or "-o" in sys.argv
+        output_dir = args.output_dir if explicit_output else None
         try:
-            _handle_kvcache_num_blocks(args.model_id, args.get_kvcache_num_blocks, args.set_kvcache_num_blocks)
+            _handle_kvcache_num_blocks(
+                args.model_id, args.get_kvcache_num_blocks, args.set_kvcache_num_blocks, output_dir
+            )
         except Exception as e:
             print(f"❌ Error: {e}", file=sys.stderr)
             sys.exit(1)

--- a/src/optimum/rbln/cli.py
+++ b/src/optimum/rbln/cli.py
@@ -20,10 +20,11 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+import rebel
 from huggingface_hub import hf_hub_download
 
 from .__version__ import __version__
-from .configuration_utils import RBLNModelConfig
+from .configuration_utils import RBLNModelConfig, load_config
 from .utils.model_utils import get_rbln_model_cls
 from .utils.runtime_utils import ContextRblnConfig
 
@@ -422,6 +423,52 @@ def _infer_rbln_class_from_model_id(
     return None
 
 
+def _handle_kvcache_num_blocks(model_id: str, get: bool, set_value: Optional[int]) -> None:
+    """Read or set kvcache_num_blocks on an already-compiled local artifact directory.
+
+    `get` prints the current block count from rbln_config.json. `set` rescales the
+    kv-cache buffers in every `*.rbln` to `set_value` blocks and rewrites both the
+    `.rbln` files and rbln_config.json. Stateless: rbln_config.json is the source of
+    truth for the current block count.
+    """
+    from .transformers.modeling_attention_utils import RBLNDecoderOnlyFlashAttentionMixin
+    from .transformers.models.decoderonly.configuration_decoderonly import KVCacheMeta
+
+    local_dir = Path(model_id)
+    if not (local_dir.exists() and local_dir.is_dir()):
+        raise ValueError(
+            f"--model-id must be a local compiled-artifact directory for this operation, got '{model_id}'."
+        )
+
+    config_cls, _ = load_config(model_id)
+    rbln_config = config_cls.from_pretrained(model_id)
+    if not (hasattr(rbln_config, "kvcache_num_blocks") and hasattr(rbln_config, "kvcache_metas")):
+        raise ValueError(
+            f"The model at '{model_id}' ({config_cls.__name__}) does not expose a top-level "
+            "resizable kv-cache. Only decoder-only causal LM artifacts are supported."
+        )
+
+    if get:
+        print(rbln_config.kvcache_num_blocks)
+        return
+
+    rbln_config.kvcache_metas = [
+        m if isinstance(m, KVCacheMeta) else KVCacheMeta(**m) for m in rbln_config.kvcache_metas
+    ]
+    compiled_models = {p.stem: rebel.RBLNCompiledModel(p) for p in sorted(local_dir.glob("*.rbln"))}
+    if not compiled_models:
+        raise FileNotFoundError(f"No .rbln compiled models found in '{model_id}'.")
+
+    RBLNDecoderOnlyFlashAttentionMixin.rescale_kvcache_num_blocks(
+        compiled_models=compiled_models, rbln_config=rbln_config, target=set_value
+    )
+    for name, compiled_model in compiled_models.items():
+        compiled_model.save(local_dir / f"{name}.rbln")
+    rbln_config.kvcache_num_blocks = set_value
+    rbln_config.save(str(local_dir))
+    print(f"Set kvcache_num_blocks to {set_value} for artifact at {local_dir.absolute()}")
+
+
 def main():
     """
     Main CLI function for optimum-rbln model compilation.
@@ -521,6 +568,22 @@ def main():
         help="Show rbln_config keys for the resolved RBLN class (via --class or inferred from --model-id) and exit",
     )
 
+    # Post-compilation kv-cache block-count operations on an existing --model-id directory
+    parser.add_argument(
+        "--get-kvcache-num-blocks",
+        dest="get_kvcache_num_blocks",
+        action="store_true",
+        help="Print kvcache_num_blocks of the compiled artifact at --model-id and exit (no compilation)",
+    )
+    parser.add_argument(
+        "--set-kvcache-num-blocks",
+        dest="set_kvcache_num_blocks",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Resize the kv-cache of the compiled artifact at --model-id to N blocks and exit (no compilation)",
+    )
+
     # Standard --version that integrates with argparse (works after full parse)
     parser.add_argument(
         "--version",
@@ -573,6 +636,15 @@ def main():
 
     # Parse known args to allow for additional rbln_* arguments
     args, unknown_args = parser.parse_known_args()
+
+    # Post-compilation kv-cache block-count operations short-circuit the compile flow.
+    if args.get_kvcache_num_blocks or args.set_kvcache_num_blocks is not None:
+        try:
+            _handle_kvcache_num_blocks(args.model_id, args.get_kvcache_num_blocks, args.set_kvcache_num_blocks)
+        except Exception as e:
+            print(f"❌ Error: {e}", file=sys.stderr)
+            sys.exit(1)
+        return
 
     try:
         # Resolve or infer model class for compilation

--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -171,16 +171,15 @@ def format_byte_size(nbytes: int) -> str:
 def _resolve_memory_budget(memory_budget: Optional[object], available_total: int) -> int:
     """Resolve `memory_budget` to usable DRAM bytes (system reserve excluded), capped at available_total.
 
-    None -> available_total; "80%" -> that fraction of it; int/"10GB"/"512MB" -> parsed bytes.
+    None -> available_total; a float in (0, 1] -> that fraction of it; int/"10GB"/"512MB" -> parsed bytes.
     `available_total` is the device-wide available DRAM after the per-chiplet system reserve.
     """
     if memory_budget is None:
         return available_total
-    if isinstance(memory_budget, str) and memory_budget.strip().endswith("%"):
-        pct = float(memory_budget.strip()[:-1])
-        if pct <= 0:
-            raise ValueError(f"memory_budget percentage must be positive, got {memory_budget!r}.")
-        budget = int(available_total * pct / 100)
+    if isinstance(memory_budget, float):
+        if not 0.0 < memory_budget <= 1.0:
+            raise ValueError(f"memory_budget as a fraction must be in (0, 1], got {memory_budget}.")
+        budget = int(available_total * memory_budget)
     else:
         budget = parse_byte_size(memory_budget)
     if budget > available_total:

--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Optional, Tuple
 import rebel
 
 from ..utils.logging import get_logger
-from ..utils.runtime_utils import get_available_dram_per_chiplet, get_total_dram, parse_byte_size
+from ..utils.runtime_utils import get_available_dram_per_chiplet, parse_byte_size
 
 
 if TYPE_CHECKING:
@@ -168,23 +168,25 @@ def format_byte_size(nbytes: int) -> str:
         return f"{nbytes / 1024**3:.2f} GB"
 
 
-def _resolve_memory_budget(memory_budget: Optional[object], npu: Optional[str]) -> int:
-    """Resolve `memory_budget` to a device total-DRAM budget in bytes, capped at the NPU total.
+def _resolve_memory_budget(memory_budget: Optional[object], available_total: int) -> int:
+    """Resolve `memory_budget` to usable DRAM bytes (system reserve excluded), capped at available_total.
 
-    None -> NPU total DRAM; "80%" -> that fraction of it; int/"10GB"/"512MB" -> parsed bytes.
+    None -> available_total; "80%" -> that fraction of it; int/"10GB"/"512MB" -> parsed bytes.
+    `available_total` is the device-wide available DRAM after the per-chiplet system reserve.
     """
-    total = get_total_dram(npu)
     if memory_budget is None:
-        return total
+        return available_total
     if isinstance(memory_budget, str) and memory_budget.strip().endswith("%"):
         pct = float(memory_budget.strip()[:-1])
         if pct <= 0:
             raise ValueError(f"memory_budget percentage must be positive, got {memory_budget!r}.")
-        budget = int(total * pct / 100)
+        budget = int(available_total * pct / 100)
     else:
         budget = parse_byte_size(memory_budget)
-    if budget > total:
-        raise ValueError(f"memory_budget ({budget} bytes) exceeds the target NPU's total DRAM ({total} bytes).")
+    if budget > available_total:
+        raise ValueError(
+            f"memory_budget ({budget} bytes) exceeds the target NPU's available DRAM ({available_total} bytes)."
+        )
     return budget
 
 
@@ -276,10 +278,9 @@ class RBLNDecoderOnlyFlashAttentionMixin:
                     chiplets.add((node_id, chiplet_id))
 
         num_chiplets = max((chiplet_id for _, chiplet_id in chiplets), default=0) + 1
-        total_budget = _resolve_memory_budget(rbln_config.memory_budget, rbln_config.npu)
-        available_per_chiplet = get_available_dram_per_chiplet(
-            num_chiplets, rbln_config.npu, total_memory=total_budget
-        )
+        available_total = get_available_dram_per_chiplet(num_chiplets, rbln_config.npu) * num_chiplets
+        budget = _resolve_memory_budget(rbln_config.memory_budget, available_total)
+        available_per_chiplet = budget // num_chiplets
         return alloc_without_dram, kvcache_tensor_sizes, available_per_chiplet, chiplets
 
     @classmethod

--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -341,16 +341,20 @@ class RBLNDecoderOnlyFlashAttentionMixin:
         kvcache_tensor_sizes: dict[str, list[list[int]]],
         rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
         num_blocks: int,
+        current_blocks: int = 1,
     ) -> dict[Tuple[int, int], int]:
-        # Per-(node, chiplet) kv-cache bytes: resizable tensors scale with num_blocks, others stay
-        # at 1, each 2MB-aligned. Alignment is applied after scaling, so bytes grow non-linearly.
+        # Per-(node, chiplet) kv-cache bytes at `num_blocks`. `kvcache_tensor_sizes` reflects the
+        # buffers' current block count (`current_blocks`), so a resizable tensor's per-block bytes
+        # are size // current_blocks, rescaled to num_blocks; others are fixed. Each 2MB-aligned
+        # after scaling, so bytes grow non-linearly.
         can_resize = {meta.name: meta.can_resize for meta in rbln_config.kvcache_metas}
         sizes: dict[Tuple[int, int], int] = defaultdict(int)
         for key, sizes_at_node in kvcache_tensor_sizes.items():
-            m = num_blocks if can_resize[key] else 1
+            resizable = can_resize[key]
             for node_id, sizes_at_chiplet in enumerate(sizes_at_node):
                 for chiplet_id, size in enumerate(sizes_at_chiplet):
-                    sizes[(node_id, chiplet_id)] += align_2MB(size * m)
+                    scaled = size // current_blocks * num_blocks if resizable else size
+                    sizes[(node_id, chiplet_id)] += align_2MB(scaled)
         return sizes
 
     @classmethod
@@ -362,11 +366,15 @@ class RBLNDecoderOnlyFlashAttentionMixin:
     ) -> int:
         """Total device-wide kv-cache DRAM (bytes) at `num_blocks`, with 2MB alignment applied.
 
-        Assumes the block-size-1 compile baseline (as during estimation); the returned bytes are
-        not linear in `num_blocks` because alignment is applied after scaling.
+        Works for any current block size: the buffers' block count is `rbln_config.kvcache_num_blocks`
+        (0 for the unresized compile baseline is treated as 1). Bytes are not linear in `num_blocks`
+        because alignment is applied after scaling.
         """
         kvcache_tensor_sizes = compiled_models["prefill"].exp_get_dram_tensor_sizes()
-        return sum(cls._kvcache_bytes_per_chiplet(kvcache_tensor_sizes, rbln_config, num_blocks).values())
+        current_blocks = rbln_config.kvcache_num_blocks or 1
+        return sum(
+            cls._kvcache_bytes_per_chiplet(kvcache_tensor_sizes, rbln_config, num_blocks, current_blocks).values()
+        )
 
     @classmethod
     def multiply_kv_cache_num_blocks(

--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -171,15 +171,21 @@ def format_byte_size(nbytes: int) -> str:
 def _resolve_memory_budget(memory_budget: Optional[object], available_total: int) -> int:
     """Resolve `memory_budget` to usable DRAM bytes (system reserve excluded), capped at available_total.
 
-    None -> available_total; a float in (0, 1] -> that fraction of it; int/"10GB"/"512MB" -> parsed bytes.
-    `available_total` is the device-wide available DRAM after the per-chiplet system reserve.
+    None -> available_total; a float in (0, 1] (or a "80%" string) -> that fraction of it;
+    int/"10GB"/"512MB" -> parsed bytes. `available_total` is the device-wide available DRAM after
+    the per-chiplet system reserve.
     """
     if memory_budget is None:
         return available_total
+    fraction = None
     if isinstance(memory_budget, float):
-        if not 0.0 < memory_budget <= 1.0:
-            raise ValueError(f"memory_budget as a fraction must be in (0, 1], got {memory_budget}.")
-        budget = int(available_total * memory_budget)
+        fraction = memory_budget
+    elif isinstance(memory_budget, str) and memory_budget.strip().endswith("%"):
+        fraction = float(memory_budget.strip()[:-1]) / 100
+    if fraction is not None:
+        if not 0.0 < fraction <= 1.0:
+            raise ValueError(f"memory_budget fraction must be in (0, 1] (or (0%, 100%]), got {memory_budget!r}.")
+        budget = int(available_total * fraction)
     else:
         budget = parse_byte_size(memory_budget)
     if budget > available_total:

--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Optional, Tuple
 import rebel
 
 from ..utils.logging import get_logger
-from ..utils.runtime_utils import get_available_dram_per_chiplet
+from ..utils.runtime_utils import get_available_dram_per_chiplet, get_total_dram, parse_byte_size
 
 
 if TYPE_CHECKING:
@@ -168,6 +168,26 @@ def format_byte_size(nbytes: int) -> str:
         return f"{nbytes / 1024**3:.2f} GB"
 
 
+def _resolve_memory_budget(memory_budget: Optional[object], npu: Optional[str]) -> int:
+    """Resolve `memory_budget` to a device total-DRAM budget in bytes, capped at the NPU total.
+
+    None -> NPU total DRAM; "80%" -> that fraction of it; int/"10GB"/"512MB" -> parsed bytes.
+    """
+    total = get_total_dram(npu)
+    if memory_budget is None:
+        return total
+    if isinstance(memory_budget, str) and memory_budget.strip().endswith("%"):
+        pct = float(memory_budget.strip()[:-1])
+        if pct <= 0:
+            raise ValueError(f"memory_budget percentage must be positive, got {memory_budget!r}.")
+        budget = int(total * pct / 100)
+    else:
+        budget = parse_byte_size(memory_budget)
+    if budget > total:
+        raise ValueError(f"memory_budget ({budget} bytes) exceeds the target NPU's total DRAM ({total} bytes).")
+    return budget
+
+
 class RBLNDecoderOnlyFlashAttentionMixin:
     @classmethod
     def set_kvcache_num_blocks_after_compilation(
@@ -256,7 +276,10 @@ class RBLNDecoderOnlyFlashAttentionMixin:
                     chiplets.add((node_id, chiplet_id))
 
         num_chiplets = max((chiplet_id for _, chiplet_id in chiplets), default=0) + 1
-        available_per_chiplet = get_available_dram_per_chiplet(num_chiplets, rbln_config.npu)
+        total_budget = _resolve_memory_budget(rbln_config.memory_budget, rbln_config.npu)
+        available_per_chiplet = get_available_dram_per_chiplet(
+            num_chiplets, rbln_config.npu, total_memory=total_budget
+        )
         return alloc_without_dram, kvcache_tensor_sizes, available_per_chiplet, chiplets
 
     @classmethod
@@ -271,23 +294,10 @@ class RBLNDecoderOnlyFlashAttentionMixin:
         remaining_dram_at_chiplet: dict[Tuple[int, int], int] = {
             key: available_per_chiplet - alloc_without_dram.get(key, 0) for key in chiplets
         }
-        kvcache_meta_can_resize: dict[str, bool] = {
-            kvcache_meta.name: kvcache_meta.can_resize for kvcache_meta in rbln_config.kvcache_metas
-        }
-
-        def kvcache_sizes_at_chiplet(multiplier: int) -> dict[Tuple[int, int], int]:
-            # Resize multiplier applies only to resizable tensors; 2MB-aligned.
-            sizes: dict[Tuple[int, int], int] = defaultdict(int)
-            for key, sizes_at_node in kvcache_tensor_sizes.items():
-                m = multiplier if kvcache_meta_can_resize[key] else 1
-                for node_id, sizes_at_chiplet in enumerate(sizes_at_node):
-                    for chiplet_id, size in enumerate(sizes_at_chiplet):
-                        sizes[(node_id, chiplet_id)] += align_2MB(size * m)
-            return sizes
 
         def check_memory_fits(multiplier: int) -> Tuple[bool, dict[Tuple[int, int], int]]:
             # Fits only if every chiplet bucket has room.
-            kvcache_sizes = kvcache_sizes_at_chiplet(multiplier)
+            kvcache_sizes = cls._kvcache_bytes_per_chiplet(kvcache_tensor_sizes, rbln_config, multiplier)
             fits = all(remaining_dram_at_chiplet[key] >= kvcache_sizes.get(key, 0) for key in chiplets)
             return fits, kvcache_sizes
 
@@ -324,6 +334,39 @@ class RBLNDecoderOnlyFlashAttentionMixin:
                 right = mid - 1
 
         return multiplier
+
+    @classmethod
+    def _kvcache_bytes_per_chiplet(
+        cls,
+        kvcache_tensor_sizes: dict[str, list[list[int]]],
+        rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
+        num_blocks: int,
+    ) -> dict[Tuple[int, int], int]:
+        # Per-(node, chiplet) kv-cache bytes: resizable tensors scale with num_blocks, others stay
+        # at 1, each 2MB-aligned. Alignment is applied after scaling, so bytes grow non-linearly.
+        can_resize = {meta.name: meta.can_resize for meta in rbln_config.kvcache_metas}
+        sizes: dict[Tuple[int, int], int] = defaultdict(int)
+        for key, sizes_at_node in kvcache_tensor_sizes.items():
+            m = num_blocks if can_resize[key] else 1
+            for node_id, sizes_at_chiplet in enumerate(sizes_at_node):
+                for chiplet_id, size in enumerate(sizes_at_chiplet):
+                    sizes[(node_id, chiplet_id)] += align_2MB(size * m)
+        return sizes
+
+    @classmethod
+    def _required_memory_at(
+        cls,
+        compiled_models: dict[str, rebel.RBLNCompiledModel],
+        rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
+        num_blocks: int,
+    ) -> int:
+        """Total device-wide kv-cache DRAM (bytes) at `num_blocks`, with 2MB alignment applied.
+
+        Assumes the block-size-1 compile baseline (as during estimation); the returned bytes are
+        not linear in `num_blocks` because alignment is applied after scaling.
+        """
+        kvcache_tensor_sizes = compiled_models["prefill"].exp_get_dram_tensor_sizes()
+        return sum(cls._kvcache_bytes_per_chiplet(kvcache_tensor_sizes, rbln_config, num_blocks).values())
 
     @classmethod
     def multiply_kv_cache_num_blocks(

--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -340,3 +340,51 @@ class RBLNDecoderOnlyFlashAttentionMixin:
                     if kvcache_meta.can_resize
                 }
             )
+
+    @classmethod
+    def rescale_kvcache_num_blocks(
+        cls,
+        compiled_models: dict[str, rebel.RBLNCompiledModel],
+        rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
+        target: int,
+    ):
+        """Resize an already-compiled artifact's kv-cache to `target` blocks.
+
+        The saved buffers hold `per_block * current` bytes, where `current` is the
+        block count resolved at compile time (`rbln_config.kvcache_num_blocks`).
+        Scaling by the rational ratio `target / current` yields `per_block * target`
+        exactly, so `exp_rescale_buffer_size` never rejects the ratio for a
+        block-size-1 baseline.
+        """
+        current = rbln_config.kvcache_num_blocks
+        if current <= 0:
+            raise ValueError(
+                f"Cannot rescale kv-cache: the artifact's current kvcache_num_blocks ({current}) "
+                "is not a resolved positive block count."
+            )
+        if target < rbln_config.num_min_blocks:
+            raise ValueError(
+                f"kvcache_num_blocks={target} is below the minimum required for the full sequence "
+                f"length (num_min_blocks={rbln_config.num_min_blocks})."
+            )
+        for compiled_model in compiled_models.values():
+            if not hasattr(compiled_model, "exp_rescale_buffer_size"):
+                raise RuntimeError(
+                    "The installed rebel-compiler does not support post-compilation kv-cache "
+                    "resizing (`exp_rescale_buffer_size`). Please upgrade rebel-compiler. "
+                    "See https://docs.rbln.ai/about_atom/release_note.html"
+                )
+        if target > current:
+            logger.warning(
+                f"Requested kvcache_num_blocks={target} exceeds the block count chosen at compile "
+                f"time to fit device DRAM ({current}); the model may fail to allocate at runtime. "
+                "Proceeding without a device-fit check."
+            )
+        for compiled_model in compiled_models.values():
+            compiled_model.exp_rescale_buffer_size(
+                {
+                    kvcache_meta.name: (target, current)
+                    for kvcache_meta in rbln_config.kvcache_metas
+                    if kvcache_meta.can_resize
+                }
+            )

--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -380,6 +380,12 @@ class RBLNDecoderOnlyFlashAttentionMixin:
                 f"time to fit device DRAM ({current}); the model may fail to allocate at runtime. "
                 "Proceeding without a device-fit check."
             )
+        if target > rbln_config.num_full_blocks:
+            logger.warning(
+                f"Requested kvcache_num_blocks={target} exceeds num_full_blocks "
+                f"({rbln_config.num_full_blocks}), the blocks needed to cover the full batch at "
+                "max_seq_len; the excess blocks are never used."
+            )
         for compiled_model in compiled_models.values():
             compiled_model.exp_rescale_buffer_size(
                 {

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -53,6 +53,7 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
         lora_config: Optional[Union[Dict[str, Any], RBLNLoRAConfig]] = None,
         prefill_chunk_size: Optional[int] = None,
         kvcache_num_blocks: Optional[int] = None,
+        memory_budget: Optional[Union[int, str]] = None,
         decoder_batch_sizes: Optional[List[int]] = None,
         cache_impl: Optional[CacheImplType] = None,
         sliding_window: Optional[int] = None,
@@ -97,6 +98,10 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
             kvcache_num_blocks (Optional[int]): The total number of blocks to allocate for the
                 PagedAttention KV cache at compile time. Defaults to 0 (automatically determined).
                 See the "KV Cache Number of Blocks (`kvcache_num_blocks`)" section below for details.
+            memory_budget (Optional[Union[int, str]]): Device DRAM budget used when auto-estimating
+                `kvcache_num_blocks`. Accepts bytes as an int or string ("10GB", "512MB"), or a
+                percentage ("80%") of the NPU total DRAM. Defaults to None (the NPU total DRAM).
+                Must not exceed the target NPU's total DRAM.
             decoder_batch_sizes (Optional[List[int]]): A list of batch sizes for which separate decoder models will be compiled.
                 This allows the model to handle varying batch sizes efficiently during generation. If not specified,
                 defaults to a list containing only the model's main batch size. When specifying multiple batch sizes:
@@ -225,6 +230,7 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
             raise ValueError("`prefill_chunk_size` must be a positive integer divisible by 64.")
 
         self.kvcache_num_blocks = kvcache_num_blocks if kvcache_num_blocks is not None else 0
+        self.memory_budget = memory_budget
         self.cache_impl = cache_impl or "static"
         self.sliding_window = sliding_window
         self.sliding_window_layers = sliding_window_layers or []

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -99,10 +99,11 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
                 PagedAttention KV cache at compile time. Defaults to 0 (automatically determined).
                 See the "KV Cache Number of Blocks (`kvcache_num_blocks`)" section below for details.
             memory_budget (Optional[Union[int, float, str]]): Usable DRAM budget (system reserve
-                excluded) used when auto-estimating `kvcache_num_blocks`. Accepts a float in (0, 1]
-                as a fraction of the NPU available DRAM (e.g. 0.8 for 80%), or bytes as an int or
-                string ("10GB", "512MB"). Defaults to None (the full NPU available DRAM). Must not
-                exceed the target NPU's available DRAM.
+                excluded) used when auto-estimating `kvcache_num_blocks`. Prefer a float in (0, 1]
+                as a fraction of the NPU available DRAM (e.g. 0.8 for 80%). A "80%" string is also
+                accepted (convenient for passing through the compile CLI), as are bytes given as an
+                int or string ("10GB", "512MB"). Defaults to None (the full NPU available DRAM).
+                Must not exceed the target NPU's available DRAM.
             decoder_batch_sizes (Optional[List[int]]): A list of batch sizes for which separate decoder models will be compiled.
                 This allows the model to handle varying batch sizes efficiently during generation. If not specified,
                 defaults to a list containing only the model's main batch size. When specifying multiple batch sizes:

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -98,10 +98,10 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
             kvcache_num_blocks (Optional[int]): The total number of blocks to allocate for the
                 PagedAttention KV cache at compile time. Defaults to 0 (automatically determined).
                 See the "KV Cache Number of Blocks (`kvcache_num_blocks`)" section below for details.
-            memory_budget (Optional[Union[int, str]]): Device DRAM budget used when auto-estimating
-                `kvcache_num_blocks`. Accepts bytes as an int or string ("10GB", "512MB"), or a
-                percentage ("80%") of the NPU total DRAM. Defaults to None (the NPU total DRAM).
-                Must not exceed the target NPU's total DRAM.
+            memory_budget (Optional[Union[int, str]]): Usable DRAM budget (system reserve excluded)
+                used when auto-estimating `kvcache_num_blocks`. Accepts bytes as an int or string
+                ("10GB", "512MB"), or a percentage ("80%") of the NPU available DRAM. Defaults to
+                None (the full NPU available DRAM). Must not exceed the target NPU's available DRAM.
             decoder_batch_sizes (Optional[List[int]]): A list of batch sizes for which separate decoder models will be compiled.
                 This allows the model to handle varying batch sizes efficiently during generation. If not specified,
                 defaults to a list containing only the model's main batch size. When specifying multiple batch sizes:

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -53,7 +53,7 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
         lora_config: Optional[Union[Dict[str, Any], RBLNLoRAConfig]] = None,
         prefill_chunk_size: Optional[int] = None,
         kvcache_num_blocks: Optional[int] = None,
-        memory_budget: Optional[Union[int, str]] = None,
+        memory_budget: Optional[Union[int, float, str]] = None,
         decoder_batch_sizes: Optional[List[int]] = None,
         cache_impl: Optional[CacheImplType] = None,
         sliding_window: Optional[int] = None,
@@ -98,10 +98,11 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
             kvcache_num_blocks (Optional[int]): The total number of blocks to allocate for the
                 PagedAttention KV cache at compile time. Defaults to 0 (automatically determined).
                 See the "KV Cache Number of Blocks (`kvcache_num_blocks`)" section below for details.
-            memory_budget (Optional[Union[int, str]]): Usable DRAM budget (system reserve excluded)
-                used when auto-estimating `kvcache_num_blocks`. Accepts bytes as an int or string
-                ("10GB", "512MB"), or a percentage ("80%") of the NPU available DRAM. Defaults to
-                None (the full NPU available DRAM). Must not exceed the target NPU's available DRAM.
+            memory_budget (Optional[Union[int, float, str]]): Usable DRAM budget (system reserve
+                excluded) used when auto-estimating `kvcache_num_blocks`. Accepts a float in (0, 1]
+                as a fraction of the NPU available DRAM (e.g. 0.8 for 80%), or bytes as an int or
+                string ("10GB", "512MB"). Defaults to None (the full NPU available DRAM). Must not
+                exceed the target NPU's available DRAM.
             decoder_batch_sizes (Optional[List[int]]): A list of batch sizes for which separate decoder models will be compiled.
                 This allows the model to handle varying batch sizes efficiently during generation. If not specified,
                 defaults to a list containing only the model's main batch size. When specifying multiple batch sizes:

--- a/src/optimum/rbln/utils/runtime_utils.py
+++ b/src/optimum/rbln/utils/runtime_utils.py
@@ -54,7 +54,16 @@ def _dram_spec(npu: str) -> tuple[int, int]:
     raise ValueError(f"Unknown npu name: {npu}")
 
 
-def get_available_dram_per_chiplet(num_chiplets: int, npu: Optional[str] = None) -> int:
+def get_total_dram(npu: Optional[str] = None) -> int:
+    """Total device DRAM in bytes for the target NPU (resolved from the local device if None)."""
+    npu = _resolve_npu(npu)
+    dram_nbytes, _ = _dram_spec(npu)
+    return dram_nbytes
+
+
+def get_available_dram_per_chiplet(
+    num_chiplets: int, npu: Optional[str] = None, total_memory: Optional[int] = None
+) -> int:
     """
     Get the available DRAM per chiplet. Device DRAM is physically partitioned across
     chiplets, so an allocation pinned to a chiplet must fit within this amount, not the
@@ -65,6 +74,8 @@ def get_available_dram_per_chiplet(num_chiplets: int, npu: Optional[str] = None)
             Number of chiplets the device DRAM is split across.
         npu : Optional[str], default=None
             The NPU to get the available DRAM size. Resolved from the local device if None.
+        total_memory : Optional[int], default=None
+            Override for the device total DRAM in bytes. Defaults to the NPU's total DRAM.
 
     Returns:
         int
@@ -72,7 +83,37 @@ def get_available_dram_per_chiplet(num_chiplets: int, npu: Optional[str] = None)
     """
     npu = _resolve_npu(npu)
     dram_nbytes, sys_per_chiplet = _dram_spec(npu)
+    if total_memory is not None:
+        dram_nbytes = total_memory
     return dram_nbytes // num_chiplets - sys_per_chiplet
+
+
+_BYTE_UNITS = {"B": 1, "KB": 2**10, "MB": 2**20, "GB": 2**30, "TB": 2**40}
+
+
+def parse_byte_size(value: Union[int, str]) -> int:
+    """Parse a byte size given as an int (bytes) or a string like "10GB" / "512MB".
+
+    Units are case-insensitive and binary (KB=2**10 ... TB=2**40). Returns a positive int of bytes.
+    """
+    if isinstance(value, bool):
+        raise ValueError(f"Invalid byte size: {value!r}")
+    if isinstance(value, int):
+        nbytes = value
+    elif isinstance(value, str):
+        match = re.fullmatch(r"\s*(\d+)\s*([KMGT]?B)?\s*", value, re.IGNORECASE)
+        if not match:
+            raise ValueError(
+                f"Invalid byte size {value!r}. Expected an integer optionally suffixed with "
+                "B, KB, MB, GB, or TB (e.g. '10GB')."
+            )
+        unit = match.group(2)
+        nbytes = int(match.group(1)) * (_BYTE_UNITS[unit.upper()] if unit else 1)
+    else:
+        raise ValueError(f"Invalid byte size type: {type(value).__name__}")
+    if nbytes <= 0:
+        raise ValueError(f"Byte size must be positive, got {nbytes}.")
+    return nbytes
 
 
 def normalize_npu(npu: str) -> str:

--- a/src/optimum/rbln/utils/runtime_utils.py
+++ b/src/optimum/rbln/utils/runtime_utils.py
@@ -54,16 +54,7 @@ def _dram_spec(npu: str) -> tuple[int, int]:
     raise ValueError(f"Unknown npu name: {npu}")
 
 
-def get_total_dram(npu: Optional[str] = None) -> int:
-    """Total device DRAM in bytes for the target NPU (resolved from the local device if None)."""
-    npu = _resolve_npu(npu)
-    dram_nbytes, _ = _dram_spec(npu)
-    return dram_nbytes
-
-
-def get_available_dram_per_chiplet(
-    num_chiplets: int, npu: Optional[str] = None, total_memory: Optional[int] = None
-) -> int:
+def get_available_dram_per_chiplet(num_chiplets: int, npu: Optional[str] = None) -> int:
     """
     Get the available DRAM per chiplet. Device DRAM is physically partitioned across
     chiplets, so an allocation pinned to a chiplet must fit within this amount, not the
@@ -74,8 +65,6 @@ def get_available_dram_per_chiplet(
             Number of chiplets the device DRAM is split across.
         npu : Optional[str], default=None
             The NPU to get the available DRAM size. Resolved from the local device if None.
-        total_memory : Optional[int], default=None
-            Override for the device total DRAM in bytes. Defaults to the NPU's total DRAM.
 
     Returns:
         int
@@ -83,8 +72,6 @@ def get_available_dram_per_chiplet(
     """
     npu = _resolve_npu(npu)
     dram_nbytes, sys_per_chiplet = _dram_spec(npu)
-    if total_memory is not None:
-        dram_nbytes = total_memory
     return dram_nbytes // num_chiplets - sys_per_chiplet
 
 


### PR DESCRIPTION
## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Overview
Two related capabilities for controlling the decoder-only kv-cache block count:

1. **Post-compilation CLI** to inspect/resize `kvcache_num_blocks` on an already-compiled artifact, without recompiling.
2. **Compile-time `memory_budget`** to bound the DRAM the automatic block estimation may assume.

## 1. Post-compilation CLI
Two subcommands on `optimum-rbln-cli` operating on an artifact directory (`--model-id DIR`):
- `--get-kvcache-num-blocks` — prints `kvcache_num_blocks` from `rbln_config.json`.
- `--set-kvcache-num-blocks N` — resizes the kv-cache of every `*.rbln` to `N` blocks and writes the `.rbln` files and `rbln_config.json`. Edits in place, or with `--output-dir` writes a full resized copy there (copying the non-`.rbln` files too) and leaves the source untouched.

```bash
# Read the current kv-cache block count
optimum-rbln-cli --get-kvcache-num-blocks --model-id ./my_artifact

# Resize in place to 128 blocks
optimum-rbln-cli --set-kvcache-num-blocks 128 --model-id ./my_artifact

# Resize into a new directory, leaving the source untouched
optimum-rbln-cli --set-kvcache-num-blocks 128 --model-id ./my_artifact --output-dir ./my_artifact_128
```

Internals — new `RBLNDecoderOnlyFlashAttentionMixin.rescale_kvcache_num_blocks(compiled_models, rbln_config, target)`:
- Saved kv-cache buffers hold `per_block * current` bytes (`current = rbln_config.kvcache_num_blocks`). Rescaling by the rational ratio `target / current` (rebel-compiler `exp_rescale_buffer_size`) yields exactly `per_block * target`.
- Stateless: `rbln_config.json` is the single source of truth for the current block count.
- `target < num_min_blocks` → `ValueError` (config only). Non-fatal warnings (config only): `target` above the compile-time count (may not fit device DRAM), and `target` above `num_full_blocks` (excess blocks never used). Older rebel-compiler without the API → clear `RuntimeError` via `hasattr` capability detection.

Depends on rebel-compiler's new `exp_rescale_buffer_size` (rebellions-sw/rebel_compiler#12067).

## 2. Compile-time `memory_budget`
`RBLNDecoderOnlyModelConfig` gains a `memory_budget` member that caps the device DRAM the automatic `kvcache_num_blocks` estimation may assume:
- Prefer a float in (0, 1] as a fraction of the NPU available DRAM (e.g. `0.8` for 80%, matching vllm's `gpu_memory_utilization`). A `"80%"` string is also accepted (handy for passing through the compile CLI), as are bytes given as an int or string (`"10GB"`, `"512MB"`). The fraction is of usable memory (after the per-chiplet system reserve), not the raw total.
- Defaults to the full available DRAM and must not exceed it (`ValueError` otherwise). The budget is split evenly per chiplet with no further reserve subtraction (already excluded), so the default reproduces current estimation exactly.
- Flows through the compile CLI as a forwarded `rbln_config` key:

```bash
optimum-rbln-cli --model-id meta-llama/Llama-2-7b-chat-hf --memory-budget 0.8
optimum-rbln-cli --model-id meta-llama/Llama-2-7b-chat-hf --memory-budget 80%
optimum-rbln-cli --model-id meta-llama/Llama-2-7b-chat-hf --memory-budget 100GB
```

Also adds `RBLNDecoderOnlyFlashAttentionMixin._required_memory_at(compiled_models, rbln_config, num_blocks)`, returning the device-wide kv-cache DRAM at a given block count with 2MB alignment applied (non-linear in the block count). It works for any current block size — resizable tensors are normalized to per-block bytes using `rbln_config.kvcache_num_blocks`. The aligned per-chiplet math is factored into `_kvcache_bytes_per_chiplet`, shared with the block search (unchanged behavior).

## Motivation and Context
- Users need to tune `kvcache_num_blocks` on a compiled artifact without recompiling the whole model (CLI).
- Users need to constrain kv-cache block estimation to a memory budget smaller than the full device (e.g. to leave headroom), expressed intuitively in bytes or a percentage (`memory_budget`).

## How to test
- CLI: on a compiled decoder-only artifact, `--get` prints the stored count; `--set N` (N ≥ num_min_blocks) rewrites the kv-cache buffers to `per_block * N` and updates the config (verified by reloading the `.rbln`); `--set` below `num_min_blocks` raises `ValueError`; `--output-dir` leaves the source untouched.
- `memory_budget`: estimation with a smaller budget yields fewer blocks (monotonic), `None` reproduces the current result, and a budget above the NPU total raises `ValueError`. `_required_memory_at(N)` is monotonic in `N`, equals the current footprint at `N = kvcache_num_blocks`, and stays correct for an already-resized artifact.
