### PR TITLE
other: name the static-address tensors in encoder-decoder compile contexts

### DIFF
--- a/src/optimum/rbln/transformers/models/seq2seq/modeling_seq2seq.py
+++ b/src/optimum/rbln/transformers/models/seq2seq/modeling_seq2seq.py
@@ -155,14 +155,14 @@ class RBLNModelForSeq2SeqLM(RBLNModel, GenerationMixin, ABC):
         for (name, _, _), tensor in zip(enc_compile_config.input_info, enc_example_inputs, strict=False):
             if "key_value_states" in name:
                 static_tensors[name] = tensor
-                context.mark_static_address(tensor)
+                context.mark_static_address(tensor, name)
 
         dec_example_inputs = dec_compile_config.get_dummy_inputs(fill=0, static_tensors=static_tensors)
 
         # Mark decoder's static tensors (self kv states)
         for (name, _, _), tensor in zip(dec_compile_config.input_info, dec_example_inputs, strict=False):
             if "key_value_states" in name:
-                context.mark_static_address(tensor)
+                context.mark_static_address(tensor, name)
 
         compiled_encoder = cls.compile(
             wrapped_model.encoder,

--- a/src/optimum/rbln/transformers/models/time_series_transformer/modeling_time_series_transformer.py
+++ b/src/optimum/rbln/transformers/models/time_series_transformer/modeling_time_series_transformer.py
@@ -176,14 +176,14 @@ class RBLNTimeSeriesTransformerForPrediction(RBLNModel):
         for (name, _, _), tensor in zip(enc_compile_config.input_info, enc_example_inputs, strict=False):
             if "key_value_states" in name:
                 static_tensors[name] = tensor
-                context.mark_static_address(tensor)
+                context.mark_static_address(tensor, name)
 
         dec_example_inputs = dec_compile_config.get_dummy_inputs(fill=0, static_tensors=static_tensors)
 
         # Mark decoder's static tensors (self kv states)
         for (name, _, _), tensor in zip(dec_compile_config.input_info, dec_example_inputs, strict=False):
             if "key_value_states" in name:
-                context.mark_static_address(tensor)
+                context.mark_static_address(tensor, name)
 
         compiled_encoder = cls.compile(
             wrapped_model.encoder,

--- a/src/optimum/rbln/transformers/models/whisper/modeling_whisper.py
+++ b/src/optimum/rbln/transformers/models/whisper/modeling_whisper.py
@@ -228,14 +228,14 @@ class RBLNWhisperForConditionalGeneration(RBLNModel, RBLNWhisperGenerationMixin)
         for (name, _, _), tensor in zip(enc_compile_config.input_info, enc_example_inputs, strict=False):
             if "key_value_states" in name:
                 static_tensors[name] = tensor
-                context.mark_static_address(tensor)
+                context.mark_static_address(tensor, name)
 
         dec_example_inputs = dec_compile_config.get_dummy_inputs(fill=0, static_tensors=static_tensors)
 
         # Mark decoder's static tensors (self kv states)
         for (name, _, _), tensor in zip(dec_compile_config.input_info, dec_example_inputs, strict=False):
             if "key_value_states" in name:
-                context.mark_static_address(tensor)
+                context.mark_static_address(tensor, name)
 
         compiled_encoder = cls.compile(
             wrapped_model.encoder,


### PR DESCRIPTION
# Pull Request Description

## Type of Change
- [ ] Release (dev → main merge for production release)
- [ ] New Model Support
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Other (please describe): labels the static tensors that were being marked without a name.

## Changes Overview
Six call sites were invoking `CompileContext.mark_static_address` without the `name` argument. All of them now forward the name they already have from `input_info`.

| File | What is marked |
|---|---|
| `transformers/models/seq2seq/modeling_seq2seq.py` | The two loops marking the encoder's cross KV and the decoder's self KV. |
| `transformers/models/whisper/modeling_whisper.py` | The same two loops. |
| `transformers/models/time_series_transformer/modeling_time_series_transformer.py` | The same two loops. |

Each of these loops already binds the `input_info` name as its loop variable, so passing it through is all that is needed. `decoderonly/modeling_decoderonly.py` and `qwen3_5/modeling_qwen3_5.py` already pass the name and are left untouched.

## Motivation and Context
`mark_static_address(tensor, name=None)` accepts a name for the tensor being marked, and the name is what identifies that tensor afterwards. The encoder-decoder paths were the only ones leaving it out, so their KV cache tensors stayed anonymous and could not be told apart, whereas the decoder-only and Qwen3.5 paths were already naming theirs. After this change the encoder-decoder paths carry `cross_key_value_states*` and `self_key_value_states_*` in the same way.

The name is descriptive only, so neither the compiled models nor runtime behavior change. The cross KV tensors are marked once in the encoder loop and then, having been handed to the decoder through `static_tensors`, marked a second time in the decoder loop; both `input_info` definitions use the same name, so the second call repeats the identical name for the identical tensor, and no two distinct tensors share a name.

## Related Issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)