### PR TITLE
model(decoderonly): load embed_tokens in the compile dtype

### DIFF
--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -82,10 +82,6 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
             artifacts = torch.load(self.model_save_dir / self.subfolder / "torch_artifacts.pth", weights_only=False)
             self.embed_tokens = self._create_embedding_layer()
             self.embed_tokens.load_state_dict(artifacts["embed_tokens"])
-            # _create_embedding_layer builds an fp32 module and load_state_dict
-            # keeps that dtype, so cast to the compile dtype: the lookup output
-            # feeds the runtime's inputs_embeds, which expects rbln_config.dtype.
-            self.embed_tokens.to(self.rbln_config.dtype)
         else:
             self.embed_tokens = None
 
@@ -202,11 +198,15 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
             torch.save(save_dict, save_dir_path / subfolder / "torch_artifacts.pth")
 
     def _create_embedding_layer(self):
+        # Created in the compile dtype: load_state_dict casts the fp32
+        # checkpoint into it, and the lookup output feeds the runtime's
+        # inputs_embeds, which expects rbln_config.dtype.
         with no_init_weights():
             embed_tokens = torch.nn.Embedding(
                 self.config.vocab_size,
                 self.config.hidden_size,
                 self.config.pad_token_id,
+                dtype=self.rbln_config.dtype,
             )
         return embed_tokens
 

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -82,6 +82,10 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
             artifacts = torch.load(self.model_save_dir / self.subfolder / "torch_artifacts.pth", weights_only=False)
             self.embed_tokens = self._create_embedding_layer()
             self.embed_tokens.load_state_dict(artifacts["embed_tokens"])
+            # _create_embedding_layer builds an fp32 module and load_state_dict
+            # keeps that dtype, so cast to the compile dtype: the lookup output
+            # feeds the runtime's inputs_embeds, which expects rbln_config.dtype.
+            self.embed_tokens.to(self.rbln_config.dtype)
         else:
             self.embed_tokens = None
 

--- a/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/modeling_decoderonly.py
@@ -198,9 +198,6 @@ class RBLNDecoderOnlyModel(RBLNModel, RBLNDecoderOnlyFlashAttentionMixin):
             torch.save(save_dict, save_dir_path / subfolder / "torch_artifacts.pth")
 
     def _create_embedding_layer(self):
-        # Created in the compile dtype: load_state_dict casts the fp32
-        # checkpoint into it, and the lookup output feeds the runtime's
-        # inputs_embeds, which expects rbln_config.dtype.
         with no_init_weights():
             embed_tokens = torch.nn.Embedding(
                 self.config.vocab_size,

--- a/src/optimum/rbln/transformers/models/exaone4_5/modeling_exaone4_5.py
+++ b/src/optimum/rbln/transformers/models/exaone4_5/modeling_exaone4_5.py
@@ -375,7 +375,7 @@ class RBLNExaone4_5_Model(RBLNDecoderOnlyModel):
         video_grid_thw: torch.LongTensor = None,
         second_per_grid_ts: torch.Tensor = None,
     ):
-        inputs_embeds = self.embed_tokens(input_ids).to(self.rbln_config.dtype)
+        inputs_embeds = self.embed_tokens(input_ids)
 
         if pixel_values is not None:
             image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)

--- a/src/optimum/rbln/transformers/models/exaone4_5/modeling_exaone4_5.py
+++ b/src/optimum/rbln/transformers/models/exaone4_5/modeling_exaone4_5.py
@@ -338,6 +338,7 @@ class RBLNExaone4_5_Model(RBLNDecoderOnlyModel):
                 self.config.text_config.vocab_size,
                 self.config.text_config.hidden_size,
                 self.config.text_config.pad_token_id,
+                dtype=self.rbln_config.dtype,
             )
         return embed_tokens
 

--- a/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/optimum/rbln/transformers/models/gemma3/modeling_gemma3.py
@@ -405,7 +405,9 @@ class RBLNGemma3ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
                 self.config.pad_token_id,
                 embed_scale=self.config.hidden_size**0.5,
             )
-        return embed_tokens
+        # Gemma3TextScaledWordEmbedding does not forward a dtype kwarg to
+        # nn.Embedding, so cast the module instead.
+        return embed_tokens.to(self.rbln_config.dtype)
 
     @classmethod
     def _update_submodule_config(

--- a/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
@@ -441,7 +441,9 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
                 self.config.pad_token_id,
                 embed_scale=self.config.hidden_size_per_layer_input**0.5,
             )
-        return embed_per_layer
+        # Gemma4TextScaledWordEmbedding does not forward a dtype kwarg to
+        # nn.Embedding, so cast the module instead.
+        return embed_per_layer.to(self.rbln_config.dtype)
 
     def __post_init__(self, **kwargs):
         artifacts_path = self.model_save_dir / self.subfolder / "torch_artifacts.pth"
@@ -450,14 +452,12 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         if self.rbln_config.use_inputs_embeds and "embed_tokens" in artifacts:
             self.embed_tokens = self._create_embedding_layer()
             self.embed_tokens.load_state_dict(artifacts["embed_tokens"])
-            self.embed_tokens.to(self.rbln_config.dtype)
         else:
             self.embed_tokens = None
 
         if getattr(self.config, "hidden_size_per_layer_input", 0) and "embed_tokens_per_layer" in artifacts:
             self.embed_tokens_per_layer = self._create_per_layer_embedding_layer()
             self.embed_tokens_per_layer.load_state_dict(artifacts["embed_tokens_per_layer"])
-            self.embed_tokens_per_layer.to(self.rbln_config.dtype)
         else:
             self.embed_tokens_per_layer = None
 
@@ -515,7 +515,9 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
                 self.config.pad_token_id,
                 embed_scale=self.config.hidden_size**0.5,
             )
-        return embed_tokens
+        # Gemma4TextScaledWordEmbedding does not forward a dtype kwarg to
+        # nn.Embedding, so cast the module instead.
+        return embed_tokens.to(self.rbln_config.dtype)
 
     @classmethod
     def _pre_populate_cache_metas(

--- a/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/optimum/rbln/transformers/models/paligemma/modeling_paligemma.py
@@ -195,6 +195,7 @@ class RBLNPaliGemmaForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGeneration
                 self.config.text_config.vocab_size,
                 self.config.text_config.hidden_size,
                 self.config.text_config.pad_token_id,
+                dtype=self.rbln_config.dtype,
             )
         return embed_tokens
 
@@ -456,6 +457,7 @@ class RBLNPaliGemmaModel(RBLNModel):
                 self.config.text_config.vocab_size,
                 self.config.text_config.hidden_size,
                 self.config.text_config.pad_token_id,
+                dtype=self.rbln_config.dtype,
             )
         return embed_tokens
 

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -439,7 +439,7 @@ class RBLNQwen2_5_VLModel(RBLNDecoderOnlyModel):
         mm_token_type_ids: torch.IntTensor | None = None,
     ):
         batch_size = input_ids.shape[0]
-        inputs_embeds = self.embed_tokens(input_ids).to(self.rbln_config.dtype)
+        inputs_embeds = self.embed_tokens(input_ids)
 
         if pixel_values is not None:
             image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)
@@ -709,7 +709,7 @@ class RBLNQwen2_5_VLForConditionalGeneration(RBLNQwen2_5_VLModel, RBLNDecoderOnl
                 f"Cache position size mismatch: got {cache_position.shape[0]}, expected {self.rbln_config.batch_size}."
             )
 
-        inputs_embeds = self.embed_tokens(input_ids).to(self.rbln_config.dtype)
+        inputs_embeds = self.embed_tokens(input_ids)
         position_embeds = []
         for b_idx in range(self.rbln_config.batch_size):
             delta = cache_position[b_idx] + self.rope_deltas[b_idx]

--- a/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -387,6 +387,7 @@ class RBLNQwen2_5_VLModel(RBLNDecoderOnlyModel):
                 self.config.text_config.vocab_size,
                 self.config.text_config.hidden_size,
                 self.config.text_config.pad_token_id,
+                dtype=self.rbln_config.dtype,
             )
         return embed_tokens
 

--- a/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -280,6 +280,7 @@ class RBLNQwen2VLModel(RBLNDecoderOnlyModel):
                 self.config.text_config.vocab_size,
                 self.config.text_config.hidden_size,
                 self.config.text_config.pad_token_id,
+                dtype=self.rbln_config.dtype,
             )
         return embed_tokens
 

--- a/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -331,7 +331,7 @@ class RBLNQwen2VLModel(RBLNDecoderOnlyModel):
         mm_token_type_ids: torch.IntTensor | None = None,
     ):
         batch_size = input_ids.shape[0]
-        inputs_embeds = self.embed_tokens(input_ids).to(self.rbln_config.dtype)
+        inputs_embeds = self.embed_tokens(input_ids)
 
         if pixel_values is not None:
             image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)
@@ -595,7 +595,7 @@ class RBLNQwen2VLForConditionalGeneration(RBLNQwen2VLModel, RBLNDecoderOnlyModel
                 f"Cache position size mismatch: got {cache_position.shape[0]}, expected {self.rbln_config.batch_size}."
             )
 
-        inputs_embeds = self.embed_tokens(input_ids).to(self.rbln_config.dtype)
+        inputs_embeds = self.embed_tokens(input_ids)
         position_embeds = []
         for b_idx in range(self.rbln_config.batch_size):
             delta = cache_position[b_idx] + self.rope_deltas[b_idx]

--- a/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -617,6 +617,7 @@ class RBLNQwen3_5Model(RBLNDecoderOnlyModel):
                 self.config.text_config.vocab_size,
                 self.config.text_config.hidden_size,
                 getattr(self.config.text_config, "pad_token_id", None),
+                dtype=self.rbln_config.dtype,
             )
         return embed_tokens
 

--- a/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/optimum/rbln/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -668,7 +668,7 @@ class RBLNQwen3_5Model(RBLNDecoderOnlyModel):
         **kwargs,
     ):
         batch_size = input_ids.shape[0]
-        inputs_embeds = self.embed_tokens(input_ids).to(self.rbln_config.dtype)
+        inputs_embeds = self.embed_tokens(input_ids)
 
         if pixel_values is not None:
             image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)
@@ -905,7 +905,7 @@ class RBLNQwen3_5ForConditionalGeneration(RBLNQwen3_5Model, RBLNDecoderOnlyModel
                 f"Cache position size mismatch: got {cache_position.shape[0]}, expected {self.rbln_config.batch_size}."
             )
 
-        inputs_embeds = self.embed_tokens(input_ids).to(self.rbln_config.dtype)
+        inputs_embeds = self.embed_tokens(input_ids)
         position_embeds = []
         for b_idx in range(self.rbln_config.batch_size):
             delta = cache_position[b_idx] + self.rope_deltas[b_idx]

--- a/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -498,7 +498,7 @@ class RBLNQwen3VLModel(RBLNDecoderOnlyModel):
         mm_token_type_ids: torch.IntTensor | None = None,
     ):
         batch_size = input_ids.shape[0]
-        inputs_embeds = self.embed_tokens(input_ids).to(self.rbln_config.dtype)
+        inputs_embeds = self.embed_tokens(input_ids)
 
         image_mask = None
         video_mask = None
@@ -924,7 +924,7 @@ class RBLNQwen3VLForConditionalGeneration(RBLNQwen3VLModel, RBLNDecoderOnlyModel
                 f"Cache position size mismatch: got {cache_position.shape[0]}, expected {self.rbln_config.batch_size}."
             )
 
-        inputs_embeds = self.embed_tokens(input_ids).to(self.rbln_config.dtype)
+        inputs_embeds = self.embed_tokens(input_ids)
         position_embeds = []
         for b_idx in range(self.rbln_config.batch_size):
             delta = cache_position[b_idx] + self.rope_deltas[b_idx]

--- a/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/optimum/rbln/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -416,6 +416,7 @@ class RBLNQwen3VLModel(RBLNDecoderOnlyModel):
                 self.config.text_config.vocab_size,
                 self.config.text_config.hidden_size,
                 getattr(self.config.text_config, "pad_token_id", None),
+                dtype=self.rbln_config.dtype,
             )
         return embed_tokens
 


### PR DESCRIPTION
## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Overview
- Build `embed_tokens` in `rbln_config.dtype` at construction, inside every `_create_embedding_layer`: the plain `nn.Embedding` sites take a `dtype` kwarg, and `load_state_dict` casts the fp32 checkpoint into the module dtype. The Gemma scaled-embedding classes (`Gemma3/Gemma4TextScaledWordEmbedding`) do not forward a `dtype` kwarg, so those cast the module after construction.
- Move gemma4's existing load-time casts into its `_create_embedding_layer` / `_create_per_layer_embedding_layer` accordingly.
- Drop the call-site casts that are now no-ops: `self.embed_tokens(input_ids).to(self.rbln_config.dtype)` in qwen2_vl, qwen2_5_vl, qwen3_vl, qwen3_5 (prefill/decode each) and exaone4_5 (prefill). The cast in Exaone-4.5's `forward` stays because it also covers caller-passed `inputs_embeds`.

## Motivation and Context
`_create_embedding_layer` built an fp32 `nn.Embedding` and `load_state_dict` keeps the module dtype, so a model compiled with bf16/fp16 still served its embedding lookups in fp32.

Consequences:
- Every consumer had to patch over it at the call site with `.to(rbln_config.dtype)`; the same patchwork leaked into vllm-rbln (its `embed_tokens(...).to(...)` casts become removable once this lands).
- Paths without the patch fed fp32 embeddings to a runtime compiled for bf16/fp16 — e.g. `decoderonly_runtime_utils.py`'s inputs_embeds preparation returns `self.embed_tokens(input_ids)` uncast.

Applying the dtype inside `_create_embedding_layer` (rather than after load in `__post_init__`) makes the invariant hold wherever the layer is constructed, including subclasses with their own load paths. For fp32-compiled models (including all `_supports_non_fp32 = False` classes) it is a no-op, so behavior is unchanged there.

`_get_position_embeddings` casts cos/sin to `rbln_config.dtype` itself, so removing the call-site casts does not affect the position-embedding dtype.

## Related Issues
Counterpart of the vLLM/optimum dtype sync work in vllm-rbln (fix/model-dtype-redo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)