### PR TITLE
model: fix default prefill_chunk_size to max_seq_len for bidirectional prefill (paligemma)

### DIFF
--- a/src/optimum/rbln/transformers/models/colpali/configuration_colpali.py
+++ b/src/optimum/rbln/transformers/models/colpali/configuration_colpali.py
@@ -33,11 +33,8 @@ class RBLNColPaliForRetrievalConfig(RBLNModelConfig):
 
         # Create a configuration object
         config = RBLNColPaliForRetrievalConfig(
-            vlm={
-                "language_model": {"prefill_chunk_size": 8192},
-            }
             output_hidden_states=False,
-            num_devices=4
+            num_devices=4,
         )
 
         # Use the configuration with from_pretrained

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -306,6 +306,13 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
         return "image_prefill" in self.phases
 
     @property
+    def use_bidirectional_prefill(self):
+        # Prefix-LM style prefill (e.g. PaliGemma's language model): with attention mask and
+        # position ids but no separate image_prefill phase, the compiled prefill attends
+        # bidirectionally within a chunk, so the whole prompt must fit in a single chunk.
+        return self.use_attention_mask and self.use_position_ids and not self.use_image_prefill
+
+    @property
     def image_prefill_runtime_idx(self):
         return self.phases.index("image_prefill")
 

--- a/src/optimum/rbln/transformers/models/decoderonly/decoderonly_runtime_utils.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/decoderonly_runtime_utils.py
@@ -542,6 +542,14 @@ class RBLNRuntimeModel(RBLNPytorchRuntime):
             inputs, cache_position, attention_mask, position_ids, position_embed, token_type_ids=token_type_ids
         )
 
+        if query_length > self.rbln_config.prefill_chunk_size and self.rbln_config.use_bidirectional_prefill:
+            raise ValueError(
+                f"Input length ({query_length}) exceeds `prefill_chunk_size` "
+                f"({self.rbln_config.prefill_chunk_size}). This model prefills with bidirectional "
+                "attention over the whole input, which therefore must fit in a single prefill chunk. "
+                "Compile the model with `prefill_chunk_size` >= the maximum input length."
+            )
+
         out_buffers, output_logits, output_hidden_states = self._prepare_prefill_outputs(query_length, attention_mask)
 
         # Assumed that prefix caching was performed externally if cache_position doesn't start from 0.

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -484,6 +484,12 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
     def _update_attention_config(
         cls, model: PreTrainedModel, model_config: PretrainedConfig, rbln_config: RBLNDecoderOnlyModelForCausalLMConfig
     ):
+        # Bidirectional prefill attends across the whole prompt, so the prompt must fit in a
+        # single prefill chunk — default the chunk size to max_seq_len instead of the generic
+        # NPU default, which would silently truncate the bidirectional context.
+        if rbln_config.prefill_chunk_size is None and rbln_config.use_bidirectional_prefill:
+            rbln_config.prefill_chunk_size = rbln_config.max_seq_len
+
         (
             rbln_config.attn_impl,
             rbln_config.kvcache_partition_len,

--- a/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
@@ -81,11 +81,6 @@ class RBLNPaliGemmaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
         model = RBLNPaliGemmaForConditionalGeneration.from_pretrained(
             "google/paligemma2-3b-mix-224",
             export=True,
-            rbln_config={
-                "language_model": {
-                    "prefill_chunk_size": 8192,
-                }
-            },
             rbln_num_devices=4,
         )
 
@@ -388,11 +383,6 @@ class RBLNPaliGemmaModel(RBLNModel):
         model = RBLNPaliGemmaModel.from_pretrained(
             "google/paligemma2-3b-mix-224",
             export=True,
-            rbln_config={
-                "language_model": {
-                    "prefill_chunk_size": 8192,
-                }
-            },
             rbln_num_devices=4,
         )
 


### PR DESCRIPTION
## Problem

PaliGemma's language model (and ColPali's, through its `vlm` submodule) compiles prefill with **bidirectional attention** — the attention op receives `is_bidirectional=True` when the config has `use_attention_mask=True` + `use_position_ids=True` and no `image_prefill` phase. Bidirectional attention only spans a single prefill chunk (earlier chunks' KV are frozen), so the whole prompt must fit in one chunk: effectively `prefill_chunk_size == max_seq_len`.

Nothing enforced this. With `prefill_chunk_size` unset, the generic NPU default (128, or 512 on RBLN-CR) applied — even a single 224px image (256 soft tokens) then spans two chunks and produces **silently wrong logits with no error**. The only guidance was the `prefill_chunk_size: 8192` pin in docstring examples.

## Why the fix is keyed on config flags, not the model class

The same language-model class is causal or bidirectional depending on which parent instantiates it: standalone Gemma is causal; under Gemma3/4 the text prefill is causal (they route vision runs to a separate bidirectional `image_prefill` graph); under PaliGemma it is bidirectional. The parent already communicates that semantics through the flags it injects into the submodule config, so the constraint hangs on the exact predicate the attention op uses (no new config field is introduced):

```python
use_attention_mask and use_position_ids and not use_image_prefill
```

## Changes

- **`configuration_decoderonly.py`** — new `use_bidirectional_prefill` property: the single definition of the flag combo that maps to `is_bidirectional=True` in the compiled attention op.
- **`modeling_decoderonly.py` `_update_attention_config`** — when the combo is active and `prefill_chunk_size` is unset, default it to `max_seq_len` instead of the generic NPU default. Lives on `RBLNDecoderOnlyModel`, so both the `ForCausalLM` (PaliGemma generation) and `Model` (ColPali retrieval) paths are covered. Gemma3/4 are unaffected (`use_image_prefill=True`).
- **`decoderonly_runtime_utils.py` `prefill_forward`** — if the input still exceeds `prefill_chunk_size` in bidirectional mode (e.g. a user explicitly compiled a smaller chunk), raise a clear `ValueError` instead of silently chunking into wrong outputs.
- **Docstrings** — drop the now-redundant manual `prefill_chunk_size: 8192` pins from the PaliGemma / ColPali examples. 8192 is PaliGemma's `max_position_embeddings`, i.e. exactly what the new default resolves to, so compiled artifacts for the documented usage are unchanged. (The ColPali example also had a missing-comma syntax error that goes away with the block.)

## Behavior changes

- PaliGemma/ColPali compiled **without** an explicit `prefill_chunk_size`: chunk goes from 128/512 (broken outputs) to `max_seq_len` (correct). Memory/compile-time increases accordingly — this is the cost of correctness, and matches what the docstrings already recommended.
- PaliGemma/ColPali compiled **with** the documented 8192 pin: identical artifact as before.
- A bidirectional model fed an input longer than its compiled chunk now fails loudly at runtime instead of returning wrong logits.
- Causal models, Gemma3/4, Qwen-VL, ColQwen2: no change.

Related: RBLN-SW/vllm-rbln#834 derives the same value (`prefill_chunk_size = max_model_len`) on the vLLM compile path; with this PR, even a caller that omits it gets the correct chunk from optimum-rbln itself.

## Verification

- `ruff format --check` / `ruff check --select I` / `py_compile` pass on all edited files.
- Unit tests could not run in my local environment (pre-existing `rebel._C` version mismatch breaks collection); please rely on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)