### PR TITLE
model: gemma4 bug fix

### DIFF
--- a/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
+++ b/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
@@ -17,9 +17,8 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-from transformers import PretrainedConfig, PreTrainedModel
+from transformers import PreTrainedModel
 from transformers.activations import ACT2FN
-from transformers.models.gemma4.modeling_gemma4 import Gemma4VisionRotaryEmbedding as HFRotaryEmbedding
 
 from ...utils.moe import compute_masked_routing_weight_softmax_first
 from ..decoderonly.configuration_decoderonly import RBLNLoRAConfig
@@ -578,39 +577,6 @@ class Gemma4Experts(nn.Module):
         )
 
 
-class Gemma4VisionRotaryEmbedding(nn.Module):
-    # Host-side replacement for HF Gemma4VisionRotaryEmbedding, which recomputes
-    # `inv_freq @ position_ids` -> cos/sin on every forward. Vision positions are integer patch
-    # coordinates on the resized patch grid, so the whole table is built once here and each forward
-    # is a gather — like RotaryEmbedding does for the text decoder.
-    #
-    # `max_patches` (the largest compiled bucket) bounds the table: the image processor resizes each
-    # image so that patch_height * patch_width <= max_patches, so neither axis coordinate can reach
-    # it. Smaller buckets index the same table, so one table serves them all.
-    #
-    # The table covers positions [0, ..., max_patches - 1, -1]; the trailing row makes negative
-    # indexing reproduce HF's values for padded patches (pixel_position_ids == -1).
-
-    def __init__(self, config: PretrainedConfig, max_patches: int):
-        super().__init__()
-        # Derive inv_freq through HF so rope_parameters handling stays in sync with upstream.
-        hf_rotary_emb = HFRotaryEmbedding(config)
-        positions = torch.cat([torch.arange(max_patches), torch.tensor([-1])])
-        freqs = positions[:, None].float() @ hf_rotary_emb.inv_freq[None, :].float()
-        emb = torch.cat((freqs, freqs), dim=-1)
-
-        self.register_buffer("_cos_cached", emb.cos() * hf_rotary_emb.attention_scaling, persistent=False)
-        self.register_buffer("_sin_cached", emb.sin() * hf_rotary_emb.attention_scaling, persistent=False)
-
-    def forward(self, x: torch.Tensor, position_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        # position_ids (batch, num_patches, ndim) gathers to (batch, num_patches, ndim, emb_dim);
-        # flattening the last two axes matches HF's per-spatial-dim loop plus cat(..., dim=-1).
-        batch_size, num_patches, _ = position_ids.shape
-        cos = self._cos_cached[position_ids].reshape(batch_size, num_patches, -1)
-        sin = self._sin_cached[position_ids].reshape(batch_size, num_patches, -1)
-        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
-
-
 class Gemma4VisionAttention(nn.Module):
     # Replaces HF Gemma4VisionAttention with an explicit matmul -> softmax -> matmul block.
     # HF dispatches through ALL_ATTENTION_FUNCTIONS[_attn_implementation] (default: F.scaled_dot_product_attention);
@@ -695,7 +661,7 @@ class Gemma4VisionModelWrapper(nn.Module):
     #
     # Host-side responsibilities (NOT in the compiled graph):
     # - patch_embedder: produces inputs_embeds from pixel_values.
-    # - Gemma4VisionRotaryEmbedding: produces (cos, sin) from pixel_position_ids.
+    # - rotary (cos, sin): gathered from tables RBLNGemma4VisionModel precomputes at load time.
     # - padding_positions ((pixel_position_ids == -1).all(dim=-1)) and 1D-per-key additive attn_mask
     #   ((1 - valid) * finfo.min, shape (batch, max_patches)) — both derived from pixel_position_ids
     #   on the host. attn_mask is broadcast to (batch, 1, 1, max_patches) here to mask only the key

--- a/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
+++ b/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
@@ -17,7 +17,7 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-from transformers import PreTrainedModel
+from transformers import PretrainedConfig, PreTrainedModel
 from transformers.activations import ACT2FN
 
 from ...utils.moe import compute_masked_routing_weight_softmax_first
@@ -575,6 +575,38 @@ class Gemma4Experts(nn.Module):
             masked_routing_weight=masked_routing_weight,
             hidden_act="gelu",
         )
+
+
+class Gemma4VisionRotaryEmbedding(nn.Module):
+    # Host-side replacement for HF Gemma4VisionRotaryEmbedding, which recomputes
+    # `inv_freq @ position_ids` -> cos/sin on every forward. Vision positions are integer patch
+    # coordinates bounded by `position_embedding_size` (the same bound the patch embedder's one-hot
+    # position lookup uses), so the whole table is built once here and each forward is a gather —
+    # like RotaryEmbedding does for the text decoder.
+    #
+    # The table covers positions [0, ..., position_embedding_size - 1, -1]; the trailing row makes
+    # negative indexing reproduce HF's values for padded patches (pixel_position_ids == -1).
+
+    def __init__(self, config: PretrainedConfig):
+        super().__init__()
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4VisionRotaryEmbedding as HFRotaryEmbedding
+
+        # Derive inv_freq through HF so rope_parameters handling stays in sync with upstream.
+        hf_rotary_emb = HFRotaryEmbedding(config)
+        positions = torch.cat([torch.arange(config.position_embedding_size), torch.tensor([-1])])
+        freqs = positions[:, None].float() @ hf_rotary_emb.inv_freq[None, :].float()
+        emb = torch.cat((freqs, freqs), dim=-1)
+
+        self.register_buffer("_cos_cached", emb.cos() * hf_rotary_emb.attention_scaling, persistent=False)
+        self.register_buffer("_sin_cached", emb.sin() * hf_rotary_emb.attention_scaling, persistent=False)
+
+    def forward(self, x: torch.Tensor, position_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        # position_ids (batch, num_patches, ndim) gathers to (batch, num_patches, ndim, emb_dim);
+        # flattening the last two axes matches HF's per-spatial-dim loop plus cat(..., dim=-1).
+        batch_size, num_patches, _ = position_ids.shape
+        cos = self._cos_cached[position_ids].reshape(batch_size, num_patches, -1)
+        sin = self._sin_cached[position_ids].reshape(batch_size, num_patches, -1)
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
 
 
 class Gemma4VisionAttention(nn.Module):

--- a/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
+++ b/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
@@ -19,6 +19,7 @@ import torch
 import torch.nn as nn
 from transformers import PretrainedConfig, PreTrainedModel
 from transformers.activations import ACT2FN
+from transformers.models.gemma4.modeling_gemma4 import Gemma4VisionRotaryEmbedding as HFRotaryEmbedding
 
 from ...utils.moe import compute_masked_routing_weight_softmax_first
 from ..decoderonly.configuration_decoderonly import RBLNLoRAConfig
@@ -589,8 +590,6 @@ class Gemma4VisionRotaryEmbedding(nn.Module):
 
     def __init__(self, config: PretrainedConfig):
         super().__init__()
-        from transformers.models.gemma4.modeling_gemma4 import Gemma4VisionRotaryEmbedding as HFRotaryEmbedding
-
         # Derive inv_freq through HF so rope_parameters handling stays in sync with upstream.
         hf_rotary_emb = HFRotaryEmbedding(config)
         positions = torch.cat([torch.arange(config.position_embedding_size), torch.tensor([-1])])

--- a/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
+++ b/src/optimum/rbln/transformers/models/gemma4/gemma4_architecture.py
@@ -581,18 +581,21 @@ class Gemma4Experts(nn.Module):
 class Gemma4VisionRotaryEmbedding(nn.Module):
     # Host-side replacement for HF Gemma4VisionRotaryEmbedding, which recomputes
     # `inv_freq @ position_ids` -> cos/sin on every forward. Vision positions are integer patch
-    # coordinates bounded by `position_embedding_size` (the same bound the patch embedder's one-hot
-    # position lookup uses), so the whole table is built once here and each forward is a gather —
-    # like RotaryEmbedding does for the text decoder.
+    # coordinates on the resized patch grid, so the whole table is built once here and each forward
+    # is a gather — like RotaryEmbedding does for the text decoder.
     #
-    # The table covers positions [0, ..., position_embedding_size - 1, -1]; the trailing row makes
-    # negative indexing reproduce HF's values for padded patches (pixel_position_ids == -1).
+    # `max_patches` (the largest compiled bucket) bounds the table: the image processor resizes each
+    # image so that patch_height * patch_width <= max_patches, so neither axis coordinate can reach
+    # it. Smaller buckets index the same table, so one table serves them all.
+    #
+    # The table covers positions [0, ..., max_patches - 1, -1]; the trailing row makes negative
+    # indexing reproduce HF's values for padded patches (pixel_position_ids == -1).
 
-    def __init__(self, config: PretrainedConfig):
+    def __init__(self, config: PretrainedConfig, max_patches: int):
         super().__init__()
         # Derive inv_freq through HF so rope_parameters handling stays in sync with upstream.
         hf_rotary_emb = HFRotaryEmbedding(config)
-        positions = torch.cat([torch.arange(config.position_embedding_size), torch.tensor([-1])])
+        positions = torch.cat([torch.arange(max_patches), torch.tensor([-1])])
         freqs = positions[:, None].float() @ hf_rotary_emb.inv_freq[None, :].float()
         emb = torch.cat((freqs, freqs), dim=-1)
 

--- a/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
@@ -179,7 +179,7 @@ class RBLNGemma4VisionModel(RBLNModel):
         return patch_embedder
 
     def _create_rotary_emb(self) -> torch.nn.Module:
-        return Gemma4VisionRotaryEmbedding(self.config)
+        return Gemma4VisionRotaryEmbedding(self.config, max(self.rbln_config.get_max_patches()))
 
     def __post_init__(self, **kwargs):
         artifacts_path = self.model_save_dir / self.subfolder / "torch_artifacts.pth"

--- a/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
@@ -706,7 +706,7 @@ class RBLNGemma4ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
         input_infos = []
         for max_soft_tokens in max_soft_tokens_list:
             input_info = [
-                ("image_features", [1, max_soft_tokens, vision_hidden_size], "float32"),
+                ("image_features", [1, max_soft_tokens, vision_hidden_size], rbln_config.dtype),
             ]
             input_infos.append(input_info)
         compile_cfgs = RBLNCompileConfig(input_info=input_infos)
@@ -809,10 +809,13 @@ class RBLNGemma4ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
             torch.empty(size=vision_out_0_size, dtype=self.rbln_config.vision_tower.dtype, device="cpu"),
             torch.empty(size=vision_out_1_size, dtype=torch.bool, device="cpu"),
         ]
-        projector_out_buffer = [torch.empty(size=projector_out_size, dtype=torch.float32, device="cpu")]
+        projector_dtype = self.rbln_config.dtype
+        projector_out_buffer = [torch.empty(size=projector_out_size, dtype=projector_dtype, device="cpu")]
 
         vision_outputs = self.vision_tower(pixel_values, pixel_position_ids, out=vision_out_buffer)
-        pooler_output = self.embed_vision(vision_outputs.last_hidden_state.float(), out=projector_out_buffer)
+        pooler_output = self.embed_vision(
+            vision_outputs.last_hidden_state.to(projector_dtype), out=projector_out_buffer
+        )
         pooler_output = pooler_output[vision_outputs.pooler_mask]
         return pooler_output
 

--- a/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
@@ -47,6 +47,7 @@ from .configuration_gemma4 import (
 from .gemma4_architecture import (
     Gemma4ForCausalLMWrapper,
     Gemma4VisionModelWrapper,
+    Gemma4VisionRotaryEmbedding,
 )
 from .gemma4_runtime_utils import RBLNGemma4RuntimeModel
 
@@ -109,8 +110,9 @@ class RBLNGemma4VisionModel(RBLNModel):
 
     `patch_embedder` (per-patch linear projection + 2D position embedding lookup) and
     `rotary_emb` (multidimensional cos/sin tables) both run on the host (CPU). `patch_embedder`
-    weights are persisted as a saved torch artifact; `rotary_emb` is recreated from config since
-    its `inv_freq` buffer is non-persistent. The compiled `Gemma4VisionModelWrapper`
+    weights are persisted as a saved torch artifact; `rotary_emb` is rebuilt from config at load
+    time, pre-computing its cos/sin tables so each forward only gathers rows. The compiled
+    `Gemma4VisionModelWrapper`
     (encoder-layers -> pooler) takes the host-computed `inputs_embeds`, `pixel_position_ids`,
     and `(cos, sin)` rotary tables as inputs. Padding within `max_patches` is handled by the
     encoder via `pixel_position_ids == -1` markers.
@@ -177,10 +179,7 @@ class RBLNGemma4VisionModel(RBLNModel):
         return patch_embedder
 
     def _create_rotary_emb(self) -> torch.nn.Module:
-        from transformers.models.gemma4.modeling_gemma4 import Gemma4VisionRotaryEmbedding
-
-        rotary_emb = Gemma4VisionRotaryEmbedding(self.config)
-        return rotary_emb
+        return Gemma4VisionRotaryEmbedding(self.config)
 
     def __post_init__(self, **kwargs):
         artifacts_path = self.model_save_dir / self.subfolder / "torch_artifacts.pth"

--- a/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
@@ -28,6 +28,7 @@ from transformers import (
 )
 from transformers.initialization import no_init_weights
 from transformers.modeling_outputs import BaseModelOutputWithPooling
+from transformers.models.gemma4.modeling_gemma4 import Gemma4VisionRotaryEmbedding
 
 from ....configuration_utils import RBLNCompileConfig, RBLNModelConfig
 from ....modeling import RBLNModel
@@ -47,7 +48,6 @@ from .configuration_gemma4 import (
 from .gemma4_architecture import (
     Gemma4ForCausalLMWrapper,
     Gemma4VisionModelWrapper,
-    Gemma4VisionRotaryEmbedding,
 )
 from .gemma4_runtime_utils import RBLNGemma4RuntimeModel
 
@@ -108,11 +108,10 @@ class RBLNGemma4VisionModel(RBLNModel):
     - transferring the checkpoint weights of the original into an optimized RBLN graph,
     - compiling the resulting graph using the RBLN compiler.
 
-    `patch_embedder` (per-patch linear projection + 2D position embedding lookup) and
-    `rotary_emb` (multidimensional cos/sin tables) both run on the host (CPU). `patch_embedder`
-    weights are persisted as a saved torch artifact; `rotary_emb` is rebuilt from config at load
-    time, pre-computing its cos/sin tables so each forward only gathers rows. The compiled
-    `Gemma4VisionModelWrapper`
+    `patch_embedder` (per-patch linear projection + 2D position embedding lookup) and the
+    multidimensional rotary cos/sin tables both run on the host (CPU). `patch_embedder` weights are
+    persisted as a saved torch artifact; the rotary tables are precomputed from config at load time
+    so each forward only gathers rows from them. The compiled `Gemma4VisionModelWrapper`
     (encoder-layers -> pooler) takes the host-computed `inputs_embeds`, `pixel_position_ids`,
     and `(cos, sin)` rotary tables as inputs. Padding within `max_patches` is handled by the
     encoder via `pixel_position_ids == -1` markers.
@@ -178,9 +177,6 @@ class RBLNGemma4VisionModel(RBLNModel):
             patch_embedder = Gemma4VisionPatchEmbedder(self.config)
         return patch_embedder
 
-    def _create_rotary_emb(self) -> torch.nn.Module:
-        return Gemma4VisionRotaryEmbedding(self.config, max(self.rbln_config.get_max_patches()))
-
     def __post_init__(self, **kwargs):
         artifacts_path = self.model_save_dir / self.subfolder / "torch_artifacts.pth"
         artifacts = torch.load(artifacts_path, weights_only=False) if artifacts_path.exists() else {}
@@ -191,7 +187,16 @@ class RBLNGemma4VisionModel(RBLNModel):
             self.patch_embedder.eval()
         else:
             self.patch_embedder = None
-        self.rotary_emb = self._create_rotary_emb().eval()
+
+        max_patches = max(self.rbln_config.get_max_patches())
+        table_positions = torch.cat([torch.arange(max_patches), torch.tensor([-1])])
+        cos_table, sin_table = Gemma4VisionRotaryEmbedding(self.config).eval()(
+            torch.empty(1), table_positions[None, :, None].expand(1, -1, 2)
+        )
+        per_axis_dim = cos_table.shape[-1] // 2
+        self.rotary_cos_table = cos_table[0, :, :per_axis_dim]
+        self.rotary_sin_table = sin_table[0, :, :per_axis_dim]
+
         super().__post_init__(**kwargs)
 
     def forward(
@@ -208,9 +213,9 @@ class RBLNGemma4VisionModel(RBLNModel):
         padding_positions = (pixel_position_ids == -1).all(dim=-1)
         with torch.no_grad():
             inputs_embeds = self.patch_embedder(pixel_values, pixel_position_ids, padding_positions)
-            cos, sin = self.rotary_emb(inputs_embeds, pixel_position_ids)
-        cos = cos.to(self.rbln_config.dtype)
-        sin = sin.to(self.rbln_config.dtype)
+
+        cos = self.rotary_cos_table[pixel_position_ids].flatten(2).to(self.rbln_config.dtype)
+        sin = self.rotary_sin_table[pixel_position_ids].flatten(2).to(self.rbln_config.dtype)
 
         valid = (~padding_positions).to(inputs_embeds.dtype)
         attn_mask = (1.0 - valid) * torch.finfo(inputs_embeds.dtype).min


### PR DESCRIPTION
# Pull Request Description

> **⚠️ Important: Branch Target**
> - **New features, enhancements, and non-critical fixes**: Merge to `dev` branch
> - **Critical hotfixes only**: Merge to `main` branch (must also merge to `dev`)
> 
> Please ensure you've selected the correct base branch before submitting!

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Release (dev → main merge for production release)
- [ ] New Model Support
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

1. To prevent unexpected mismatch while computing rope, calculate them before inference and reuse.
2. Set input dtype of vision_tower & embed vision according with rbln_config.dtype

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Release
    - `release`: Merging dev to main for production release
      - ex) Release v1.2.0
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update