### PR TITLE
other: CI fix  fetch artifact download_url via per-artifact GET in auto compiler update

### DIFF
--- a/.github/workflows/auto_compiler_update_impl.yaml
+++ b/.github/workflows/auto_compiler_update_impl.yaml
@@ -44,14 +44,26 @@ jobs:
             exit 1
           fi
 
-          # 2. Locate the version manifest artifact produced by that build.
-          DL_URL=$( \
+          # 2. Locate the version manifest artifact. The list response has no
+          #    download_url; only the per-artifact GET returns it.
+          ART_RESP=$( \
             curl -fsS --retry 5 --retry-max-time 120 -H "$AUTH" \
               "${API}/builds/${BUILD_NUMBER}/artifacts" \
-            | jq -r 'first((if type=="array" then . else .items end)[] | select(.filename=="compiler-nightly-version") | .download_url) // empty' \
           )
+          ART_URL=$( \
+            printf '%s' "$ART_RESP" \
+            | jq -r 'first((if type=="array" then . else .items end)[] | select(.path=="compiler-nightly-version") | .url) // empty' \
+          )
+          if [ -z "$ART_URL" ]; then
+            echo "compiler-nightly-version artifact missing on build #${BUILD_NUMBER}; artifact list response was:" >&2
+            printf '%s\n' "$ART_RESP" >&2
+            exit 1
+          fi
+          ART_META=$(curl -fsS --retry 5 --retry-max-time 120 -H "$AUTH" "$ART_URL")
+          DL_URL=$(printf '%s' "$ART_META" | jq -r '.download_url // empty')
           if [ -z "$DL_URL" ]; then
-            echo "compiler-nightly-version artifact missing on build #${BUILD_NUMBER}" >&2
+            echo "no download_url for compiler-nightly-version artifact on build #${BUILD_NUMBER}; artifact response was:" >&2
+            printf '%s\n' "$ART_META" >&2
             exit 1
           fi
 


### PR DESCRIPTION
## Problem

The scheduled **Auto Compiler Update** workflow has failed every day since the Obedients-based version-resolution script landed (Jul 15), always with:

```
compiler-nightly-version artifact missing on build #NNN
```

The artifact actually exists on every one of those builds — the error is misleading.

## Root cause

The Obedients artifact **list** response (`GET /builds/{n}/artifacts`) carries only the artifact's API resource `url`; the pre-signed `download_url` is only returned by a **follow-up GET on that url**, and list items are matched by `.path`, not `.filename`. This is the contract the canonical implementation follows (`rebel_compiler` → `.buildkite/scripts/get-nightly-version.py`):

```python
artifacts = get(f"{API}/builds/{build}/artifacts")
meta_url = next((a["url"] for a in artifacts if a["path"] == "compiler-nightly-version"), None)
download_url = get(meta_url)["download_url"]
```

The workflow's jq extracted `.download_url` straight from the list response, which is always empty, so step 2 unconditionally hit the "artifact missing" branch and exited 1.

## Fix

Resolve the artifact in two steps, matching the canonical implementation:
1. Match the list item on `.path == "compiler-nightly-version"` and take its `.url`.
2. GET that url (authenticated) and extract `.download_url`.

Also split the error message so "artifact record missing" and "no download_url" are distinguishable.

## Verification

Confirmed against live data: nightly build #551 (dev, passed, Aug 4) has the `compiler-nightly-version` artifact with `path == "compiler-nightly-version"` and a per-artifact resource url, while the failed run 30943593153 queried the same build and found nothing with the old filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)