### PR TITLE
doc: reword the insufficient-kv-cache-blocks error

### DIFF
--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -212,9 +212,10 @@ class RBLNDecoderOnlyFlashAttentionMixin:
         )
         if rbln_config.kvcache_num_blocks < rbln_config.num_min_blocks:
             raise ValueError(
-                f"Memory is not enough for the minimum number of kv-cache blocks "
-                f"({rbln_config.kvcache_num_blocks} < {rbln_config.num_min_blocks}). Please consider decreasing "
-                f"`max_seq_len` or `batch_size` ({rbln_config.batch_size}) to reduce the number of blocks."
+                f"Insufficient memory for the required KV cache: only {rbln_config.kvcache_num_blocks} blocks "
+                f"can be allocated, but at least {rbln_config.num_min_blocks} blocks are required. Consider "
+                f"reducing `max_seq_len` or `batch_size` (currently {rbln_config.batch_size}) to lower the "
+                f"memory requirement."
             )
         cls.multiply_kv_cache_num_blocks(
             compiled_models=compiled_models, rbln_config=rbln_config, multiplier=rbln_config.kvcache_num_blocks


### PR DESCRIPTION
# Pull Request Description

## Type of Change
- [x] Documentation update

## Changes Overview

Reword the error raised when the estimated kv-cache block count falls below `num_min_blocks`, as suggested in review on #648 after it had already merged:

```text
ValueError: Insufficient memory for the required KV cache: only 3 blocks can be allocated,
but at least 9 blocks are required. Consider reducing `max_seq_len` or `batch_size`
(currently 8) to lower the memory requirement.
```

The wording follows the review suggestion; the config names keep their backticks to match the surrounding messages in the same file.

## Motivation and Context

The previous text led with "Memory is not enough for the minimum number of kv-cache blocks" and read awkwardly. The new text states what could be allocated against what is required, and names the knobs to turn.

## Related Issues

Follow-up to #648.

----
🤖 Generated with [Claude Code](https://claude.com/claude-code)
