### PR TITLE
performance: add memory_budget for kv-cache block estimation

### DIFF
--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Optional, Tuple
 import rebel
 
 from ..utils.logging import get_logger
-from ..utils.runtime_utils import get_available_dram_per_chiplet
+from ..utils.runtime_utils import get_available_dram_per_chiplet, parse_byte_size
 
 
 if TYPE_CHECKING:
@@ -168,6 +168,33 @@ def format_byte_size(nbytes: int) -> str:
         return f"{nbytes / 1024**3:.2f} GB"
 
 
+def _resolve_memory_budget(memory_budget: Optional[object], available_total: int) -> int:
+    """Resolve `memory_budget` to usable DRAM bytes (system reserve excluded), capped at available_total.
+
+    None -> available_total; a float in (0, 1] (or a "80%" string) -> that fraction of it;
+    int/"10GB"/"512MB" -> parsed bytes. `available_total` is the device-wide available DRAM after
+    the per-chiplet system reserve.
+    """
+    if memory_budget is None:
+        return available_total
+    fraction = None
+    if isinstance(memory_budget, float):
+        fraction = memory_budget
+    elif isinstance(memory_budget, str) and memory_budget.strip().endswith("%"):
+        fraction = float(memory_budget.strip()[:-1]) / 100
+    if fraction is not None:
+        if not 0.0 < fraction <= 1.0:
+            raise ValueError(f"memory_budget fraction must be in (0, 1] (or (0%, 100%]), got {memory_budget!r}.")
+        budget = int(available_total * fraction)
+    else:
+        budget = parse_byte_size(memory_budget)
+    if budget > available_total:
+        raise ValueError(
+            f"memory_budget ({budget} bytes) exceeds the target NPU's available DRAM ({available_total} bytes)."
+        )
+    return budget
+
+
 class RBLNDecoderOnlyFlashAttentionMixin:
     @classmethod
     def set_kvcache_num_blocks_after_compilation(
@@ -256,7 +283,9 @@ class RBLNDecoderOnlyFlashAttentionMixin:
                     chiplets.add((node_id, chiplet_id))
 
         num_chiplets = max((chiplet_id for _, chiplet_id in chiplets), default=0) + 1
-        available_per_chiplet = get_available_dram_per_chiplet(num_chiplets, rbln_config.npu)
+        available_total = get_available_dram_per_chiplet(num_chiplets, rbln_config.npu) * num_chiplets
+        budget = _resolve_memory_budget(rbln_config.memory_budget, available_total)
+        available_per_chiplet = budget // num_chiplets
         return alloc_without_dram, kvcache_tensor_sizes, available_per_chiplet, chiplets
 
     @classmethod
@@ -271,23 +300,10 @@ class RBLNDecoderOnlyFlashAttentionMixin:
         remaining_dram_at_chiplet: dict[Tuple[int, int], int] = {
             key: available_per_chiplet - alloc_without_dram.get(key, 0) for key in chiplets
         }
-        kvcache_meta_can_resize: dict[str, bool] = {
-            kvcache_meta.name: kvcache_meta.can_resize for kvcache_meta in rbln_config.kvcache_metas
-        }
-
-        def kvcache_sizes_at_chiplet(multiplier: int) -> dict[Tuple[int, int], int]:
-            # Resize multiplier applies only to resizable tensors; 2MB-aligned.
-            sizes: dict[Tuple[int, int], int] = defaultdict(int)
-            for key, sizes_at_node in kvcache_tensor_sizes.items():
-                m = multiplier if kvcache_meta_can_resize[key] else 1
-                for node_id, sizes_at_chiplet in enumerate(sizes_at_node):
-                    for chiplet_id, size in enumerate(sizes_at_chiplet):
-                        sizes[(node_id, chiplet_id)] += align_2MB(size * m)
-            return sizes
 
         def check_memory_fits(multiplier: int) -> Tuple[bool, dict[Tuple[int, int], int]]:
             # Fits only if every chiplet bucket has room.
-            kvcache_sizes = kvcache_sizes_at_chiplet(multiplier)
+            kvcache_sizes = cls._kvcache_bytes_per_chiplet(kvcache_tensor_sizes, rbln_config, multiplier)
             fits = all(remaining_dram_at_chiplet[key] >= kvcache_sizes.get(key, 0) for key in chiplets)
             return fits, kvcache_sizes
 
@@ -324,6 +340,47 @@ class RBLNDecoderOnlyFlashAttentionMixin:
                 right = mid - 1
 
         return multiplier
+
+    @classmethod
+    def _kvcache_bytes_per_chiplet(
+        cls,
+        kvcache_tensor_sizes: dict[str, list[list[int]]],
+        rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
+        num_blocks: int,
+        current_blocks: int = 1,
+    ) -> dict[Tuple[int, int], int]:
+        # Per-(node, chiplet) kv-cache bytes at `num_blocks`. `kvcache_tensor_sizes` reflects the
+        # buffers' current block count (`current_blocks`), so a resizable tensor's per-block bytes
+        # are size // current_blocks, rescaled to num_blocks; others are fixed. Each 2MB-aligned
+        # after scaling, so bytes grow non-linearly.
+        can_resize = {meta.name: meta.can_resize for meta in rbln_config.kvcache_metas}
+        sizes: dict[Tuple[int, int], int] = defaultdict(int)
+        for key, sizes_at_node in kvcache_tensor_sizes.items():
+            resizable = can_resize[key]
+            for node_id, sizes_at_chiplet in enumerate(sizes_at_node):
+                for chiplet_id, size in enumerate(sizes_at_chiplet):
+                    scaled = size // current_blocks * num_blocks if resizable else size
+                    sizes[(node_id, chiplet_id)] += align_2MB(scaled)
+        return sizes
+
+    @classmethod
+    def _required_memory_at(
+        cls,
+        compiled_models: dict[str, rebel.RBLNCompiledModel],
+        rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
+        num_blocks: int,
+    ) -> int:
+        """Total device-wide kv-cache DRAM (bytes) at `num_blocks`, with 2MB alignment applied.
+
+        Works for any current block size: the buffers' block count is `rbln_config.kvcache_num_blocks`
+        (0 for the unresized compile baseline is treated as 1). Bytes are not linear in `num_blocks`
+        because alignment is applied after scaling.
+        """
+        kvcache_tensor_sizes = compiled_models["prefill"].exp_get_dram_tensor_sizes()
+        current_blocks = rbln_config.kvcache_num_blocks or 1
+        return sum(
+            cls._kvcache_bytes_per_chiplet(kvcache_tensor_sizes, rbln_config, num_blocks, current_blocks).values()
+        )
 
     @classmethod
     def multiply_kv_cache_num_blocks(

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -53,6 +53,7 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
         lora_config: Optional[Union[Dict[str, Any], RBLNLoRAConfig]] = None,
         prefill_chunk_size: Optional[int] = None,
         kvcache_num_blocks: Optional[int] = None,
+        memory_budget: Optional[Union[int, float, str]] = None,
         decoder_batch_sizes: Optional[List[int]] = None,
         cache_impl: Optional[CacheImplType] = None,
         sliding_window: Optional[int] = None,
@@ -97,6 +98,12 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
             kvcache_num_blocks (Optional[int]): The total number of blocks to allocate for the
                 PagedAttention KV cache at compile time. Defaults to 0 (automatically determined).
                 See the "KV Cache Number of Blocks (`kvcache_num_blocks`)" section below for details.
+            memory_budget (Optional[Union[int, float, str]]): Usable DRAM budget (system reserve
+                excluded) used when auto-estimating `kvcache_num_blocks`. Prefer a float in (0, 1]
+                as a fraction of the NPU available DRAM (e.g. 0.8 for 80%). A "80%" string is also
+                accepted (convenient for passing through the compile CLI), as are bytes given as an
+                int or string ("10GB", "512MB"). Defaults to None (the full NPU available DRAM).
+                Must not exceed the target NPU's available DRAM.
             decoder_batch_sizes (Optional[List[int]]): A list of batch sizes for which separate decoder models will be compiled.
                 This allows the model to handle varying batch sizes efficiently during generation. If not specified,
                 defaults to a list containing only the model's main batch size. When specifying multiple batch sizes:
@@ -225,6 +232,7 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
             raise ValueError("`prefill_chunk_size` must be a positive integer divisible by 64.")
 
         self.kvcache_num_blocks = kvcache_num_blocks if kvcache_num_blocks is not None else 0
+        self.memory_budget = memory_budget
         self.cache_impl = cache_impl or "static"
         self.sliding_window = sliding_window
         self.sliding_window_layers = sliding_window_layers or []

--- a/src/optimum/rbln/utils/runtime_utils.py
+++ b/src/optimum/rbln/utils/runtime_utils.py
@@ -75,6 +75,34 @@ def get_available_dram_per_chiplet(num_chiplets: int, npu: Optional[str] = None)
     return dram_nbytes // num_chiplets - sys_per_chiplet
 
 
+_BYTE_UNITS = {"B": 1, "KB": 2**10, "MB": 2**20, "GB": 2**30, "TB": 2**40}
+
+
+def parse_byte_size(value: Union[int, str]) -> int:
+    """Parse a byte size given as an int (bytes) or a string like "10GB" / "512MB".
+
+    Units are case-insensitive and binary (KB=2**10 ... TB=2**40). Returns a positive int of bytes.
+    """
+    if isinstance(value, bool):
+        raise ValueError(f"Invalid byte size: {value!r}")
+    if isinstance(value, int):
+        nbytes = value
+    elif isinstance(value, str):
+        match = re.fullmatch(r"\s*(\d+)\s*([KMGT]?B)?\s*", value, re.IGNORECASE)
+        if not match:
+            raise ValueError(
+                f"Invalid byte size {value!r}. Expected an integer optionally suffixed with "
+                "B, KB, MB, GB, or TB (e.g. '10GB')."
+            )
+        unit = match.group(2)
+        nbytes = int(match.group(1)) * (_BYTE_UNITS[unit.upper()] if unit else 1)
+    else:
+        raise ValueError(f"Invalid byte size type: {type(value).__name__}")
+    if nbytes <= 0:
+        raise ValueError(f"Byte size must be positive, got {nbytes}.")
+    return nbytes
+
+
 def normalize_npu(npu: str) -> str:
     """Normalize the NPU string by removing the form factor."""
     match = re.match(r"(RBLN-CA|RBLN-CR)(\d+)", npu)


### PR DESCRIPTION
## Type of Change
- [x] Performance improvement

## Changes Overview
Adds `memory_budget` to `RBLNDecoderOnlyModelConfig` to bound the device DRAM the automatic `kvcache_num_blocks` estimation may assume.
- Prefer a float in (0, 1] as a fraction of the NPU available DRAM (e.g. `0.8` for 80%), matching vllm's `gpu_memory_utilization`.
- A `"80%"` string is also accepted (handy for passing through the compile CLI), as are bytes given as an int or string (`"10GB"`, `"512MB"`).
- The fraction is of the available DRAM (after the per-chiplet system reserve), not the raw total. Defaults to None (full available DRAM) and must not exceed it (`ValueError` otherwise).

Also adds `RBLNDecoderOnlyFlashAttentionMixin._required_memory_at(compiled_models, rbln_config, num_blocks)`, returning the device-wide kv-cache DRAM at a given block count with 2MB alignment applied (non-linear in the block count). It works for any current block size — resizable tensors are normalized to per-block bytes using `rbln_config.kvcache_num_blocks`. The aligned per-chiplet math is factored into `_kvcache_bytes_per_chiplet`, shared with the block search (unchanged behavior).

```bash
optimum-rbln-cli --model-id meta-llama/Llama-2-7b-chat-hf --memory-budget 0.8
optimum-rbln-cli --model-id meta-llama/Llama-2-7b-chat-hf --memory-budget 80%
optimum-rbln-cli --model-id meta-llama/Llama-2-7b-chat-hf --memory-budget 100GB
```

## Motivation and Context
Users need to constrain kv-cache block estimation to a memory budget smaller than the full device (e.g. to leave headroom), expressed intuitively as a fraction or in bytes.

Note: the float-vs-`%` representation follows reviewer feedback — float is the recommended form (per vllm), with `"%"` kept for CLI convenience.

## How to test
- Estimation with a smaller budget yields fewer blocks (monotonic); `None` reproduces the current result; a budget above the NPU available DRAM raises `ValueError`.
- `_required_memory_at(N)` is monotonic in `N`, equals the current footprint at `N = kvcache_num_blocks`, and stays correct for an already-resized artifact.
