### PR TITLE
model: restore batch_size floor in num_min_blocks

### DIFF
--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -224,8 +224,9 @@ class RBLNDecoderOnlyFlashAttentionMixin:
         )
         if rbln_config.kvcache_num_blocks < rbln_config.num_min_blocks:
             raise ValueError(
-                "Memory is not enough for full sequence length. "
-                "Please consider decreasing `max_seq_len` to reduce the number of blocks."
+                f"Memory is not enough for the minimum number of kv-cache blocks "
+                f"({rbln_config.kvcache_num_blocks} < {rbln_config.num_min_blocks}). Please consider decreasing "
+                f"`max_seq_len` or `batch_size` ({rbln_config.batch_size}) to reduce the number of blocks."
             )
         cls.multiply_kv_cache_num_blocks(
             compiled_models=compiled_models, rbln_config=rbln_config, multiplier=rbln_config.kvcache_num_blocks

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -346,8 +346,8 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
     @property
     def num_min_blocks(self) -> int:
         if self.attn_impl == "flash_attn":
-            blocks_for_one_sequence = self.max_seq_len // self.kvcache_block_size + 1
-            return min(max(blocks_for_one_sequence, self.batch_size), self.num_full_blocks)
+            blocks_in_use = max(self.max_seq_len // self.kvcache_block_size, self.batch_size)
+            return min(blocks_in_use + 1, self.num_full_blocks)
         return self.batch_size
 
 

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -178,10 +178,10 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
                 which is beneficial for tasks involving many long sequences or large batch sizes, enabling
                 higher throughput. However, allocating more blocks consumes more memory.
             - **Minimum Requirement**: The system requires a minimum number of blocks to function,
-                calculated based on `max_seq_len`, `kvcache_block_size`, and `batch_size`. The number of
-                allocated blocks must be sufficient to hold at least one full sequence length per item
-                in the batch concurrently. The system will log warnings or raise errors if constraints
-                are violated (e.g., if `kvcache_num_blocks` is less than `batch_size` when using Flash Attention).
+                calculated based on `max_seq_len`, `kvcache_block_size`, and `batch_size`. The allocated
+                blocks must be enough to hold one full sequence length, and at least one block must be
+                available for every item in the batch. The system will log warnings or raise errors if
+                these constraints are violated (e.g., if `kvcache_num_blocks` is less than `batch_size`).
 
             The optimal value depends on the specific model, task, hardware, and desired trade-off
             between performance and memory usage. Automatic determination (default) provides a robust starting point
@@ -346,7 +346,8 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
     @property
     def num_min_blocks(self) -> int:
         if self.attn_impl == "flash_attn":
-            return min(self.max_seq_len // self.kvcache_block_size + 1, self.num_full_blocks)
+            blocks_for_one_sequence = self.max_seq_len // self.kvcache_block_size + 1
+            return min(max(blocks_for_one_sequence, self.batch_size), self.num_full_blocks)
         return self.batch_size
 
 

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -498,12 +498,7 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
             max_seq_len=rbln_config.max_seq_len,
         )
 
-        # Validate kvcache_num_blocks based on the number of full blocks required.
-        # Eager mode restriction:
-        # - num_blocks must be at least equal to the batch size
-        # Flash attention restriction:
-        # - num_blocks must be at least equal to (max_seq_len // kvcache_block_size) + 1
-        # - num_blocks must be no greater than the number of full blocks.
+        # Validate kvcache_num_blocks against `num_min_blocks` / `num_full_blocks`.
         if rbln_config.attn_impl == "flash_attn":
             if rbln_config.is_auto_num_blocks:
                 # Do nothing


### PR DESCRIPTION
# Pull Request Description

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Overview

`num_min_blocks` now keeps `batch_size` as a floor under flash attention:

```python
if self.attn_impl == "flash_attn":
    blocks_in_use = max(self.max_seq_len // self.kvcache_block_size, self.batch_size)
    return min(blocks_in_use + 1, self.num_full_blocks)
```

The pool must hold either one full-length sequence or one block per batch row, plus the spare block `replace_empty_block` hands out for empty block-table slots.

Examples at `kvcache_block_size = 16384`, `num_min_blocks` before → after:

| batch_size | max_seq_len | num_full_blocks | num_min_blocks |
| --- | --- | --- | --- |
| 4 | 131072 | 32 | 9 → 9 |
| 16 | 131072 | 128 | 9 → 17 |
| 64 | 32768 | 128 | 3 → 65 |

The rejection message now reports the estimated and required counts and names `batch_size`, and the `kvcache_num_blocks` docstring is corrected to match.

## Motivation and Context

Before #437 the flash attention path also required `kvcache_num_blocks >= batch_size`. Folding the checks into `num_min_blocks` dropped that term, so a configuration with fewer blocks than batch rows compiled and then failed in `generate()` with `No memory blocks are available for allocation`, since `RBLNPageTableManager` assigns a distinct block per row. It is now rejected at compile time.

## Related Issues

None.

----
🤖 Generated with [Claude Code](https://claude.com/claude-code)
