### PR TITLE
model: blocking when gdn_chunk_size > 128

### DIFF
--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -59,7 +59,6 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
         cache_impl: CacheImplType | None = None,
         sliding_window: int | None = None,
         sliding_window_layers: list[int] | None = None,
-        linear_attention_layers: list[int] | None = None,
         phases: list[PhaseType] | None = None,
         logits_to_keep: int | None = None,
         output_hidden_states: bool | None = None,
@@ -242,7 +241,6 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
         self.cache_impl = cache_impl or "static"
         self.sliding_window = sliding_window
         self.sliding_window_layers = sliding_window_layers or []
-        self.linear_attention_layers = linear_attention_layers or []
 
         if phases is not None:
             self.validate_phases_type(phases)
@@ -430,7 +428,7 @@ class KVCacheMeta(RBLNSerializableConfigProtocol):
     ) -> "KVCacheMeta":
         assert len(rbln_config.compile_cfgs) == 0, "KVCacheMeta cannot be created from rbln_config with compile_cfgs"
 
-        if layer_index in rbln_config.linear_attention_layers:
+        if layer_index in getattr(rbln_config, "linear_attention_layers", []):
             if shape is None:
                 raise ValueError("`shape` is required to build a linear_attention layer's KVCacheMeta.")
             return KVCacheMeta(

--- a/src/optimum/rbln/transformers/models/qwen3_5/configuration_qwen3_5.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/configuration_qwen3_5.py
@@ -25,9 +25,9 @@ class RBLNQwen3_5ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
     Qwen3.5 is a hybrid decoder: most layers are `linear_attention` (GatedDeltaNet) and a
     minority are `full_attention` (gated softmax attention). Full-attention layers use the
     standard paged KV cache; linear-attention layers instead carry a `conv_state` and a
-    `recurrent_state`. Which layers are linear is read directly from the HF `config.layer_types`
-    (no RBLN-config field); this config extends `RBLNDecoderOnlyModelForCausalLMConfig` only with
-    `gdn_chunk_size`.
+    `recurrent_state`. Which layers are linear is read from the HF `config.layer_types` into the internal
+    `linear_attention_layers` field; this config extends `RBLNDecoderOnlyModelForCausalLMConfig` with
+    `gdn_chunk_size` and `linear_attention_layers`.
 
     Example usage:
     ```python
@@ -45,6 +45,7 @@ class RBLNQwen3_5ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
     def __init__(
         self,
         gdn_chunk_size: int | None = None,
+        linear_attention_layers: list[int] | None = None,
         **kwargs: Any,
     ):
         """
@@ -52,10 +53,13 @@ class RBLNQwen3_5ForCausalLMConfig(RBLNDecoderOnlyModelForCausalLMConfig):
             gdn_chunk_size (Optional[int]): GatedDeltaNet prefill sub-chunk size. Each prefill window
                 is split into `prefill_chunk_size // gdn_chunk_size` sub-chunks processed by the chunked
                 delta rule. Must divide `prefill_chunk_size`. `None` -> `prefill_chunk_size` (no split).
+            linear_attention_layers (list[int] | None): The linear_attention (GatedDeltaNet)
+                layer indices, populated automatically from `layer_types` at compile time (not user-set).
             kwargs: Additional arguments passed to `RBLNDecoderOnlyModelForCausalLMConfig`.
         """
         super().__init__(**kwargs)
         self.gdn_chunk_size = gdn_chunk_size
+        self.linear_attention_layers = linear_attention_layers or []
 
 
 class RBLNQwen3_5TextModelConfig(RBLNDecoderOnlyModelConfig):
@@ -69,10 +73,21 @@ class RBLNQwen3_5TextModelConfig(RBLNDecoderOnlyModelConfig):
     def __init__(
         self,
         gdn_chunk_size: int | None = None,
+        linear_attention_layers: list[int] | None = None,
         **kwargs: Any,
     ):
+        """
+        Args:
+            gdn_chunk_size (Optional[int]): GatedDeltaNet prefill sub-chunk size. Each prefill window
+                is split into `prefill_chunk_size // gdn_chunk_size` sub-chunks processed by the chunked
+                delta rule. Must divide `prefill_chunk_size`. `None` -> `prefill_chunk_size` (no split).
+            linear_attention_layers (list[int] | None): The linear_attention (GatedDeltaNet)
+                layer indices, populated automatically from `layer_types` at compile time (not user-set).
+            kwargs: Additional arguments passed to `RBLNDecoderOnlyModelConfig`.
+        """
         super().__init__(**kwargs)
         self.gdn_chunk_size = gdn_chunk_size
+        self.linear_attention_layers = linear_attention_layers or []
 
 
 class RBLNQwen3_5VisionModelConfig(RBLNModelConfig):
@@ -125,6 +140,7 @@ class RBLNQwen3_5ModelConfig(RBLNDecoderOnlyModelConfig):
     def __init__(
         self,
         gdn_chunk_size: int | None = None,
+        linear_attention_layers: list[int] | None = None,
         visual: RBLNModelConfig | None = None,
         _load_visual_runtime: bool = True,
         **kwargs: Any,
@@ -134,6 +150,8 @@ class RBLNQwen3_5ModelConfig(RBLNDecoderOnlyModelConfig):
             gdn_chunk_size (Optional[int]): GatedDeltaNet prefill sub-chunk size. Each prefill window is
                 split into `prefill_chunk_size // gdn_chunk_size` sub-chunks processed by the chunked
                 delta rule. Must divide `prefill_chunk_size`. `None` -> `prefill_chunk_size` (no split).
+            linear_attention_layers (list[int] | None): The linear_attention (GatedDeltaNet)
+                layer indices, populated automatically from `layer_types` at compile time (not user-set).
             visual (Optional[RBLNModelConfig]): Configuration for the vision encoder submodule.
             _load_visual_runtime (bool): Whether to create the visual encoder runtime (False on
                 decoder-only nodes in a disaggregated setup). Defaults to True.
@@ -152,6 +170,7 @@ class RBLNQwen3_5ModelConfig(RBLNDecoderOnlyModelConfig):
         self.visual = self.initialize_submodule_config(submodule_config=visual, force_kwargs=True, batch_size=1)
         self._load_visual_runtime = _load_visual_runtime
         self.gdn_chunk_size = gdn_chunk_size
+        self.linear_attention_layers = linear_attention_layers or []
 
 
 class RBLNQwen3_5ForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausalLMConfig):
@@ -161,7 +180,6 @@ class RBLNQwen3_5ForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausalLMC
     Qwen3.5 pairs a Qwen3-VL-style vision encoder (no deepstack) with the hybrid Qwen3.5
     text backbone (`linear_attention` GatedDeltaNet layers + `full_attention` gated layers).
     The vision encoder output is injected into `inputs_embeds` (`use_inputs_embeds=True`).
-    Which layers are linear is read from the HF `config.text_config.layer_types` (no RBLN-config field).
 
     Independent of the Qwen3-VL config: inherits `RBLNDecoderOnlyModelForCausalLMConfig` directly
     (like the Qwen3-VL config does), carrying its own `visual` submodule handling plus the
@@ -184,6 +202,7 @@ class RBLNQwen3_5ForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausalLMC
     def __init__(
         self,
         gdn_chunk_size: int | None = None,
+        linear_attention_layers: list[int] | None = None,
         use_inputs_embeds: bool = True,
         visual: RBLNModelConfig | None = None,
         _load_visual_runtime: bool = True,
@@ -194,6 +213,8 @@ class RBLNQwen3_5ForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausalLMC
             gdn_chunk_size (Optional[int]): GatedDeltaNet prefill sub-chunk size. Each prefill window is
                 split into `prefill_chunk_size // gdn_chunk_size` sub-chunks. Must divide
                 `prefill_chunk_size`. `None` -> `prefill_chunk_size` (no split). See rbln_chunk_gated_delta_rule.
+            linear_attention_layers (list[int] | None): The linear_attention (GatedDeltaNet)
+                layer indices, populated automatically from `layer_types` at compile time (not user-set).
             use_inputs_embeds (bool): Must be True — the vision encoder output is injected into inputs_embeds.
             visual (Optional[RBLNModelConfig]): Configuration for the vision encoder submodule.
             _load_visual_runtime (bool): Whether to create the visual encoder runtime. Set False on
@@ -214,3 +235,4 @@ class RBLNQwen3_5ForConditionalGenerationConfig(RBLNDecoderOnlyModelForCausalLMC
         self.visual = self.initialize_submodule_config(submodule_config=visual, force_kwargs=True, batch_size=1)
         self._load_visual_runtime = _load_visual_runtime
         self.gdn_chunk_size = gdn_chunk_size
+        self.linear_attention_layers = linear_attention_layers or []

--- a/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -160,9 +160,18 @@ class RBLNQwen3_5TextModel(RBLNDecoderOnlyModel):
     @classmethod
     def _update_rbln_config(cls, preprocessors=None, model=None, model_config=None, rbln_config=None):
         rbln_config.linear_attention_layers = _qwen3_5_linear_layer_indices(model_config)
-        return super()._update_rbln_config(
+        rbln_config = super()._update_rbln_config(
             preprocessors=preprocessors, model=model, model_config=model_config, rbln_config=rbln_config
         )
+        if rbln_config.gdn_chunk_size is None:
+            rbln_config.gdn_chunk_size = rbln_config.prefill_chunk_size
+        if rbln_config.gdn_chunk_size > 128:
+            raise ValueError(
+                f"gdn_chunk_size must be <= 128, got {rbln_config.gdn_chunk_size}. "
+                "Larger GatedDeltaNet sub-chunk sizes are not supported yet — "
+                "set gdn_chunk_size to a value <= 128 that divides prefill_chunk_size."
+            )
+        return rbln_config
 
     @classmethod
     def get_input_info(cls, batch_size, query_length, rbln_config, model_config: PretrainedConfig):
@@ -631,9 +640,18 @@ class RBLNQwen3_5Model(RBLNDecoderOnlyModel):
     @classmethod
     def _update_rbln_config(cls, preprocessors=None, model=None, model_config=None, rbln_config=None):
         rbln_config.linear_attention_layers = _qwen3_5_linear_layer_indices(model_config)
-        return super()._update_rbln_config(
+        rbln_config = super()._update_rbln_config(
             preprocessors=preprocessors, model=model, model_config=model_config, rbln_config=rbln_config
         )
+        if rbln_config.gdn_chunk_size is None:
+            rbln_config.gdn_chunk_size = rbln_config.prefill_chunk_size
+        if rbln_config.gdn_chunk_size > 128:
+            raise ValueError(
+                f"gdn_chunk_size must be <= 128, got {rbln_config.gdn_chunk_size}. "
+                "Larger GatedDeltaNet sub-chunk sizes are not supported yet — "
+                "set gdn_chunk_size to a value <= 128 that divides prefill_chunk_size."
+            )
+        return rbln_config
 
     @classmethod
     def get_input_info(cls, batch_size, query_length, rbln_config, model_config: PretrainedConfig):

--- a/src/optimum/rbln/transformers/models/qwen3_5/qwen3_5_architecture.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/qwen3_5_architecture.py
@@ -300,9 +300,8 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             if _has_bias:
                 _lin.bias = nn.Parameter(_bi.contiguous())
 
-        self.prefill_chunk_size = getattr(rbln_config, "prefill_chunk_size", 128)
-        # GDN sub-chunk: each window splits into `chunk_size` sub-chunks (must divide prefill_chunk_size).
-        self.chunk_size = getattr(rbln_config, "gdn_chunk_size", None) or self.prefill_chunk_size
+        self.prefill_chunk_size = rbln_config.prefill_chunk_size
+        self.chunk_size = rbln_config.gdn_chunk_size
 
     @property
     def phase(self):


### PR DESCRIPTION
# Pull Request Description
Add gentle blocking when `gdn_chunk_size` > 128 and set gdn_chunk_size to rbln_config

> **⚠️ Important: Branch Target**
> - **New features, enhancements, and non-critical fixes**: Merge to `dev` branch
> - **Critical hotfixes only**: Merge to `main` branch (must also merge to `dev`)
> 
> Please ensure you've selected the correct base branch before submitting!

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Release (dev → main merge for production release)
- [ ] New Model Support
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):


## Changes Overview
<!-- Provide a brief summary of the changes in this PR -->

## Motivation and Context
<!-- Explain why this change is necessary and what problem it solves -->

## Related Issues
<!-- Link any related issues here using the syntax: Closes #123, Fixes #456 -->



----
# Conventional commit
```
type(optional scope): description
```
----
# Type candidate
  - Model Updates
    - `model`: Adding New models or Bugfix for existing models
      - ex) Add LlavaNext 
      - ex) Bugfix Whisper
  - Enhancements
    - `performance`: Optimizing some models or this library itself
      - ex) Loading RBLNModel faster
      - ex) Optimizing Memory Usage of DecoderOnlyModel
  - Code Refactor
    - `refactor`: Re-arrange class architecture, or more.
      - ex) Refactor Seq2Seq
  - Documentation
    - `doc`: Update docstring only
  - Library Dependencies
    - `dependency`: Update requirements, something like that.
  - Release
    - `release`: Merging dev to main for production release
      - ex) Release v1.2.0
  - Other
    - `other`: None of above.
      - ex) ci update
      - ex) pdm update