### PR TITLE
refactor: remove deprecations past their removal window for v0.11.1

### DIFF
--- a/src/optimum/rbln/configuration_utils.py
+++ b/src/optimum/rbln/configuration_utils.py
@@ -24,7 +24,7 @@ import torch
 from packaging.version import Version
 
 from .__version__ import __version__
-from .utils.deprecation import deprecate_kwarg, deprecate_method, warn_deprecated_npu
+from .utils.deprecation import deprecate_kwarg, warn_deprecated_npu
 from .utils.logging import get_logger
 from .utils.runtime_utils import ContextRblnConfig
 
@@ -309,42 +309,6 @@ class RBLNAutoConfig:
         return target_cls.from_pretrained(
             path, rbln_config=rbln_config, return_unused_kwargs=return_unused_kwargs, **kwargs
         )
-
-    @classmethod
-    @deprecate_method(version="0.11.0", new_method="from_pretrained")
-    def load(
-        cls,
-        path: str,
-        rbln_config: Union[dict[str, Any], "RBLNModelConfig"] | None = None,
-        return_unused_kwargs: bool = False,
-        **kwargs: dict[str, Any] | None,
-    ) -> Union["RBLNModelConfig", tuple["RBLNModelConfig", dict[str, Any]]]:
-        """
-        Load RBLNModelConfig from a path.
-        Class name is automatically inferred from the `rbln_config.json` file.
-
-        Deprecated:
-            This method is deprecated and will be removed in version 0.11.0.
-            Use `from_pretrained` instead.
-
-        Args:
-            path (str): Path to the RBLNModelConfig file or directory.
-            rbln_config (dict[str, Any] | None): Additional configuration to override.
-            return_unused_kwargs (bool): Whether to return unused kwargs.
-            kwargs: Additional keyword arguments to override configuration values.
-
-        Returns:
-            RBLNModelConfig: The loaded RBLNModelConfig.
-
-        Examples:
-            ```python
-            # Deprecated usage:
-            config = RBLNAutoConfig.load("/path/to/model")
-            # Recommended usage:
-            config = RBLNAutoConfig.from_pretrained("/path/to/model")
-            ```
-        """
-        return cls.from_pretrained(path, rbln_config=rbln_config, return_unused_kwargs=return_unused_kwargs, **kwargs)
 
 
 class RBLNModelConfig(RBLNSerializableConfigProtocol):
@@ -1002,48 +966,6 @@ class RBLNModelConfig(RBLNSerializableConfigProtocol):
             return rbln_config, kwargs
         else:
             return rbln_config
-
-    @classmethod
-    @deprecate_method(version="0.11.0", new_method="from_pretrained")
-    def load(
-        cls,
-        path: str,
-        rbln_config: Union[dict[str, Any], "RBLNModelConfig"] | None = None,
-        return_unused_kwargs: bool = False,
-        **kwargs: dict[str, Any] | None,
-    ) -> Union["RBLNModelConfig", tuple["RBLNModelConfig", dict[str, Any]]]:
-        """
-        Load a RBLNModelConfig from a path.
-
-        Deprecated:
-            This method is deprecated and will be removed in version 0.11.0.
-            Use `from_pretrained` instead.
-
-        Args:
-            path (str): Path to the RBLNModelConfig file or directory containing the config file.
-            rbln_config (dict[str, Any] | None): Additional configuration to override.
-            return_unused_kwargs (bool): Whether to return unused kwargs.
-            kwargs: Additional keyword arguments to override configuration values.
-                    Keys starting with 'rbln_' will have the prefix removed and be used
-                    to update the configuration.
-
-        Returns:
-            RBLNModelConfig: The loaded configuration instance.
-
-        Note:
-            This method loads the configuration from the specified path and applies any
-            provided overrides. If the loaded configuration class doesn't match the expected
-            class, a warning will be logged.
-
-        Examples:
-            ```python
-            # Deprecated usage:
-            config = RBLNResNetForImageClassificationConfig.load("/path/to/model")
-            # Recommended usage:
-            config = RBLNResNetForImageClassificationConfig.from_pretrained("/path/to/model")
-            ```
-        """
-        return cls.from_pretrained(path, rbln_config=rbln_config, return_unused_kwargs=return_unused_kwargs, **kwargs)
 
     @classmethod
     def initialize_from_kwargs(

--- a/src/optimum/rbln/transformers/models/audio_spectrogram_transformer/configuration_audio_spectrogram_transformer.py
+++ b/src/optimum/rbln/transformers/models/audio_spectrogram_transformer/configuration_audio_spectrogram_transformer.py
@@ -15,7 +15,6 @@
 from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
-from ....utils.deprecation import deprecate_kwarg
 
 
 class RBLNASTForAudioClassificationConfig(RBLNModelConfig):
@@ -23,7 +22,6 @@ class RBLNASTForAudioClassificationConfig(RBLNModelConfig):
     Configuration class for RBLNASTForAudioClassification.
     """
 
-    @deprecate_kwarg(old_name="num_mel_bins", version="0.10.0")
     def __init__(
         self,
         batch_size: int | None = None,

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/configuration_qwen2_5_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/configuration_qwen2_5_vl.py
@@ -15,7 +15,6 @@
 from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
-from ....utils.deprecation import deprecate_kwarg
 from ..decoderonly.configuration_decoderonly import RBLNDecoderOnlyModelConfig, RBLNDecoderOnlyModelForCausalLMConfig
 
 
@@ -78,7 +77,6 @@ class RBLNQwen2_5_VisionTransformerPretrainedModelConfig(RBLNModelConfig):
     mechanisms for processing images and videos.
     """
 
-    @deprecate_kwarg(old_name="max_seq_lens", new_name="max_seq_len", version="0.11.0")
     def __init__(self, max_seq_len: int | list[int] = None, **kwargs: Any):
         """
         Args:

--- a/src/optimum/rbln/transformers/models/qwen2_vl/configuration_qwen2_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_vl/configuration_qwen2_vl.py
@@ -15,7 +15,6 @@
 from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
-from ....utils.deprecation import deprecate_kwarg
 from ..decoderonly.configuration_decoderonly import RBLNDecoderOnlyModelConfig, RBLNDecoderOnlyModelForCausalLMConfig
 
 
@@ -62,7 +61,6 @@ class RBLNQwen2VLModelConfig(RBLNDecoderOnlyModelConfig):
 
 
 class RBLNQwen2VisionTransformerPretrainedModelConfig(RBLNModelConfig):
-    @deprecate_kwarg(old_name="max_seq_lens", new_name="max_seq_len", version="0.11.0")
     def __init__(self, max_seq_len: int | list[int] = None, **kwargs: dict[str, Any]):
         """
         Args:

--- a/src/optimum/rbln/transformers/models/qwen3_vl/configuration_qwen3_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/configuration_qwen3_vl.py
@@ -15,7 +15,6 @@
 from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
-from ....utils.deprecation import deprecate_kwarg
 from ..decoderonly.configuration_decoderonly import RBLNDecoderOnlyModelConfig, RBLNDecoderOnlyModelForCausalLMConfig
 
 
@@ -89,7 +88,6 @@ class RBLNQwen3VLVisionModelConfig(RBLNModelConfig):
     RBLN-optimized Qwen3-VL vision transformer models for processing images and videos.
     """
 
-    @deprecate_kwarg(old_name="max_seq_lens", new_name="max_seq_len", version="0.11.0")
     def __init__(self, max_seq_len: int | list[int] = None, **kwargs: Any):
         """
         Args:

--- a/src/optimum/rbln/transformers/models/seq2seq/configuration_seq2seq.py
+++ b/src/optimum/rbln/transformers/models/seq2seq/configuration_seq2seq.py
@@ -15,7 +15,6 @@
 from typing import Any
 
 from ....configuration_utils import RBLNModelConfig
-from ....utils.deprecation import deprecate_kwarg
 from ....utils.logging import get_logger
 
 
@@ -25,7 +24,6 @@ logger = get_logger()
 class RBLNModelForSeq2SeqLMConfig(RBLNModelConfig):
     support_paged_attention = None
 
-    @deprecate_kwarg(old_name="pad_token_id", version="0.10.0")
     def __init__(
         self,
         batch_size: int | None = None,


### PR DESCRIPTION
## Summary

Per the deprecation policy in `src/optimum/rbln/utils/deprecation.py` (raise an error for one release at the deprecated version, then remove in the following release), this removes everything whose window closed at v0.11.0 or earlier, ahead of the v0.11.1 release.

### Removed (past due)

| Target | Type | Deprecated since |
|---|---|---|
| `RBLNAutoConfig.load`, `RBLNModelConfig.load` | `deprecate_method` → `from_pretrained` | v0.11.0 |
| `max_seq_lens` → `max_seq_len` (Qwen2-VL / Qwen2.5-VL / Qwen3-VL vision configs) | `deprecate_kwarg` | v0.11.0 |
| `pad_token_id` (`RBLNModelForSeq2SeqLMConfig`) | `deprecate_kwarg` | v0.10.0 (overdue) |
| `num_mel_bins` (`RBLNASTForAudioClassificationConfig`) | `deprecate_kwarg` | v0.10.0 (overdue) |

The `load` methods were pure delegating aliases of `from_pretrained`, so the whole method (not just the decorator) is deleted. A repo-wide search (src / tests / examples / docs, including comments and docstrings) found no remaining callers or references; the only hits were the deleted methods' own docstring examples. The `load` example in `deprecation.py`'s docstring is a generic usage illustration of the decorator and is kept.

Old kwargs now fail with the standard `ValueError: Unexpected arguments` from `RBLNModelConfig.__init__`, so misuse still surfaces clearly.

### Kept (window not yet closed — v0.12.0)

- `model_input_shapes` (`configuration_generic.py`)
- `tensor_parallel_size` → `num_devices`, `_torch_dtype` → `dtype` (`configuration_utils.py`)

## Verification

- `ruff format --check` and `ruff check --select I` pass on all edited files.
- `python -m py_compile` passes.
- `pytest tests/test_config.py tests/test_base.py` could not collect in my local environment due to a pre-existing `rebel._C` version mismatch unrelated to this change; the existing deprecation tests only cover the v0.12.0 deprecations, which are untouched. Please rely on CI for the test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)