### PR TITLE
other: resolve latest compiler version from Obedients nightly build

### DIFF
--- a/.github/workflows/auto_compiler_update_impl.yaml
+++ b/.github/workflows/auto_compiler_update_impl.yaml
@@ -30,22 +30,37 @@ jobs:
           API="${OBEDIENTS_API_URL}/v2/organizations/main/pipelines/nightly"
           AUTH="Authorization: Bearer ${OBEDIENTS_API_TOKEN}"
 
-          # 1. Latest passed nightly build on dev (list is newest-first).
+          # 1. Latest passed *amd64* nightly build on dev. The list also
+          #    contains "nightly-build-AArch64" (ARM) and nixl-triggered
+          #    builds; only the canonical "nightly-build" carries the amd64
+          #    prod package + version manifest, so filter by message.
           BUILD_NUMBER=$( \
             curl -fsS --retry 5 --retry-max-time 120 -H "$AUTH" \
-              "${API}/builds?branch=dev&state=passed&per_page=1" \
-            | jq -r '(.items // .)[0].number' \
+              "${API}/builds?branch=dev&state=passed&per_page=30" \
+            | jq -r 'first((.items // .)[] | select(.message=="nightly-build") | .number) // empty' \
           )
+          if [ -z "$BUILD_NUMBER" ]; then
+            echo "No passed 'nightly-build' found on dev" >&2
+            exit 1
+          fi
 
           # 2. Locate the version manifest artifact produced by that build.
           DL_URL=$( \
             curl -fsS --retry 5 --retry-max-time 120 -H "$AUTH" \
               "${API}/builds/${BUILD_NUMBER}/artifacts" \
-            | jq -r '(.items // .)[] | select(.filename=="compiler-nightly-version") | .download_url' \
+            | jq -r 'first((.items // .)[] | select(.filename=="compiler-nightly-version") | .download_url) // empty' \
           )
+          if [ -z "$DL_URL" ]; then
+            echo "compiler-nightly-version artifact missing on build #${BUILD_NUMBER}" >&2
+            exit 1
+          fi
 
           # 3. Read VERSION_PROD (download_url is pre-signed, no auth header needed).
           LATEST_VERSION=$(curl -fsSL --retry 5 "$DL_URL" | grep '^VERSION_PROD=' | cut -d '=' -f2-)
+          if [ -z "$LATEST_VERSION" ]; then
+            echo "VERSION_PROD not found in manifest of build #${BUILD_NUMBER}" >&2
+            exit 1
+          fi
 
           CUR_VERSION=$(grep rebel_compiler_version .github/version.yaml | cut -d ':' -f2 | tr -d ' ')
 

--- a/.github/workflows/auto_compiler_update_impl.yaml
+++ b/.github/workflows/auto_compiler_update_impl.yaml
@@ -22,15 +22,36 @@ jobs:
 
       - name: Get compiler version
         id: get_version
+        env:
+          OBEDIENTS_API_TOKEN: ${{ secrets.OBEDIENTS_API_TOKEN }}
+          OBEDIENTS_API_URL: ${{ secrets.OBEDIENTS_API_URL }}
         run: |
+          set -euo pipefail
+          API="${OBEDIENTS_API_URL}/v2/organizations/main/pipelines/nightly"
+          AUTH="Authorization: Bearer ${OBEDIENTS_API_TOKEN}"
+
+          # 1. Latest passed nightly build on dev (list is newest-first).
+          BUILD_NUMBER=$( \
+            curl -fsS --retry 5 --retry-max-time 120 -H "$AUTH" \
+              "${API}/builds?branch=dev&state=passed&per_page=1" \
+            | jq -r '(.items // .)[0].number' \
+          )
+
+          # 2. Locate the version manifest artifact produced by that build.
+          DL_URL=$( \
+            curl -fsS --retry 5 --retry-max-time 120 -H "$AUTH" \
+              "${API}/builds/${BUILD_NUMBER}/artifacts" \
+            | jq -r '(.items // .)[] | select(.filename=="compiler-nightly-version") | .download_url' \
+          )
+
+          # 3. Read VERSION_PROD (download_url is pre-signed, no auth header needed).
+          LATEST_VERSION=$(curl -fsSL --retry 5 "$DL_URL" | grep '^VERSION_PROD=' | cut -d '=' -f2-)
+
           CUR_VERSION=$(grep rebel_compiler_version .github/version.yaml | cut -d ':' -f2 | tr -d ' ')
-          LATEST_VERSION=$( \
-                            curl -s "${{ secrets.DEV_PKG_URL }}/rebel-compiler/json" | \
-                            jq -r '.releases | keys | .[]' | \
-                            grep prod | \
-                            grep -v "latestumd" | \
-                            python .github/scripts/parsing_latest_version.py
-                          )
+
+          echo "Latest (nightly build #${BUILD_NUMBER}): $LATEST_VERSION"
+          echo "Current (.github/version.yaml): $CUR_VERSION"
+
           echo "compiler_version=$LATEST_VERSION" >> $GITHUB_OUTPUT
           echo "cur_version=$CUR_VERSION" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/auto_compiler_update_impl.yaml
+++ b/.github/workflows/auto_compiler_update_impl.yaml
@@ -37,7 +37,7 @@ jobs:
           BUILD_NUMBER=$( \
             curl -fsS --retry 5 --retry-max-time 120 -H "$AUTH" \
               "${API}/builds?branch=dev&state=passed&per_page=30" \
-            | jq -r 'first((.items // .)[] | select(.message=="nightly-build") | .number) // empty' \
+            | jq -r 'first((if type=="array" then . else .items end)[] | select(.message=="nightly-build") | .number) // empty' \
           )
           if [ -z "$BUILD_NUMBER" ]; then
             echo "No passed 'nightly-build' found on dev" >&2
@@ -48,7 +48,7 @@ jobs:
           DL_URL=$( \
             curl -fsS --retry 5 --retry-max-time 120 -H "$AUTH" \
               "${API}/builds/${BUILD_NUMBER}/artifacts" \
-            | jq -r 'first((.items // .)[] | select(.filename=="compiler-nightly-version") | .download_url) // empty' \
+            | jq -r 'first((if type=="array" then . else .items end)[] | select(.filename=="compiler-nightly-version") | .download_url) // empty' \
           )
           if [ -z "$DL_URL" ]; then
             echo "compiler-nightly-version artifact missing on build #${BUILD_NUMBER}" >&2


### PR DESCRIPTION
## Problem

The auto compiler update workflow (`auto_compiler_update_impl.yaml`) picked the "latest" prod compiler version by **PEP 440-sorting the package registry's version strings** via `parsing_latest_version.py`.

rebel-compiler uses `setuptools_scm`-style versions where the `.devN` segment is the **commit distance from the last tag**. That count resets across branches, so a chronologically newer build can have a *smaller* N. Concretely:

| build | commit | date | version |
|-------|--------|------|---------|
| side branch | `8b9056e9` | 2026-07-07 | `0.11.1.dev501+g8b9056e9.prod` |
| dev HEAD (nightly #441) | `6beed8a0` | 2026-07-14 | `0.11.1.dev351+g6beed8a0.prod` |

Because `dev351 < dev501` under PEP 440, the workflow pinned `dev` to the **older side-branch build** and would never advance to the real latest dev build (e.g. run [29361990709](https://github.com/RBLN-SW/optimum-rbln/actions/runs/29361990709) skipped `create-pr`).

## Fix

Resolve the version from the **latest passed `nightly` build on `dev`** in Obedients, reading `VERSION_PROD` from its `compiler-nightly-version` artifact:

1. `GET /pipelines/nightly/builds?branch=dev&state=passed&per_page=1` -> latest build (newest-first)
2. find the `compiler-nightly-version` artifact of that build
3. parse `VERSION_PROD` from it (download URL is pre-signed)

This tracks the actual dev HEAD, and `branch=dev&state=passed` filters out side-branch prod uploads. Both versions are now logged so a skipped `create-pr` is explainable from the run output.

Follows the Obedients API pattern from #630.

## Required before merge

- [x] `OBEDIENTS_API_TOKEN` secret (already added)
- [x] `OBEDIENTS_API_URL` secret (Obedients API origin)

## Notes

- `parsing_latest_version.py` and `DEV_PKG_URL` are left in place -- still used by `bc_latest_tag.yaml` and `rbln_optimum_pytest.yaml` respectively.
- jq/curl response shape handled defensively with `(.items // .)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)