### PR TITLE
model(qwen3_5): fix video_grid_thw indexing for batched prefill

### DIFF
--- a/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -686,14 +686,23 @@ class RBLNQwen3_5Model(RBLNDecoderOnlyModel):
         image_token_id = self.config.image_token_id
         video_token_id = self.config.video_token_id
         vision_start_token_id = self.config.vision_start_token_id
-        image_idx, video_idx = 0, 0
+        image_idx, video_row_idx = 0, 0
 
         for b_idx in range(batch_size):
             input_id = input_ids[b_idx : b_idx + 1][:, attention_mask[b_idx].bool()]
             vision_start_indices = torch.argwhere(input_id == vision_start_token_id).squeeze(1)
             vision_tokens = input_id[0][vision_start_indices + 1]
-            image_nums = (vision_tokens == image_token_id).sum()
-            video_nums = (vision_tokens == video_token_id).sum()
+            image_nums = int((vision_tokens == image_token_id).sum().item())
+            video_nums = int((vision_tokens == video_token_id).sum().item())
+
+            video_grid_slice = None
+            if video_grid_thw is not None:
+                start_row = video_row_idx
+                consumed_video_chunks = 0
+                while video_row_idx < video_grid_thw.shape[0] and consumed_video_chunks < video_nums:
+                    consumed_video_chunks += int(video_grid_thw[video_row_idx, 0].item())
+                    video_row_idx += 1
+                video_grid_slice = video_grid_thw[start_row:video_row_idx]
 
             if mm_token_type_ids is not None:
                 batch_mm_token_type_ids = mm_token_type_ids[b_idx : b_idx + 1][:, attention_mask[b_idx].bool()]
@@ -706,10 +715,9 @@ class RBLNQwen3_5Model(RBLNDecoderOnlyModel):
                 input_id,
                 batch_mm_token_type_ids,
                 image_grid_thw[image_idx : image_idx + image_nums] if image_grid_thw is not None else None,
-                video_grid_thw[video_idx : video_idx + video_nums] if video_grid_thw is not None else None,
+                video_grid_slice,
             )
             image_idx += image_nums
-            video_idx += video_nums
 
             position_embed = self._get_position_embeddings(inputs_embeds, position_ids)
             mask_indices = torch.nonzero(attention_mask[b_idx], as_tuple=True)[0]


### PR DESCRIPTION
# Pull Request Description

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Overview
Fix Qwen3.5 `_preprocess_prefill` indexing `video_grid_thw` by **frame count** in batched video prefill. Replaced with the **"accumulate grid rows"** approach already used by Qwen3-VL.

```python
# before (buggy)
video_grid_thw[video_idx : video_idx + video_nums]   # video_nums = frame count
video_idx += video_nums

# after
# walk grid rows, accumulating each row's temporal t until this sequence's
# frame segments are covered; advance by rows consumed (= #videos)
```

## Motivation and Context
Qwen3.5 tokenizes a video by separating frames with timestamps: `<t1><vision_start>frame1<vision_end><t2><vision_start>frame2...`. So `video_nums` (the count of `<vision_start>`+video_token) equals the **number of frames T**, whereas `video_grid_thw` holds **one row per video** (`[T, H, W]`) — transformers `get_rope_index` later expands that single row into T rows via `repeat_interleave`.

The old code mistook `video_nums` (frames) for the **number of grid rows**, slicing `video_grid_thw[video_idx : video_idx + video_nums]` and advancing `video_idx += video_nums`. As a result:
- **batch = 1**: the single row is returned regardless of the slice bound, so it happens to work.
- **batch ≥ 2**: the first sequence advances `video_idx` by T (=12), so from the second sequence on the slice `video_grid_thw[12:24]` is **empty**, and `get_rope_index`'s `next(grid_iters[video])` raises **StopIteration**.

The fix walks `video_grid_thw` row by row, accumulating each row's temporal dim `t` until this sequence's frame segments are covered, consuming only the rows needed and advancing by the **number of rows consumed (= number of videos)** — mirroring Qwen3-VL's `_preprocess_prefill`.

### Verification
Reproduced with a real video + the Qwen3.5 processor for batch 1 / 2 / 4:
- before: `StopIteration` for batch ≥ 2
- after: all pass — each sequence consumes exactly its own video's single row, matching the frame-segment count.

## Related Issues
<!-- N/A -->
