### PR TITLE
model: memory_budget config semantics (non-save, mutually exclusive with kvcache_num_blocks)

### DIFF
--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -38,6 +38,7 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
 
     _default_phases = ["prefill"]
     _default_logits_to_keep = 0
+    subclass_non_save_attributes = ["memory_budget"]
 
     def __init__(
         self,

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -234,6 +234,12 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
 
         self.kvcache_num_blocks = kvcache_num_blocks if kvcache_num_blocks is not None else 0
         self.memory_budget = memory_budget
+        if self.memory_budget is not None and self.kvcache_num_blocks > 0:
+            raise ValueError(
+                "`memory_budget` and an explicit `kvcache_num_blocks` are mutually exclusive. "
+                "`memory_budget` only guides automatic block estimation, which runs when "
+                "`kvcache_num_blocks` is unset."
+            )
         self.cache_impl = cache_impl or "static"
         self.sliding_window = sliding_window
         self.sliding_window_layers = sliding_window_layers or []

--- a/src/optimum/rbln/transformers/models/qwen3_vl/configuration_qwen3_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/configuration_qwen3_vl.py
@@ -29,7 +29,7 @@ class RBLNQwen3VLForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausalLMC
     """
 
     submodules = ["visual"]
-    subclass_non_save_attributes = ["_load_visual_runtime"]
+    subclass_non_save_attributes = ["_load_visual_runtime", "memory_budget"]
 
     def __init__(
         self,
@@ -66,7 +66,7 @@ class RBLNQwen3VLForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausalLMC
 
 class RBLNQwen3VLModelConfig(RBLNDecoderOnlyModelConfig):
     submodules = ["visual"]
-    subclass_non_save_attributes = ["_load_visual_runtime"]
+    subclass_non_save_attributes = ["_load_visual_runtime", "memory_budget"]
 
     def __init__(self, visual: Optional[RBLNModelConfig] = None, _load_visual_runtime: bool = True, **kwargs: Any):
         super().__init__(**kwargs)


### PR DESCRIPTION
## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

Two `memory_budget` config-semantics fixes, follow-up to #637.

## 1. Do not serialize `memory_budget`
`memory_budget` is a compile-time estimation input, not a persisted property (the resolved `kvcache_num_blocks` is what the artifact keeps), and it is never read at load/inference. It was being written to `rbln_config.json`, so register it in `subclass_non_save_attributes`.
- Added on `RBLNDecoderOnlyModelConfig`; qwen3_vl configs override that list (replacing, not extending), so `memory_budget` is added there too.
- Still readable at runtime (used by the estimator); just no longer written to `rbln_config.json`. Same pattern as the (now-dropped) `kvcache_num_blocks_adjuster`.

## 2. Reject `memory_budget` together with an explicit `kvcache_num_blocks`
Estimation (which consumes `memory_budget`) runs only when `kvcache_num_blocks` is unset (auto). If both are given at compile time, estimation is skipped and `memory_budget` would be silently ignored. `RBLNDecoderOnlyModelConfig.__init__` now raises `ValueError` when both are set, instead of silently dropping the budget.

## How to test
- `RBLNDecoderOnlyModelForCausalLMConfig(..., memory_budget=0.8)._prepare_for_serialization()` has no `memory_budget` (while `kvcache_num_blocks` remains); `cfg.memory_budget` is still readable. Same for qwen3_vl configs.
- Constructing with both `kvcache_num_blocks=N` (N>0) and `memory_budget` raises `ValueError`; either alone (or `memory_budget` with auto `kvcache_num_blocks`) is accepted.
