### PR TITLE
other(ci): trigger Buildkite model-generation pipeline on tag release

### DIFF
--- a/.github/workflows/deploy-on-tag.yaml
+++ b/.github/workflows/deploy-on-tag.yaml
@@ -66,20 +66,25 @@ jobs:
     container:
       image: ${{ vars.DEV_CONTAINER_IMAGE }}
     steps:
-      - uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GIT_PAT }}
-          script: |
-            const result = await github.rest.actions.createWorkflowDispatch({
-              owner: 'rebellions-sw',
-              repo: 'rebel_compiler',
-              workflow_id: 'rebel_dispatch_model_generation_for_vllm.yaml',
-              ref: 'dev',
-              inputs: {
-                optimum_rbln_version: "${{ github.ref_name }}",
-              }
-            })
-            console.log(result)
+      # rebel_compiler's model-generation CI was migrated from GitHub Actions to
+      # Buildkite/Obedients, so trigger the Obedients pipeline directly (create a
+      # build via the BK-compatible REST API) instead of a workflow_dispatch.
+      # The pipeline reads OPTIMUM_RBLN_VERSION to pin the just-released tag.
+      - name: Trigger Obedients model-generation pipeline
+        env:
+          OBEDIENTS_API_TOKEN: ${{ secrets.OBEDIENTS_API_TOKEN }}
+          OPTIMUM_RBLN_VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          command -v jq >/dev/null 2>&1 || (apt-get update && apt-get install -y jq curl)
+          curl -fsS --retry 5 --retry-max-time 120 -X POST \
+            "https://obedients-api.k8s.rebellions.in/v2/organizations/main/pipelines/standalone-rebel-compiler-model-generation-vllm-rbln-pr-ci/builds" \
+            -H "Authorization: Bearer ${OBEDIENTS_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n --arg ver "$OPTIMUM_RBLN_VERSION" \
+              '{commit: "HEAD", branch: "dev",
+                message: ("optimum-rbln " + $ver + " → model generation for vllm-rbln CI"),
+                env: {OPTIMUM_RBLN_VERSION: $ver, VLLM_RBLN_REF: "dev"}}')"
 
   bc-compile:
     name: BC compile for release tag

--- a/.github/workflows/deploy-on-tag.yaml
+++ b/.github/workflows/deploy-on-tag.yaml
@@ -66,10 +66,6 @@ jobs:
     container:
       image: ${{ vars.DEV_CONTAINER_IMAGE }}
     steps:
-      # rebel_compiler's model-generation CI was migrated from GitHub Actions to
-      # Buildkite/Obedients, so trigger the Obedients pipeline directly (create a
-      # build via the BK-compatible REST API) instead of a workflow_dispatch.
-      # The pipeline reads OPTIMUM_RBLN_VERSION to pin the just-released tag.
       - name: Trigger Obedients model-generation pipeline
         env:
           OBEDIENTS_API_TOKEN: ${{ secrets.OBEDIENTS_API_TOKEN }}


### PR DESCRIPTION
# Pull Request Description
Change the `trigger-vllm-model-compilation` job in `deploy-on-tag.yaml` (runs on tag release)
to **create a Buildkite (Obedients) build directly** instead of a GitHub Actions `workflow_dispatch`.

- Before: dispatched `rebel_compiler`'s `rebel_dispatch_model_generation_for_vllm.yaml`.
- After: creates a build through the Obedients API.
  - `Authorization: Bearer $OBEDIENTS_API_TOKEN`
  - body: `branch=dev`, `commit=HEAD`, `env.OPTIMUM_RBLN_VERSION=<released tag>`, `env.VLLM_RBLN_REF=dev`

## Notes / Checklist (required before merge)
- [ ] Add the **`OBEDIENTS_API_TOKEN`** secret to the optimum-rbln repo (not present today; the same Obedients API token used in rebel_compiler)

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Release (dev → main merge for production release)
- [ ] New Model Support
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Release
    - `release`: Merging dev to main for production release
      - ex) Release v1.2.0
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update