### PR TITLE
fix: quote rebel.* union annotations to avoid runtime TypeError

### DIFF
--- a/src/optimum/rbln/modeling_base.py
+++ b/src/optimum/rbln/modeling_base.py
@@ -75,7 +75,7 @@ class RBLNBaseModel(SubModulesMixin, PushToHubMixin, PreTrainedModel):
         rbln_config: RBLNModelConfig,
         model_save_dir: str | Path | TemporaryDirectory | None = None,
         subfolder: str = "",
-        rbln_compiled_models: rebel.RBLNCompiledModel | None = None,
+        rbln_compiled_models: "rebel.RBLNCompiledModel | None" = None,
         rbln_submodules: list["RBLNBaseModel"] | None = None,
         **kwargs,
     ):

--- a/src/optimum/rbln/transformers/models/gemma3/gemma3_runtime_utils.py
+++ b/src/optimum/rbln/transformers/models/gemma3/gemma3_runtime_utils.py
@@ -33,7 +33,7 @@ class RBLNGemma3RuntimeModel(RBLNDecoderOnlyChunkedMultimodalPrefillMixin, RBLNR
 
     _prefill_output_cls = RBLNGemma3ForCausalLMOutput
 
-    def __init__(self, *args: Any, image_prefill: rebel.Runtime | None = None, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, image_prefill: "rebel.Runtime | None" = None, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.image_prefill = RBLNPytorchRuntime(image_prefill)
         self.prefill = RBLNPytorchRuntime(self.runtime) if self.phase == "prefill" else None


### PR DESCRIPTION
# Pull Request Description

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Overview
Quotes two runtime-evaluated parameter annotations so they are not evaluated at import time:
- `transformers/models/gemma3/gemma3_runtime_utils.py` — `image_prefill: "rebel.Runtime | None"`
- `modeling_base.py` — `rbln_compiled_models: "rebel.RBLNCompiledModel | None"`

## Motivation and Context
The type-annotation modernization (#624) rewrote `Optional[rebel.Runtime]` to `rebel.Runtime | None`. In some rebel-compiler versions `rebel.Runtime` is exposed as a **function**, not a class. Without `from __future__ import annotations`, a parameter annotation is evaluated at definition time, and `function | None` raises:

```
TypeError: unsupported operand type(s) for |: 'function' and 'NoneType'
```

because only `type` implements `__or__`. The original `Optional[rebel.Runtime]` worked because `typing._type_check` accepts any callable. This crashed Gemma3 in the standalone deploy (build 685). Quoting the annotation defers evaluation (it becomes a string), fixing the crash while keeping the modern `X | None` syntax and **without** reintroducing `from __future__ import annotations`.

## Scope / completeness
A full sweep for `rebel.* | ...` annotations in runtime-evaluated positions found exactly three sites:

| Location | Position | Evaluated? | Action |
|---|---|---|---|
| `gemma3_runtime_utils.py:36` | function param | yes | fixed (the reported crash) |
| `modeling_base.py:78` | function param | yes (at class def) | fixed (same pattern; latent landmine) |
| `modeling.py:189` | local variable | no (PEP 526) | left as-is (never evaluated) |

## Verification
- Simulated the deploy condition (`rebel.Runtime` monkeypatched to a function): the old form reproduces the exact `TypeError`; the quoted form imports cleanly.
- Forced **every** `rebel` class to a function and imported all ~300 submodules → top-level import OK, **0** `|`-annotation failures.
- `ruff check` / `ruff format --check` pass on both files.

## Related Issues
Follow-up to #624. Deploy failure: standalone-rbln-deploy build 685.

----
# Conventional commit
```
fix: quote rebel.* union annotations to avoid runtime TypeError
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)