### PR TITLE
model(decoderonly): return the full sequence when prompt length is a multiple of prefill_chunk_size

### DIFF
--- a/src/optimum/rbln/transformers/models/decoderonly/decoderonly_runtime_utils.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/decoderonly_runtime_utils.py
@@ -625,18 +625,18 @@ class RBLNRuntimeModel(RBLNPytorchRuntime):
 
         # Aggregate output_logits
         padding_size = (self.rbln_config.prefill_chunk_size - query_length) % self.rbln_config.prefill_chunk_size
+        # `-padding_size` as a slice end drops the whole sequence when padding_size == 0 ([:, :-0] == [:, :0])
+        trim_end = -padding_size if padding_size > 0 else None
         if self.rbln_config.logits_to_keep == 1:
             output_logits = output_logits
         elif self.rbln_config.logits_to_keep > 1:
-            output_logits = output_logits[:, -padding_size - self.rbln_config.logits_to_keep : -padding_size, :]
+            output_logits = output_logits[:, -padding_size - self.rbln_config.logits_to_keep : trim_end, :]
         else:
-            output_logits = output_logits[:, :-padding_size, :]
+            output_logits = output_logits[:, :trim_end, :]
 
         all_hidden_states = None
         if self.rbln_config.output_hidden_states:
-            all_hidden_states = [
-                output_hidden_state[:, :-padding_size, :] for output_hidden_state in output_hidden_states
-            ]
+            all_hidden_states = [output_hidden_state[:, :trim_end, :] for output_hidden_state in output_hidden_states]
             all_hidden_states = tuple(all_hidden_states)
 
         # Update decoder attention mask with processed KV-cache length from prefill phase

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -150,6 +150,26 @@ class LLMTest:
     class TestLLMWithoutLMHead(TestLLM):
         RBLN_AUTO_CLASS = RBLNAutoModel
 
+        def test_forward_prompt_length_multiple_of_prefill_chunk_size(self):
+            # Regression test for #649: when the prompt length was an exact multiple of
+            # `prefill_chunk_size`, prefill trimmed the whole sequence ([:, :-0, :]) and
+            # returned an empty last_hidden_state.
+            chunk_size = self.model.rbln_config.prefill_chunk_size
+            batch_size = self.model.rbln_config.batch_size
+            max_seq_len = self.model.rbln_config.max_seq_len
+            hidden_size = self.model.config.hidden_size
+
+            for length in (chunk_size, chunk_size * 2):
+                if length > max_seq_len:
+                    continue
+                with self.subTest(length=length):
+                    input_ids = torch.ones((batch_size, length), dtype=torch.int64)
+                    output = self.model(input_ids=input_ids, attention_mask=torch.ones_like(input_ids))
+                    self.assertEqual(output.last_hidden_state.shape, (batch_size, length, hidden_size))
+                    if self.model.rbln_config.output_hidden_states:
+                        for hidden_state in output.hidden_states:
+                            self.assertEqual(hidden_state.shape, (batch_size, length, hidden_size))
+
 
 class TestMistralForCausalLM(LLMTest.TestLLM):
     RBLN_CLASS = RBLNMistralForCausalLM


### PR DESCRIPTION
Fixes #649.

## What

When `query_length` is an exact multiple of `prefill_chunk_size`, `padding_size` is `0` and the trailing-pad trim `[:, :-padding_size, :]` becomes `[:, :0, :]`, dropping the whole sequence instead of nothing. `RBLNQwen3Model` (and any decoder-only model with `logits_to_keep == 0`, e.g. everything served through vllm-rbln's `runner="pooling"`) returned an empty `last_hidden_state` for prompt lengths 128, 256, 384, ... The `output_hidden_states=True` path had the same bug.

## Fix

Guard the slice end with `None` when there is nothing to trim, mirroring the `if padding_size > 0:` guard already present on the input-padding side of the same function:

```python
trim_end = -padding_size if padding_size > 0 else None
```

Applied to the `logits_to_keep == 0`, `logits_to_keep > 1`, and `output_hidden_states` trims. (`logits_to_keep > 1` is currently rejected at config time, but the branch is now correct anyway. `logits_to_keep == 1` was never affected.)

## Verification

Ran the real `RBLNRuntimeModel.prefill_forward` against a mock runtime that writes position-coded values into the out buffers (no NPU needed), for lengths 1–1024 including every multiple of the chunk size, with and without `output_hidden_states`:

- **Before the fix**: `L=128` returns logits of shape `(1, 0, hidden)` — exactly the reported bug; with `output_hidden_states=True` every hidden state is empty too.
- **After the fix**: every length returns the full sequence with correct per-position values, and lengths that are *not* chunk multiples are bit-identical to the old behaviour.

## Test-suite hole

No existing test could catch this: every LLM test prompt is `"Who are you?"` (a handful of tokens), so `query_length % prefill_chunk_size == 0` was never exercised, and the empty output only occurs on the `logits_to_keep == 0` / `output_hidden_states` paths that the `*Model` (no-LM-head) tests use.

Added `test_forward_prompt_length_multiple_of_prefill_chunk_size` to `LLMTest.TestLLMWithoutLMHead`, which runs a forward pass with prompt lengths of exactly `prefill_chunk_size` and `2 * prefill_chunk_size` and asserts the output covers the full sequence. It is inherited by all `*Model` test classes (Mistral, Qwen2/3, OPT, Llama, Llama-Flash, GPT2, Phi), including `TestQwen2Model_OutputHiddenStates`, which also exercises the hidden-states trim (with the bug, that path crashes with a shape mismatch in `copy_`). It reuses the already-compiled model from `setUpClass`, so the added CI cost is a few short forward passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)