### PR TITLE
other(build): cap hatchling <1.32 to keep Metadata-Version 2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,10 @@ deploy = [
 ]
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+# hatchling 1.32 bumped the emitted Metadata-Version to 2.5, which the twine 6.x
+# pinned in the deploy job rejects ("'2.5' is not a valid metadata version").
+# Cap at <1.32 so `uv build` emits 2.4 until the deploy stack (twine) moves up.
+requires = ["hatchling<1.32", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]


### PR DESCRIPTION
## Problem

The tag deploy (`deploy-on-tag` → `deploy.yaml`) fails at **Publish package**:

```
twine upload → InvalidDistribution: Invalid distribution metadata:
               '2.5' is not a valid metadata version
```

## Root cause

The build and publish steps disagree on the core Metadata-Version:

- `uv build` resolves the build backend fresh in an isolated env, picking the **latest hatchling**. hatchling **1.32** bumped the emitted `Metadata-Version` to **2.5**.
- The publish step installs twine from `uv.lock` (`uv sync --frozen --only-group deploy` → **twine 6.2.0**). twine 6.x monkeypatches `packaging`'s valid-version list to **<= 2.4** and rejects 2.5.

So hatchling moved forward while twine stayed pinned in the lock — a mismatch. Verified locally (isolated venvs): hatchling 1.31 → `Metadata-Version: 2.4`, hatchling 1.32 → `2.5` (deterministic).

## Fix

Cap the build backend at **`hatchling<1.32`** so `uv build` emits **2.4** again, which twine 6.x — and the widest range of consumer tooling that reads the published wheel — accepts.

- `[build-system].requires` is read directly by `uv build`'s isolated environment, **not** from `uv.lock`, so **no re-lock is needed**. (A full `uv lock` currently fails on an unrelated `torchcodec`/aarch64 resolution issue, so avoiding re-lock is a plus.)
- `deploy.yaml` is left unchanged; the reproducible lock-based publish flow stays intact.

Conservative stopgap: lift the cap once the deploy stack moves to `twine>=7` (which recognizes Metadata-Version 2.5/2.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
