### PR TITLE
refactor: split cache metadata into a polymorphic CacheMeta hierarchy

### DIFF
--- a/src/optimum/rbln/transformers/cache_utils.py
+++ b/src/optimum/rbln/transformers/cache_utils.py
@@ -1,0 +1,187 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Metadata classes describing the on-device caches of a decoder-only model.
+
+Analogous to Transformers' ``cache_utils`` (which keeps ``DynamicCache`` / sliding-window /
+linear-attention layers as distinct types), this module holds a small polymorphic hierarchy:
+
+    CacheMeta                     # base: name, layer_index, shape, dtype; serialization
+    ├─ KVCacheMeta                # paged KV: [num_blocks, num_heads, block_size, head_dim]
+    │   ├─ FullAttentionKVCacheMeta      # resizable when is_auto (grown after compile)
+    │   └─ SlidingWindowKVCacheMeta      # fixed-size window
+    └─ LinearAttentionCacheMeta   # conv/recurrent state; raw model-computed shape, never resized
+
+Each subclass owns its ``can_resize`` / ``compile_shape`` and a class-level ``layer_type`` tag, so
+the previous single-dataclass-with-a-``layer_type``-string design (and its magic-string ``can_resize``)
+is gone. Instances are built through the ``make()`` dispatcher / the subclass ``from_config()``
+factories, which compute the derived ``shape`` and construct the meta.
+"""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from ..configuration_utils import RBLNSerializableConfigProtocol
+
+
+if TYPE_CHECKING:
+    from .models.decoderonly.configuration_decoderonly import RBLNDecoderOnlyModelForCausalLMConfig
+
+
+@dataclass
+class CacheMeta(RBLNSerializableConfigProtocol):
+    """
+    Base metadata describing a decoder cache tensor for one transformer layer.
+
+    Concrete subclasses distinguish the cache algorithm (full/sliding-window paged KV, linear
+    attention state). Each subclass owns its ``can_resize`` / ``compile_shape`` semantics and a
+    class-level ``layer_type`` tag; that avoids the previous single-dataclass-with-a-``layer_type``
+    -string design.
+
+    Instances are created through the ``make()`` dispatcher / the subclass ``from_config()`` factories,
+    which compute the derived ``shape`` and construct the meta; the dataclass constructor is just the
+    low-level mechanism those factories call.
+
+    Attributes:
+        name (str): Logical name of the cache tensor.
+        layer_index (int): Index of the transformer layer this cache belongs to.
+        shape (list[int]): Final tensor shape stored by the factory.
+        dtype (str): Data type of the cache buffer ("float16", "float32", ...).
+    """
+
+    name: str
+    layer_index: int
+    shape: list[int]
+    dtype: str
+
+    # Class-level cache-algorithm tag; overridden per subclass and emitted into the serialized config.
+    layer_type: ClassVar[str] = "cache"
+
+    def _prepare_for_serialization(self) -> dict[str, Any]:
+        # Emit the historical schema so serialized rbln_config.json stays consistent across cache types
+        # and with older artifacts. ``is_auto`` only exists on the full-attention subclass.
+        return {
+            "name": self.name,
+            "layer_index": self.layer_index,
+            "shape": self.shape,
+            "layer_type": self.layer_type,
+            "is_auto": getattr(self, "is_auto", False),
+            "dtype": self.dtype,
+        }
+
+    @property
+    def can_resize(self) -> bool:
+        return False
+
+    @property
+    def compile_shape(self) -> list[int]:
+        return self.shape
+
+
+@dataclass
+class KVCacheMeta(CacheMeta):
+    """Paged KV cache: ``shape == [num_blocks, num_heads, block_size, head_dim]``."""
+
+    @property
+    def num_blocks(self) -> int:
+        return self.shape[0]
+
+    @property
+    def block_size(self) -> int:
+        return self.shape[2]
+
+    @staticmethod
+    def _validate_num_blocks(num_blocks: int) -> None:
+        if num_blocks <= 0:
+            raise ValueError("`num_blocks` must be greater than 0 when using KV cache.")
+
+
+@dataclass
+class FullAttentionKVCacheMeta(KVCacheMeta):
+    """Full-attention paged KV cache. The only resizable cache: when ``is_auto`` it compiles with a
+    single block and is grown to the estimated block count after compilation."""
+
+    is_auto: bool
+    layer_type: ClassVar[str] = "full_attention"
+
+    @property
+    def can_resize(self) -> bool:
+        return self.is_auto
+
+    @property
+    def compile_shape(self) -> list[int]:
+        return [1, self.shape[1], self.shape[2], self.shape[3]] if self.is_auto else self.shape
+
+    @classmethod
+    def from_config(
+        cls,
+        name: str,
+        layer_index: int,
+        num_key_value_heads: int,
+        head_dim: int,
+        dtype: str,
+        rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
+    ) -> "FullAttentionKVCacheMeta":
+        block_size = rbln_config.kvcache_block_size
+        if rbln_config.is_auto_num_blocks:
+            num_blocks, is_auto = rbln_config.num_full_blocks, True
+        else:
+            num_blocks, is_auto = rbln_config.kvcache_num_blocks, False
+        cls._validate_num_blocks(num_blocks)
+        return cls(
+            name=name,
+            layer_index=layer_index,
+            shape=[num_blocks, num_key_value_heads, block_size, head_dim],
+            dtype=dtype,
+            is_auto=is_auto,
+        )
+
+
+@dataclass
+class SlidingWindowKVCacheMeta(KVCacheMeta):
+    """Sliding-window paged KV cache. Fixed size (one block per batch item), never resized."""
+
+    layer_type: ClassVar[str] = "sliding_attention"
+
+    @classmethod
+    def from_config(
+        cls,
+        name: str,
+        layer_index: int,
+        num_key_value_heads: int,
+        head_dim: int,
+        dtype: str,
+        rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
+    ) -> "SlidingWindowKVCacheMeta":
+        block_size = rbln_config.sliding_window
+        num_blocks = rbln_config.batch_size
+        cls._validate_num_blocks(num_blocks)
+        return cls(
+            name=name,
+            layer_index=layer_index,
+            shape=[num_blocks, num_key_value_heads, block_size, head_dim],
+            dtype=dtype,
+        )
+
+
+@dataclass
+class LinearAttentionCacheMeta(CacheMeta):
+    """Linear-attention (e.g. GatedDeltaNet) state: a fixed-size conv/recurrent tensor whose raw shape
+    is computed by the model. Not a paged KV cache — no block/head layout, never resized."""
+
+    layer_type: ClassVar[str] = "linear_attention"
+
+    @classmethod
+    def from_config(cls, name: str, layer_index: int, *, shape: list[int], dtype: str) -> "LinearAttentionCacheMeta":
+        return cls(name=name, layer_index=layer_index, shape=shape, dtype=dtype)

--- a/src/optimum/rbln/transformers/cache_utils.py
+++ b/src/optimum/rbln/transformers/cache_utils.py
@@ -35,7 +35,7 @@ class CacheMeta(RBLNSerializableConfigProtocol):
         │   └─ SlidingWindowKVCacheMeta      # fixed-size window
         └─ LinearAttentionCacheMeta   # conv/recurrent state; raw model-computed shape, never resized
 
-    Each subclass owns its ``can_resize`` / ``compile_shape`` and a class-level ``layer_type`` tag. 
+    Each subclass owns its ``can_resize`` / ``compile_shape`` and a class-level ``layer_type`` tag.
     ``CacheMeta`` / ``KVCacheMeta`` are abstract; instances are built through the
     subclass ``from_config()`` factories, which compute the derived ``shape`` and construct the meta.
 

--- a/src/optimum/rbln/transformers/cache_utils.py
+++ b/src/optimum/rbln/transformers/cache_utils.py
@@ -32,7 +32,7 @@ class CacheMeta(RBLNSerializableConfigProtocol):
         CacheMeta
         ├─ KVCacheMeta                # paged KV: [num_blocks, num_heads, block_size, head_dim]
         │   ├─ FullAttentionKVCacheMeta      # resizable when is_auto (grown after compile)
-        │   └─ SlidingWindowKVCacheMeta      # fixed-size window
+        │   └─ SlidingWindowAttentionKVCacheMeta      # fixed-size window
         └─ LinearAttentionCacheMeta   # conv/recurrent state; raw model-computed shape, never resized
 
     Each subclass owns its ``can_resize`` / ``compile_shape`` and a class-level ``layer_type`` tag.
@@ -141,7 +141,7 @@ class FullAttentionKVCacheMeta(KVCacheMeta):
 
 
 @dataclass
-class SlidingWindowKVCacheMeta(KVCacheMeta):
+class SlidingWindowAttentionKVCacheMeta(KVCacheMeta):
     """Sliding-window paged KV cache. Fixed size (one block per batch item), never resized."""
 
     layer_type: ClassVar[str] = "sliding_attention"
@@ -155,7 +155,7 @@ class SlidingWindowKVCacheMeta(KVCacheMeta):
         head_dim: int,
         dtype: str,
         rbln_config: "RBLNDecoderOnlyModelForCausalLMConfig",
-    ) -> "SlidingWindowKVCacheMeta":
+    ) -> "SlidingWindowAttentionKVCacheMeta":
         block_size = rbln_config.sliding_window
         num_blocks = rbln_config.batch_size
         cls._validate_num_blocks(num_blocks)

--- a/src/optimum/rbln/transformers/cache_utils.py
+++ b/src/optimum/rbln/transformers/cache_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Rebellions Inc. All rights reserved.
+# Copyright 2026 Rebellions Inc. All rights reserved.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,23 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Metadata classes describing the on-device caches of a decoder-only model.
-
-Analogous to Transformers' ``cache_utils`` (which keeps ``DynamicCache`` / sliding-window /
-linear-attention layers as distinct types), this module holds a small polymorphic hierarchy:
-
-    CacheMeta                     # base: name, layer_index, shape, dtype; serialization
-    ├─ KVCacheMeta                # paged KV: [num_blocks, num_heads, block_size, head_dim]
-    │   ├─ FullAttentionKVCacheMeta      # resizable when is_auto (grown after compile)
-    │   └─ SlidingWindowKVCacheMeta      # fixed-size window
-    └─ LinearAttentionCacheMeta   # conv/recurrent state; raw model-computed shape, never resized
-
-Each subclass owns its ``can_resize`` / ``compile_shape`` and a class-level ``layer_type`` tag, so
-the previous single-dataclass-with-a-``layer_type``-string design (and its magic-string ``can_resize``)
-is gone. Instances are built through the ``make()`` dispatcher / the subclass ``from_config()``
-factories, which compute the derived ``shape`` and construct the meta.
-"""
-
+from abc import abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -42,21 +26,23 @@ if TYPE_CHECKING:
 @dataclass
 class CacheMeta(RBLNSerializableConfigProtocol):
     """
-    Base metadata describing a decoder cache tensor for one transformer layer.
+    Base metadata describing a decoder cache tensor for one transformer layer, and the root of a small
+    polymorphic hierarchy. Concrete subclasses distinguish the cache algorithm:
 
-    Concrete subclasses distinguish the cache algorithm (full/sliding-window paged KV, linear
-    attention state). Each subclass owns its ``can_resize`` / ``compile_shape`` semantics and a
-    class-level ``layer_type`` tag; that avoids the previous single-dataclass-with-a-``layer_type``
-    -string design.
+        CacheMeta
+        ├─ KVCacheMeta                # paged KV: [num_blocks, num_heads, block_size, head_dim]
+        │   ├─ FullAttentionKVCacheMeta      # resizable when is_auto (grown after compile)
+        │   └─ SlidingWindowKVCacheMeta      # fixed-size window
+        └─ LinearAttentionCacheMeta   # conv/recurrent state; raw model-computed shape, never resized
 
-    Instances are created through the ``make()`` dispatcher / the subclass ``from_config()`` factories,
-    which compute the derived ``shape`` and construct the meta; the dataclass constructor is just the
-    low-level mechanism those factories call.
+    Each subclass owns its ``can_resize`` / ``compile_shape`` and a class-level ``layer_type`` tag. 
+    ``CacheMeta`` / ``KVCacheMeta`` are abstract; instances are built through the
+    subclass ``from_config()`` factories, which compute the derived ``shape`` and construct the meta.
 
     Attributes:
         name (str): Logical name of the cache tensor.
         layer_index (int): Index of the transformer layer this cache belongs to.
-        shape (list[int]): Final tensor shape stored by the factory.
+        shape (list[int]): Derived tensor shape computed by the factory.
         dtype (str): Data type of the cache buffer ("float16", "float32", ...).
     """
 
@@ -87,6 +73,14 @@ class CacheMeta(RBLNSerializableConfigProtocol):
     @property
     def compile_shape(self) -> list[int]:
         return self.shape
+
+    @classmethod
+    @abstractmethod
+    def from_config(cls, *args, **kwargs) -> "CacheMeta":
+        # Construction entry point. Concrete subclasses define the real signature (paged KV takes
+        # num_key_value_heads/head_dim/rbln_config; linear takes a raw shape) and compute the derived
+        # shape.
+        ...
 
 
 @dataclass
@@ -183,5 +177,5 @@ class LinearAttentionCacheMeta(CacheMeta):
     layer_type: ClassVar[str] = "linear_attention"
 
     @classmethod
-    def from_config(cls, name: str, layer_index: int, *, shape: list[int], dtype: str) -> "LinearAttentionCacheMeta":
+    def from_config(cls, name: str, layer_index: int, shape: list[int], dtype: str) -> "LinearAttentionCacheMeta":
         return cls(name=name, layer_index=layer_index, shape=shape, dtype=dtype)

--- a/src/optimum/rbln/transformers/cache_utils.py
+++ b/src/optimum/rbln/transformers/cache_utils.py
@@ -55,8 +55,6 @@ class CacheMeta(RBLNSerializableConfigProtocol):
     layer_type: ClassVar[str] = "cache"
 
     def _prepare_for_serialization(self) -> dict[str, Any]:
-        # Emit the historical schema so serialized rbln_config.json stays consistent across cache types
-        # and with older artifacts. ``is_auto`` only exists on the full-attention subclass.
         return {
             "name": self.name,
             "layer_index": self.layer_index,

--- a/src/optimum/rbln/transformers/modeling_attention_utils.py
+++ b/src/optimum/rbln/transformers/modeling_attention_utils.py
@@ -343,7 +343,7 @@ class RBLNDecoderOnlyFlashAttentionMixin:
         # buffers' current block count (`current_blocks`), so a resizable tensor's per-block bytes
         # are size // current_blocks, rescaled to num_blocks; others are fixed. Each 2MB-aligned
         # after scaling, so bytes grow non-linearly.
-        can_resize = {meta.name: meta.can_resize for meta in rbln_config.kvcache_metas}
+        can_resize = {meta.name: meta.can_resize for meta in rbln_config.cache_metas}
         sizes: dict[tuple[int, int], int] = defaultdict(int)
         for key, sizes_at_node in kvcache_tensor_sizes.items():
             resizable = can_resize[key]
@@ -381,9 +381,5 @@ class RBLNDecoderOnlyFlashAttentionMixin:
     ):
         for compiled_model in compiled_models.values():
             compiled_model.exp_multiply_buffer_size(
-                {
-                    kvcache_meta.name: multiplier
-                    for kvcache_meta in rbln_config.kvcache_metas
-                    if kvcache_meta.can_resize
-                }
+                {cache_meta.name: multiplier for cache_meta in rbln_config.cache_metas if cache_meta.can_resize}
             )

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import asdict, dataclass
 from typing import Any, Literal, get_args
 
-from ....configuration_utils import RBLNModelConfig, RBLNSerializableConfigProtocol
+from ....configuration_utils import RBLNModelConfig
 from ....utils.logging import get_logger
+from ...cache_utils import CacheMeta
 from ...utils.rbln_quantization import RBLNQuantizationConfig
 from .configuration_lora import RBLNLoRAConfig
 
@@ -62,7 +62,7 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
         phases: list[PhaseType] | None = None,
         logits_to_keep: int | None = None,
         output_hidden_states: bool | None = None,
-        kvcache_metas: list["KVCacheMeta"] | None = None,
+        kvcache_metas: list["CacheMeta"] | None = None,
         **kwargs: Any,
     ):
         """
@@ -125,7 +125,7 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
             logits_to_keep (int | None): The number of logits to keep for the decoder.  If set to 0, the decoder will keep all logits.
                 Defaults to 0 if DecoderOnlyModel is used, 1 if DecoderOnlyModelForCausalLM is used.
             output_hidden_states (bool | None): Whether to output the hidden states of the decoder. Defaults to False.
-            kvcache_metas (list["KVCacheMeta"] | None): The metadata for the KV cache tensors. Handled internally if not provided. Defaults to None.
+            kvcache_metas (list["CacheMeta"] | None): The metadata for the cache tensors. Handled internally if not provided. Defaults to None.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:
@@ -272,7 +272,7 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
                 # Larger batch size should be at the beginning of the list.
                 self.decoder_batch_sizes.sort(reverse=True)
 
-        self.kvcache_metas: list[KVCacheMeta] = kvcache_metas or []
+        self.kvcache_metas: list[CacheMeta] = kvcache_metas or []
 
     @staticmethod
     def validate_phases_type(phases: list[PhaseType]):
@@ -367,100 +367,3 @@ class RBLNDecoderOnlyModelForCausalLMConfig(RBLNDecoderOnlyModelConfig):
 
     _default_phases = ["prefill", "decode"]
     _default_logits_to_keep = 1
-
-
-@dataclass
-class KVCacheMeta(RBLNSerializableConfigProtocol):
-    """
-    KVCacheMeta contains metadata describing the key-value (KV) cache tensor for a specific transformer layer.
-
-    This is used during compilation and runtime on RBLN devices to manage memory and configure the
-    static or dynamic characteristics of the cache implementation for decoder-only models.
-
-    Attributes:
-        name (str): Logical name of the KV cache tensor.
-        layer_index (int): Index of the transformer layer corresponding to this cache.
-        shape (list[int]): The 4D shape of the cache tensor:
-            [num_blocks, num_heads, block_size, head_dim]. The number of blocks may be dynamic or static
-            depending on model configuration.
-        layer_type (str): String describing the attention/cache algorithm (e.g., "full_attention", "sliding_attention").
-        is_auto (bool): Whether the number of blocks is automatically determined during compilation (True) or manually specified (False).
-            In both cases, the KV cache size is fixed at compile time.
-        dtype (str): Data type of the cache buffer ("float16", "float32", etc.).
-    """
-
-    name: str
-    layer_index: int
-    shape: list[int]  # (num_blocks, num_heads, block_size(seq), head_dim)
-    layer_type: str
-    is_auto: bool
-    dtype: str
-
-    def _prepare_for_serialization(self) -> dict[str, Any]:
-        return asdict(self)
-
-    @property
-    def compile_shape(self):
-        return [1, self.shape[1], self.shape[2], self.shape[3]] if self.can_resize else self.shape
-
-    @property
-    def can_resize(self):
-        return self.is_auto and self.layer_type == "full_attention"
-
-    @property
-    def num_blocks(self) -> int:
-        return self.shape[0]
-
-    @property
-    def block_size(self) -> int:
-        return self.shape[2]
-
-    @staticmethod
-    def make(
-        name: str,
-        layer_index: int,
-        num_key_value_heads: int | None = None,
-        head_dim: int | None = None,
-        dtype: str | None = None,
-        rbln_config: RBLNDecoderOnlyModelForCausalLMConfig | None = None,
-        *,
-        shape: list[int] | None = None,
-    ) -> "KVCacheMeta":
-        assert len(rbln_config.compile_cfgs) == 0, "KVCacheMeta cannot be created from rbln_config with compile_cfgs"
-
-        if layer_index in getattr(rbln_config, "linear_attention_layers", []):
-            if shape is None:
-                raise ValueError("`shape` is required to build a linear_attention layer's KVCacheMeta.")
-            return KVCacheMeta(
-                name=name,
-                layer_index=layer_index,
-                shape=shape,
-                layer_type="linear_attention",
-                is_auto=False,
-                dtype=dtype,
-            )
-
-        elif rbln_config.sliding_window is not None and layer_index in rbln_config.sliding_window_layers:
-            layer_type = "sliding_attention"
-            block_size = rbln_config.sliding_window
-            num_blocks = rbln_config.batch_size
-            is_auto = False
-
-        else:
-            layer_type = "full_attention"
-            block_size = rbln_config.kvcache_block_size
-
-            if rbln_config.is_auto_num_blocks:
-                num_blocks = rbln_config.num_full_blocks
-                is_auto = True
-            else:
-                num_blocks = rbln_config.kvcache_num_blocks
-                is_auto = False
-
-        shape = [num_blocks, num_key_value_heads, block_size, head_dim]
-        if num_blocks <= 0:
-            raise ValueError("`num_blocks` must be greater than 0 when using KV cache.")
-
-        return KVCacheMeta(
-            name=name, layer_index=layer_index, shape=shape, layer_type=layer_type, is_auto=is_auto, dtype=dtype
-        )

--- a/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/configuration_decoderonly.py
@@ -15,6 +15,7 @@
 from typing import Any, Literal, get_args
 
 from ....configuration_utils import RBLNModelConfig
+from ....utils.deprecation import deprecate_kwarg
 from ....utils.logging import get_logger
 from ...cache_utils import CacheMeta
 from ...utils.rbln_quantization import RBLNQuantizationConfig
@@ -40,6 +41,7 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
     _default_logits_to_keep = 0
     subclass_non_save_attributes = ["memory_budget"]
 
+    @deprecate_kwarg(old_name="kvcache_metas", new_name="cache_metas", version="0.12.0")
     def __init__(
         self,
         batch_size: int | None = None,
@@ -62,7 +64,7 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
         phases: list[PhaseType] | None = None,
         logits_to_keep: int | None = None,
         output_hidden_states: bool | None = None,
-        kvcache_metas: list["CacheMeta"] | None = None,
+        cache_metas: list["CacheMeta"] | None = None,
         **kwargs: Any,
     ):
         """
@@ -125,7 +127,7 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
             logits_to_keep (int | None): The number of logits to keep for the decoder.  If set to 0, the decoder will keep all logits.
                 Defaults to 0 if DecoderOnlyModel is used, 1 if DecoderOnlyModelForCausalLM is used.
             output_hidden_states (bool | None): Whether to output the hidden states of the decoder. Defaults to False.
-            kvcache_metas (list["CacheMeta"] | None): The metadata for the cache tensors. Handled internally if not provided. Defaults to None.
+            cache_metas (list["CacheMeta"] | None): The metadata for the cache tensors. Handled internally if not provided. Defaults to None.
             kwargs: Additional arguments passed to the parent RBLNModelConfig.
 
         Raises:
@@ -272,7 +274,7 @@ class RBLNDecoderOnlyModelConfig(RBLNModelConfig):
                 # Larger batch size should be at the beginning of the list.
                 self.decoder_batch_sizes.sort(reverse=True)
 
-        self.kvcache_metas: list[CacheMeta] = kvcache_metas or []
+        self.cache_metas: list[CacheMeta] = cache_metas or []
 
     @staticmethod
     def validate_phases_type(phases: list[PhaseType]):

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -27,6 +27,7 @@ from transformers.modeling_outputs import BaseModelOutputWithPast
 from ....configuration_utils import RBLNCompileConfig
 from ....modeling import RBLNModel
 from ....utils.logging import get_logger
+from ...cache_utils import FullAttentionKVCacheMeta, SlidingWindowKVCacheMeta
 from ...modeling_attention_utils import (
     RBLNDecoderOnlyFlashAttentionMixin,
     set_default_values,
@@ -35,7 +36,7 @@ from ...modeling_attention_utils import (
 )
 from ...modeling_outputs import RBLNDecoderOnlyOutput, _validate_output_hidden_states
 from ...utils.rbln_quantization import get_quantized_model
-from .configuration_decoderonly import KVCacheMeta, RBLNDecoderOnlyModelConfig, RBLNDecoderOnlyModelForCausalLMConfig
+from .configuration_decoderonly import RBLNDecoderOnlyModelConfig, RBLNDecoderOnlyModelForCausalLMConfig
 from .decoderonly_architecture import DecoderOnlyWrapper
 from .decoderonly_runtime_utils import RBLNPageTableManager, RBLNRuntimeModel
 from .generation_decoderonly import RBLNDecoderOnlyGenerationMixin
@@ -410,18 +411,21 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
             if rbln_config.quantization and rbln_config.quantization.kv_caches == "fp8":
                 kvcache_dtype = "float8_e4m3fn"
 
+            kvcache_dtype = RBLNCompileConfig.normalize_dtype(kvcache_dtype)
             kvcache_metas = []
             for i in range(num_hidden_layers * 2):
                 layer_idx = i // 2
                 name = f"past_key_values_{i}"
-                kvcache_meta = KVCacheMeta.make(
-                    name,
-                    layer_idx,
-                    num_key_value_heads,
-                    head_dim,
-                    RBLNCompileConfig.normalize_dtype(kvcache_dtype),
-                    rbln_config,
-                )
+                # Pick the concrete meta by the layer's cache kind (linear layers are handled by model
+                # subclasses that pre-populate kvcache_metas, so here it's sliding-window vs full).
+                if rbln_config.sliding_window is not None and layer_idx in rbln_config.sliding_window_layers:
+                    kvcache_meta = SlidingWindowKVCacheMeta.from_config(
+                        name, layer_idx, num_key_value_heads, head_dim, kvcache_dtype, rbln_config
+                    )
+                else:
+                    kvcache_meta = FullAttentionKVCacheMeta.from_config(
+                        name, layer_idx, num_key_value_heads, head_dim, kvcache_dtype, rbln_config
+                    )
                 kvcache_metas.append(kvcache_meta)
                 input_info.append((name, kvcache_meta.compile_shape, kvcache_meta.dtype))
 

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -27,7 +27,7 @@ from transformers.modeling_outputs import BaseModelOutputWithPast
 from ....configuration_utils import RBLNCompileConfig
 from ....modeling import RBLNModel
 from ....utils.logging import get_logger
-from ...cache_utils import FullAttentionKVCacheMeta, SlidingWindowKVCacheMeta
+from ...cache_utils import FullAttentionKVCacheMeta, SlidingWindowAttentionKVCacheMeta
 from ...modeling_attention_utils import (
     RBLNDecoderOnlyFlashAttentionMixin,
     set_default_values,
@@ -417,7 +417,7 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
                 layer_idx = i // 2
                 name = f"past_key_values_{i}"
                 if rbln_config.sliding_window is not None and layer_idx in rbln_config.sliding_window_layers:
-                    cache_meta = SlidingWindowKVCacheMeta.from_config(
+                    cache_meta = SlidingWindowAttentionKVCacheMeta.from_config(
                         name, layer_idx, num_key_value_heads, head_dim, kvcache_dtype, rbln_config
                     )
                 else:

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -416,8 +416,6 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
             for i in range(num_hidden_layers * 2):
                 layer_idx = i // 2
                 name = f"past_key_values_{i}"
-                # Pick the concrete meta by the layer's cache kind (linear layers are handled by model
-                # subclasses that pre-populate cache_metas, so here it's sliding-window vs full).
                 if rbln_config.sliding_window is not None and layer_idx in rbln_config.sliding_window_layers:
                     cache_meta = SlidingWindowKVCacheMeta.from_config(
                         name, layer_idx, num_key_value_heads, head_dim, kvcache_dtype, rbln_config

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -397,12 +397,12 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
         if rbln_config.use_lora:
             input_info.append(("lora_int_ids", [batch_size], "int32"))
 
-        if len(rbln_config.kvcache_metas) > 0:
+        if len(rbln_config.cache_metas) > 0:
             # Meta is already set, use it
             input_info.extend(
                 [
-                    (kvcache_meta.name, kvcache_meta.compile_shape, kvcache_meta.dtype)
-                    for kvcache_meta in rbln_config.kvcache_metas
+                    (cache_meta.name, cache_meta.compile_shape, cache_meta.dtype)
+                    for cache_meta in rbln_config.cache_metas
                 ]
             )
 
@@ -412,24 +412,24 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
                 kvcache_dtype = "float8_e4m3fn"
 
             kvcache_dtype = RBLNCompileConfig.normalize_dtype(kvcache_dtype)
-            kvcache_metas = []
+            cache_metas = []
             for i in range(num_hidden_layers * 2):
                 layer_idx = i // 2
                 name = f"past_key_values_{i}"
                 # Pick the concrete meta by the layer's cache kind (linear layers are handled by model
-                # subclasses that pre-populate kvcache_metas, so here it's sliding-window vs full).
+                # subclasses that pre-populate cache_metas, so here it's sliding-window vs full).
                 if rbln_config.sliding_window is not None and layer_idx in rbln_config.sliding_window_layers:
-                    kvcache_meta = SlidingWindowKVCacheMeta.from_config(
+                    cache_meta = SlidingWindowKVCacheMeta.from_config(
                         name, layer_idx, num_key_value_heads, head_dim, kvcache_dtype, rbln_config
                     )
                 else:
-                    kvcache_meta = FullAttentionKVCacheMeta.from_config(
+                    cache_meta = FullAttentionKVCacheMeta.from_config(
                         name, layer_idx, num_key_value_heads, head_dim, kvcache_dtype, rbln_config
                     )
-                kvcache_metas.append(kvcache_meta)
-                input_info.append((name, kvcache_meta.compile_shape, kvcache_meta.dtype))
+                cache_metas.append(cache_meta)
+                input_info.append((name, cache_meta.compile_shape, cache_meta.dtype))
 
-            rbln_config.kvcache_metas.extend(kvcache_metas)
+            rbln_config.cache_metas.extend(cache_metas)
 
         return input_info
 

--- a/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
@@ -33,7 +33,7 @@ from transformers.models.gemma4.modeling_gemma4 import Gemma4VisionRotaryEmbeddi
 from ....configuration_utils import RBLNCompileConfig, RBLNModelConfig
 from ....modeling import RBLNModel
 from ....utils.logging import get_logger
-from ...cache_utils import FullAttentionKVCacheMeta, SlidingWindowKVCacheMeta
+from ...cache_utils import FullAttentionKVCacheMeta, SlidingWindowAttentionKVCacheMeta
 from ...modeling_attention_utils import validate_sliding_window
 from ...modeling_outputs import RBLNDecoderOnlyOutput
 from ...utils.rbln_runtime_wrapper import LoopProcessor
@@ -561,7 +561,7 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             num_kv = num_kv_sliding if is_sliding else num_kv_full
             head_dim = head_dim_sliding if is_sliding else head_dim_full
 
-            meta_cls = SlidingWindowKVCacheMeta if is_sliding else FullAttentionKVCacheMeta
+            meta_cls = SlidingWindowAttentionKVCacheMeta if is_sliding else FullAttentionKVCacheMeta
             for kv_offset, _ in enumerate(("key", "value")):
                 name = f"past_key_values_{layer_idx * 2 + kv_offset}"
                 meta = meta_cls.from_config(

--- a/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
@@ -33,10 +33,10 @@ from transformers.models.gemma4.modeling_gemma4 import Gemma4VisionRotaryEmbeddi
 from ....configuration_utils import RBLNCompileConfig, RBLNModelConfig
 from ....modeling import RBLNModel
 from ....utils.logging import get_logger
+from ...cache_utils import FullAttentionKVCacheMeta, SlidingWindowKVCacheMeta
 from ...modeling_attention_utils import validate_sliding_window
 from ...modeling_outputs import RBLNDecoderOnlyOutput
 from ...utils.rbln_runtime_wrapper import LoopProcessor
-from ..decoderonly.configuration_decoderonly import KVCacheMeta
 from ..decoderonly.decoderonly_runtime_utils import RBLNPageTableManager
 from ..decoderonly.generation_decoderonly import RBLNDecoderOnlyGenerationMixin
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModelForCausalLM
@@ -561,9 +561,10 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
             num_kv = num_kv_sliding if is_sliding else num_kv_full
             head_dim = head_dim_sliding if is_sliding else head_dim_full
 
+            meta_cls = SlidingWindowKVCacheMeta if is_sliding else FullAttentionKVCacheMeta
             for kv_offset, _ in enumerate(("key", "value")):
                 name = f"past_key_values_{layer_idx * 2 + kv_offset}"
-                meta = KVCacheMeta.make(
+                meta = meta_cls.from_config(
                     name=name,
                     layer_index=layer_idx,
                     num_key_value_heads=num_kv,

--- a/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
@@ -257,7 +257,7 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         rbln_config: RBLNGemma4ForCausalLMConfig,
         model_config: PretrainedConfig,
     ):
-        cls._pre_populate_kvcache_metas(model_config, rbln_config)
+        cls._pre_populate_cache_metas(model_config, rbln_config)
 
         base_info = super().get_input_info(
             batch_size=batch_size,
@@ -518,20 +518,20 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         return embed_tokens
 
     @classmethod
-    def _pre_populate_kvcache_metas(
+    def _pre_populate_cache_metas(
         cls,
         model_config: "PretrainedConfig",
         rbln_config: RBLNGemma4ForCausalLMConfig,
     ) -> None:
-        # Pre-populates rbln_config.kvcache_metas with per-layer-heterogeneous KV shapes.
+        # Pre-populates rbln_config.cache_metas with per-layer-heterogeneous KV shapes.
         # Gemma4 mixes two layer kinds:
         #   sliding_attention: head_dim=config.head_dim, num_kv=config.num_key_value_heads.
         #   full_attention: head_dim=config.global_head_dim,
         #     num_kv=config.num_global_key_value_heads (attention_k_eq_v=True) or num_key_value_heads.
-        # Base get_input_info short-circuits on a non-empty kvcache_metas list and uses these entries
+        # Base get_input_info short-circuits on a non-empty cache_metas list and uses these entries
         # verbatim as compile-time KV cache input shapes — the only way to express per-layer
         # heterogeneous KV geometry in the current pipeline.
-        if len(rbln_config.kvcache_metas) > 0:
+        if len(rbln_config.cache_metas) > 0:
             return  # already populated (e.g. loaded from disk)
 
         dtype_str = RBLNCompileConfig.normalize_dtype(rbln_config.dtype)
@@ -572,7 +572,7 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
                     dtype=dtype_str,
                     rbln_config=rbln_config,
                 )
-                rbln_config.kvcache_metas.append(meta)
+                rbln_config.cache_metas.append(meta)
 
     @classmethod
     def _update_submodule_config(

--- a/src/optimum/rbln/transformers/models/modernbert/modeling_modernbert.py
+++ b/src/optimum/rbln/transformers/models/modernbert/modeling_modernbert.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 
 import torch
 from transformers.modeling_outputs import MaskedLMOutput
@@ -65,10 +65,10 @@ class RBLNModernBertForMaskedLM(RBLNModelForMaskedLM):
 
     def forward(
         self,
-        input_ids: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
+        input_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
         **kwargs,
-    ) -> Union[Tuple, MaskedLMOutput]:
+    ) -> tuple | MaskedLMOutput:
         """
         Forward pass for the RBLN-optimized ModernBERT model for masked language modeling tasks.
 

--- a/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -33,8 +33,8 @@ from transformers.models.qwen3_5.modeling_qwen3_5 import (
 from ....configuration_utils import RBLNCompileConfig
 from ....modeling import RBLNModel
 from ....utils import logging
+from ...cache_utils import FullAttentionKVCacheMeta, LinearAttentionCacheMeta
 from ...modeling_outputs import RBLNDecoderOnlyOutput
-from ..decoderonly.configuration_decoderonly import KVCacheMeta
 from ..decoderonly.decoderonly_runtime_utils import RBLNPageTableManager
 from ..decoderonly.modeling_decoderonly import RBLNDecoderOnlyModel, RBLNDecoderOnlyModelForCausalLM
 from .configuration_qwen3_5 import (
@@ -236,28 +236,20 @@ class RBLNQwen3_5TextModel(RBLNDecoderOnlyModel):
                     # recurrent cache is stored 3D (B, Hv*Dk, Dv); GatedDeltaNet reshapes to 4D internally.
                     conv_shape, recurrent_shape = _qwen3_5_linear_state_shapes(text_config, rbln_config.batch_size)
                     kvcache_metas.append(
-                        KVCacheMeta.make(
-                            f"conv_state_{layer_idx}",
-                            layer_idx,
-                            dtype=_state_dtype,
-                            rbln_config=rbln_config,
-                            shape=list(conv_shape),
+                        LinearAttentionCacheMeta.from_config(
+                            f"conv_state_{layer_idx}", layer_idx, shape=list(conv_shape), dtype=_state_dtype
                         )
                     )
                     kvcache_metas.append(
-                        KVCacheMeta.make(
-                            f"recurrent_state_{layer_idx}",
-                            layer_idx,
-                            dtype=_state_dtype,
-                            rbln_config=rbln_config,
-                            shape=list(recurrent_shape),
+                        LinearAttentionCacheMeta.from_config(
+                            f"recurrent_state_{layer_idx}", layer_idx, shape=list(recurrent_shape), dtype=_state_dtype
                         )
                     )
                 else:
                     for slot in range(2):
                         name = f"past_key_values_{layer_idx * 2 + slot}"
                         kvcache_metas.append(
-                            KVCacheMeta.make(
+                            FullAttentionKVCacheMeta.from_config(
                                 name,
                                 layer_idx,
                                 num_key_value_heads,

--- a/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -220,8 +220,8 @@ class RBLNQwen3_5TextModel(RBLNDecoderOnlyModel):
         # per-layer state: full_attention -> paged KV (key, value); linear_attention -> (conv_state, recurrent_state).
         linear_layers = rbln_config.linear_attention_layers
 
-        if len(rbln_config.kvcache_metas) > 0:
-            input_info.extend([(meta.name, meta.compile_shape, meta.dtype) for meta in rbln_config.kvcache_metas])
+        if len(rbln_config.cache_metas) > 0:
+            input_info.extend([(meta.name, meta.compile_shape, meta.dtype) for meta in rbln_config.cache_metas])
         else:
             kvcache_dtype = rbln_config.dtype
             if rbln_config.quantization and rbln_config.quantization.kv_caches == "fp8":
@@ -230,17 +230,17 @@ class RBLNQwen3_5TextModel(RBLNDecoderOnlyModel):
             # conv/recurrent caches are one shared static tensor, so sized to the max batch (not batch_size=1 for
             # prefill). Prefill writes its own slot (batch_idx); decode runs the full batch.
             _state_dtype = RBLNCompileConfig.normalize_dtype(rbln_config.dtype)
-            kvcache_metas = []
+            cache_metas = []
             for layer_idx in range(num_hidden_layers):
                 if layer_idx in linear_layers:
                     # recurrent cache is stored 3D (B, Hv*Dk, Dv); GatedDeltaNet reshapes to 4D internally.
                     conv_shape, recurrent_shape = _qwen3_5_linear_state_shapes(text_config, rbln_config.batch_size)
-                    kvcache_metas.append(
+                    cache_metas.append(
                         LinearAttentionCacheMeta.from_config(
                             f"conv_state_{layer_idx}", layer_idx, shape=list(conv_shape), dtype=_state_dtype
                         )
                     )
-                    kvcache_metas.append(
+                    cache_metas.append(
                         LinearAttentionCacheMeta.from_config(
                             f"recurrent_state_{layer_idx}", layer_idx, shape=list(recurrent_shape), dtype=_state_dtype
                         )
@@ -248,7 +248,7 @@ class RBLNQwen3_5TextModel(RBLNDecoderOnlyModel):
                 else:
                     for slot in range(2):
                         name = f"past_key_values_{layer_idx * 2 + slot}"
-                        kvcache_metas.append(
+                        cache_metas.append(
                             FullAttentionKVCacheMeta.from_config(
                                 name,
                                 layer_idx,
@@ -258,8 +258,8 @@ class RBLNQwen3_5TextModel(RBLNDecoderOnlyModel):
                                 rbln_config,
                             )
                         )
-            input_info.extend([(meta.name, meta.compile_shape, meta.dtype) for meta in kvcache_metas])
-            rbln_config.kvcache_metas.extend(kvcache_metas)
+            input_info.extend([(meta.name, meta.compile_shape, meta.dtype) for meta in cache_metas])
+            rbln_config.cache_metas.extend(cache_metas)
 
         # shared 0/1 masks: runtime feeds zeros on prefill window 0 (reset linear state), ones after (carry). See docs.
         if linear_layers:


### PR DESCRIPTION
## Summary

Refactors the decoder-only cache metadata from a single string-typed `KVCacheMeta` dataclass into a
small **polymorphic `CacheMeta` hierarchy**, moved to `transformers/cache_utils.py` (mirroring HF
Transformers' `cache_utils.py` location).

```
CacheMeta                         # base (abstract): name, layer_index, shape, dtype; serialization
├─ KVCacheMeta                    # paged KV (abstract): num_blocks / block_size
│   ├─ FullAttentionKVCacheMeta   # resizable when is_auto
│   └─ SlidingWindowKVCacheMeta   # fixed-size window
└─ LinearAttentionCacheMeta       # conv/recurrent state; raw model-computed shape, never resized
```

## Motivation

The previous single `KVCacheMeta` dataclass crammed three different cache kinds together:

- `can_resize` was a **magic-string** property: `is_auto and layer_type == "full_attention"`.
- `shape` was documented as 4D `[num_blocks, num_heads, block_size, head_dim]`, but linear-attention
  (Qwen3.5 GatedDeltaNet) stuffed raw `conv_state` / `recurrent_state` shapes into the same field via a
  `shape=` early-return hack in `KVCacheMeta.make()`.
- Linear-attention state was only registered as a `KVCacheMeta` (with `layer_type="linear_attention"`)
  as a **stopgap** so the block-estimation code's `can_resize[key]` lookup wouldn't `KeyError` on the
  linear DRAM tensors.

## What changed (structure)

- Each cache kind is now its own type; `can_resize` / `compile_shape` are **per-subclass properties**
  (no magic string), and `layer_type` is a class-level tag.
- Construction goes through per-subclass `from_config()` factories. The old `KVCacheMeta.make()`
  if-chain dispatcher is **removed** — each builder picks the concrete subclass by the layer kind it
  already knows (decoder-only base & gemma4: sliding vs full; qwen3.5: linear vs full).
- `CacheMeta` / `KVCacheMeta` are abstract (`from_config` is `@abstractmethod`; ABCMeta comes from the
  serialization Protocol base) — only the concrete leaves are instantiable.
- Linear state is now a first-class `LinearAttentionCacheMeta` instead of a disguised `KVCacheMeta`, so
  the block-estimation `KeyError` is avoided **by design** rather than by the stopgap registration.
- `RBLNDecoderOnlyModelConfig.kvcache_metas` is renamed to **`cache_metas`** (the list now holds non-KV
  linear metas too, so `kvcache_metas` was a misnomer). A `@deprecate_kwarg(old_name="kvcache_metas",
  new_name="cache_metas", version="0.12.0")` remaps the old key.

## Behavior

Runtime and block-estimation behavior is **unchanged**; the one observable difference is the serialized
config key rename, handled with a deprecation remap.

| Aspect | Before | After |
| --- | --- | --- |
| `can_resize` | `is_auto and layer_type == "full_attention"` | subclass property (Full = `is_auto`; sliding/linear = `False`) — **identical values** |
| `compile_shape` | `[1, h, block, d]` if resizable else `shape` | Full flattens blocks→1 when `is_auto`; others return `shape` — **identical** |
| `num_block` estimation / DRAM sizing | `_kvcache_bytes_per_chiplet` scales resizable tensors; `multiply_kv_cache_num_blocks` grows `can_resize` buffers | same inputs (`meta.name` / `meta.can_resize` / `compile_shape`) — **identical result** |
| Config field / serialized key | `kvcache_metas` | **`cache_metas`** (old key remapped on load via `@deprecate_kwarg`) |
| Per-meta serialized schema | `{name, layer_index, shape, layer_type, is_auto, dtype}` | same keys emitted (`is_auto` defaults to `False`) — **identical** |

Why the estimation is unaffected: `modeling_attention_utils` reads only `meta.name` and
`meta.can_resize` (plus `compile_shape` indirectly, via what gets compiled). All three are byte-identical
to the old formula across every cache kind (verified: full-auto / full-manual / sliding / linear-conv /
linear-recur). Avoiding the `can_resize[key]` `KeyError` for linear tensors is now structural (linear is
a registered first-class meta) instead of the previous stopgap.

## Backward compatibility

- **Config key rename** `kvcache_metas` → `cache_metas` is remapped on load by `@deprecate_kwarg`, so
  existing `rbln_config.json` artifacts (which serialize `kvcache_metas`) load unchanged. Metas are
  compile-time only and inert on load anyway.
- The per-meta serialized schema is unchanged; `layer_type` is retained purely as a serialized tag for
  readability/compat and no longer drives any logic.

## Testing

- Unit parity check: new `can_resize` / `compile_shape` / serialized schema match the old formula for
  all five cache kinds; `@deprecate_kwarg` remaps `kvcache_metas=` → `cache_metas=`.
- Compile + generate tests pass: `TestQwen3_5ForConditionalGeneration` (full + linear),
  `TestGemma3ForCausalLM` (sliding + full) — covers the decoder-only base builder and the qwen3.5 builder.
- `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
