### PR TITLE
refactor(config): remove RBLNConfig.load() past its 0.11.0 removal deadline

### DIFF
--- a/src/optimum/rbln/configuration_utils.py
+++ b/src/optimum/rbln/configuration_utils.py
@@ -24,7 +24,7 @@ import torch
 from packaging.version import Version
 
 from .__version__ import __version__
-from .utils.deprecation import deprecate_kwarg, deprecate_method, warn_deprecated_npu
+from .utils.deprecation import deprecate_kwarg, warn_deprecated_npu
 from .utils.logging import get_logger
 from .utils.runtime_utils import ContextRblnConfig
 
@@ -309,42 +309,6 @@ class RBLNAutoConfig:
         return target_cls.from_pretrained(
             path, rbln_config=rbln_config, return_unused_kwargs=return_unused_kwargs, **kwargs
         )
-
-    @classmethod
-    @deprecate_method(version="0.11.0", new_method="from_pretrained")
-    def load(
-        cls,
-        path: str,
-        rbln_config: Union[dict[str, Any], "RBLNModelConfig"] | None = None,
-        return_unused_kwargs: bool = False,
-        **kwargs: dict[str, Any] | None,
-    ) -> Union["RBLNModelConfig", tuple["RBLNModelConfig", dict[str, Any]]]:
-        """
-        Load RBLNModelConfig from a path.
-        Class name is automatically inferred from the `rbln_config.json` file.
-
-        Deprecated:
-            This method is deprecated and will be removed in version 0.11.0.
-            Use `from_pretrained` instead.
-
-        Args:
-            path (str): Path to the RBLNModelConfig file or directory.
-            rbln_config (dict[str, Any] | None): Additional configuration to override.
-            return_unused_kwargs (bool): Whether to return unused kwargs.
-            kwargs: Additional keyword arguments to override configuration values.
-
-        Returns:
-            RBLNModelConfig: The loaded RBLNModelConfig.
-
-        Examples:
-            ```python
-            # Deprecated usage:
-            config = RBLNAutoConfig.load("/path/to/model")
-            # Recommended usage:
-            config = RBLNAutoConfig.from_pretrained("/path/to/model")
-            ```
-        """
-        return cls.from_pretrained(path, rbln_config=rbln_config, return_unused_kwargs=return_unused_kwargs, **kwargs)
 
 
 class RBLNModelConfig(RBLNSerializableConfigProtocol):
@@ -1002,48 +966,6 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
             return rbln_config, kwargs
         else:
             return rbln_config
-
-    @classmethod
-    @deprecate_method(version="0.11.0", new_method="from_pretrained")
-    def load(
-        cls,
-        path: str,
-        rbln_config: Union[dict[str, Any], "RBLNModelConfig"] | None = None,
-        return_unused_kwargs: bool = False,
-        **kwargs: dict[str, Any] | None,
-    ) -> Union["RBLNModelConfig", tuple["RBLNModelConfig", dict[str, Any]]]:
-        """
-        Load a RBLNModelConfig from a path.
-
-        Deprecated:
-            This method is deprecated and will be removed in version 0.11.0.
-            Use `from_pretrained` instead.
-
-        Args:
-            path (str): Path to the RBLNModelConfig file or directory containing the config file.
-            rbln_config (dict[str, Any] | None): Additional configuration to override.
-            return_unused_kwargs (bool): Whether to return unused kwargs.
-            kwargs: Additional keyword arguments to override configuration values.
-                    Keys starting with 'rbln_' will have the prefix removed and be used
-                    to update the configuration.
-
-        Returns:
-            RBLNModelConfig: The loaded configuration instance.
-
-        Note:
-            This method loads the configuration from the specified path and applies any
-            provided overrides. If the loaded configuration class doesn't match the expected
-            class, a warning will be logged.
-
-        Examples:
-            ```python
-            # Deprecated usage:
-            config = RBLNResNetForImageClassificationConfig.load("/path/to/model")
-            # Recommended usage:
-            config = RBLNResNetForImageClassificationConfig.from_pretrained("/path/to/model")
-            ```
-        """
-        return cls.from_pretrained(path, rbln_config=rbln_config, return_unused_kwargs=return_unused_kwargs, **kwargs)
 
     @classmethod
     def initialize_from_kwargs(


### PR DESCRIPTION
# Pull Request Description

## Type of Change
- [x] Code refactoring

## Changes Overview

Deletes the two deprecated `load()` classmethods from `src/optimum/rbln/configuration_utils.py`, decorator included.

- `RBLNAutoConfig.load()` and `RBLNModelConfig.load()` were thin wrappers forwarding their arguments verbatim to `from_pretrained()`, so callers only need to change the method name.
- The `deprecate_method` import goes with them, since nothing in that module uses it anymore. The helper itself stays in `utils/deprecation.py` next to `deprecate_kwarg` and remains covered by `tests/test_base.py::test_deprecate_method_raises_at_or_past_cutoff`.

No test changes are needed: `test_load_config_object` was already switched to `from_pretrained()` in 48217ce0.

## Motivation and Context

Both methods carried `@deprecate_method(version="0.11.0", new_method="from_pretrained")`, and every 0.11.x build is now past that cutoff, so calling either one raises `ValueError` instead of warning. Two things put us there:

1. `v0.11.0.post1` became reachable from `dev` with the back-merge in #618, which pushed the hatch-vcs derived version to `0.11.0.post2.devN`.
2. #614 normalized the cutoff to compare PEP 440 base versions, so alpha and dev builds (`0.11.1aN.devM`) are past it as well.

The deprecation policy table at the top of `utils/deprecation.py` prescribes exactly this sequence: raise for one version, then drop the decorator. This PR performs that removal step.

No callers remain. `auto_factory.py` moved to `from_pretrained()` in 235075e4, `test_load_config_object` in 48217ce0, and a repository-wide search turns up no other references beyond the unrelated `load_from_dict`.

## Verification

`ruff check` and `ruff format` pass on the changed file. The change is a pure deletion of two unreachable wrappers plus the import that served them, so behaviour is unchanged for every code path that still works today.

## Out of Scope

The three `max_seq_lens` → `max_seq_len` `deprecate_kwarg` entries on the Qwen2-VL / Qwen2.5-VL / Qwen3-VL vision configs share the same 0.11.0 cutoff and are equally past it, but no test or internal caller exercises them, so they are left for a follow-up.

## Related Issues

SR-365
