### PR TITLE
other: remove obsolete vllm model-generation dispatch

### DIFF
--- a/.github/workflows/deploy-on-tag.yaml
+++ b/.github/workflows/deploy-on-tag.yaml
@@ -59,28 +59,6 @@ jobs:
             })
             console.log(result)
 
-  trigger-vllm-model-compilation:
-    name: trigger vllm model compile and generation ci
-    needs: [deploy-on-tag]
-    runs-on: rbln-sw-k8s-4c-32gb
-    container:
-      image: ${{ vars.DEV_CONTAINER_IMAGE }}
-    steps:
-      - uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GIT_PAT }}
-          script: |
-            const result = await github.rest.actions.createWorkflowDispatch({
-              owner: 'rebellions-sw',
-              repo: 'rebel_compiler',
-              workflow_id: 'rebel_dispatch_model_generation_for_vllm.yaml',
-              ref: 'dev',
-              inputs: {
-                optimum_rbln_version: "${{ github.ref_name }}",
-              }
-            })
-            console.log(result)
-
   bc-compile:
     name: BC compile for release tag
     needs: check-tag


### PR DESCRIPTION
## What

Remove the `trigger-vllm-model-compilation` job from `deploy-on-tag.yaml`.

## Why

The job dispatched `rebel_dispatch_model_generation_for_vllm.yaml` in `rebellions-sw/rebel_compiler`, but that workflow no longer exposes a `workflow_dispatch` trigger. So the step fails on **every tag deploy**:

```
RequestError [HttpError]: Workflow does not have 'workflow_dispatch' trigger
POST .../rebel_compiler/actions/workflows/rebel_dispatch_model_generation_for_vllm.yaml/dispatches
```

(e.g. run 31694450151)

The dispatch target is gone, so the trigger is dead weight. No other job `needs` it, and the remaining jobs (`check-tag`, `deploy-on-tag`, `trigger-vllm-rbln-pkg-update`, `bc-compile`) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
