### PR TITLE
model(gemma4): strip image padding by the position ids, not the returned mask

### DIFF
--- a/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
@@ -595,12 +595,8 @@ def pooler_mask_from_position_ids(
     """Which soft-token slots of the pooler output hold a real patch block.
 
     `pixel_position_ids` is (batch, max_patches, 2) with (-1, -1) marking padding,
-    and the pooler averages each `pooling_kernel_size**2` block into one soft
-    token, so row i holds `valid_patches(i) // k**2` real tokens at the front.
-
-    This is the same arithmetic vllm-rbln uses to split the returned features per
-    image, so deriving the mask here keeps the producer and the consumer in
-    agreement by construction rather than by assumption.
+    and the pooler averages each `pooling_kernel_size**2` block into one soft token,
+    so row i holds `valid_patches(i) // k**2` real tokens at the front.
     """
     valid_patches = (~(pixel_position_ids == -1).all(dim=-1)).sum(dim=-1)
     valid_soft_tokens = valid_patches // (pooling_kernel_size * pooling_kernel_size)
@@ -838,13 +834,8 @@ class RBLNGemma4ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
 
         vision_outputs = self.vision_tower(pixel_values, pixel_position_ids, out=vision_out_buffer)
         pooler_output = self.embed_vision(vision_outputs.last_hidden_state.float(), out=projector_out_buffer)
-        # Strip padding using the mask derived from the position ids rather than the
-        # one the tower returns. The two agree on device; they do not when the model
-        # never reaches one — with `device=-1` the tower hands back an all-valid mask,
-        # so the padding slots survive and the caller's split rejects the result
-        # (measured: mask true=280 of 280, position ids describe 266). Deriving it
-        # host-side costs a few CPU ops and makes producer and consumer agree by
-        # construction; a disagreement on real devices is logged rather than hidden.
+        # The position ids are the same source the caller splits the features by, so
+        # deriving the mask from them keeps the two in agreement by construction.
         host_mask = pooler_mask_from_position_ids(pixel_position_ids, max_soft_tokens, pooling)
         if not torch.equal(vision_outputs.pooler_mask, host_mask):
             logger.warning(

--- a/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/optimum/rbln/transformers/models/gemma4/modeling_gemma4.py
@@ -589,6 +589,26 @@ class RBLNGemma4ForCausalLM(RBLNDecoderOnlyModelForCausalLM):
         return rbln_config
 
 
+def pooler_mask_from_position_ids(
+    pixel_position_ids: torch.Tensor, max_soft_tokens: int, pooling_kernel_size: int
+) -> torch.Tensor:
+    """Which soft-token slots of the pooler output hold a real patch block.
+
+    `pixel_position_ids` is (batch, max_patches, 2) with (-1, -1) marking padding,
+    and the pooler averages each `pooling_kernel_size**2` block into one soft
+    token, so row i holds `valid_patches(i) // k**2` real tokens at the front.
+
+    This is the same arithmetic vllm-rbln uses to split the returned features per
+    image, so deriving the mask here keeps the producer and the consumer in
+    agreement by construction rather than by assumption.
+    """
+    valid_patches = (~(pixel_position_ids == -1).all(dim=-1)).sum(dim=-1)
+    valid_soft_tokens = valid_patches // (pooling_kernel_size * pooling_kernel_size)
+    return torch.arange(max_soft_tokens, device="cpu").expand(
+        pixel_position_ids.shape[0], max_soft_tokens
+    ) < valid_soft_tokens.unsqueeze(1)
+
+
 class RBLNGemma4ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMixin):
     """
     Gemma4 model for image-text-to-text generation optimized for RBLN NPU.
@@ -818,7 +838,23 @@ class RBLNGemma4ForConditionalGeneration(RBLNModel, RBLNDecoderOnlyGenerationMix
 
         vision_outputs = self.vision_tower(pixel_values, pixel_position_ids, out=vision_out_buffer)
         pooler_output = self.embed_vision(vision_outputs.last_hidden_state.float(), out=projector_out_buffer)
-        pooler_output = pooler_output[vision_outputs.pooler_mask]
+        # Strip padding using the mask derived from the position ids rather than the
+        # one the tower returns. The two agree on device; they do not when the model
+        # never reaches one — with `device=-1` the tower hands back an all-valid mask,
+        # so the padding slots survive and the caller's split rejects the result
+        # (measured: mask true=280 of 280, position ids describe 266). Deriving it
+        # host-side costs a few CPU ops and makes producer and consumer agree by
+        # construction; a disagreement on real devices is logged rather than hidden.
+        host_mask = pooler_mask_from_position_ids(pixel_position_ids, max_soft_tokens, pooling)
+        if not torch.equal(vision_outputs.pooler_mask, host_mask):
+            logger.warning(
+                "vision tower pooler_mask marks %d of %d soft tokens valid; the position ids "
+                "describe %d. Using the position ids.",
+                int(vision_outputs.pooler_mask.sum()),
+                vision_outputs.pooler_mask.numel(),
+                int(host_mask.sum()),
+            )
+        pooler_output = pooler_output[host_mask]
         return pooler_output
 
     def get_video_features(

--- a/tests/test_gemma4_pooler_mask.py
+++ b/tests/test_gemma4_pooler_mask.py
@@ -1,0 +1,60 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The pooler mask Gemma4 strips padding with, derived from the position ids.
+
+The tower is supposed to return this mask, and on device it does. When the model
+never reaches a device (`device=-1`, as CI's dummy runs) it comes back all-valid,
+the padding slots survive, and the caller's per-image split rejects a tensor that
+is longer than the prompt reserved. Deriving it from the position ids is the same
+arithmetic the caller uses, so these cases pin that the two cannot drift.
+"""
+
+import pytest
+import torch
+
+from optimum.rbln.transformers.models.gemma4.modeling_gemma4 import (
+    pooler_mask_from_position_ids,
+)
+
+
+def _position_ids(valid_patches: list[int], max_patches: int) -> torch.Tensor:
+    ids = torch.full((len(valid_patches), max_patches, 2), -1, dtype=torch.int64)
+    for row, n in enumerate(valid_patches):
+        ids[row, :n] = torch.arange(n).unsqueeze(1).expand(n, 2)
+    return ids
+
+
+@pytest.mark.parametrize(
+    ("valid_patches", "max_patches", "pooling", "expected"),
+    [
+        # the case observed in CI: 2394 of 2520 patches, 3x3 pooling -> 266 of 280
+        pytest.param([2394], 2520, 3, [266], id="ci_case"),
+        pytest.param([2394, 1800], 2520, 3, [266, 200], id="two_images"),
+        pytest.param([2520], 2520, 3, [280], id="no_padding"),
+        pytest.param([0], 2520, 3, [0], id="all_padding"),
+    ],
+)
+def test_mask_counts_match_the_position_ids(valid_patches, max_patches, pooling, expected):
+    max_soft_tokens = max_patches // (pooling * pooling)
+    mask = pooler_mask_from_position_ids(_position_ids(valid_patches, max_patches), max_soft_tokens, pooling)
+    assert mask.shape == (len(valid_patches), max_soft_tokens)
+    assert mask.dtype == torch.bool
+    assert mask.sum(dim=1).tolist() == expected
+
+
+def test_valid_tokens_are_at_the_front():
+    """The caller splits the flat output per image, so order is part of the contract."""
+    mask = pooler_mask_from_position_ids(_position_ids([2394], 2520), 280, 3)
+    assert mask[0, :266].all()
+    assert not mask[0, 266:].any()

--- a/tests/test_gemma4_pooler_mask.py
+++ b/tests/test_gemma4_pooler_mask.py
@@ -11,14 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""The pooler mask Gemma4 strips padding with, derived from the position ids.
-
-The tower is supposed to return this mask, and on device it does. When the model
-never reaches a device (`device=-1`, as CI's dummy runs) it comes back all-valid,
-the padding slots survive, and the caller's per-image split rejects a tensor that
-is longer than the prompt reserved. Deriving it from the position ids is the same
-arithmetic the caller uses, so these cases pin that the two cannot drift.
-"""
+"""The pooler mask Gemma4 strips padding with, derived from the position ids."""
 
 import pytest
 import torch


### PR DESCRIPTION
## Symptom

Serving gemma-4 with an image on the **dummy device** (`rbln_config.device = -1`) fails at the caller's per-image split:

```
RuntimeError: split_with_sizes expects split_sizes to sum exactly to 280
              (input tensor's size at dimension 0), but got split_sizes=[266]
```

This is how the deploy vLLM suite runs — a suite step gets one NPU while these recipes ask for sixteen, so it validates at the API level on the dummy device. `gemma-4-26b-a4b` and `gemma-4-31b` have been red there since they were added, while **the same documented commands serve and answer on 16× RBLN-CA22** (both models, on two stacks).

## Measured, not inferred

I instrumented the strip rather than reasoning about it — two earlier explanations of mine were wrong:

```
[probe] mask shape=(1, 280) dtype=torch.bool true=280  pooler_out=(1, 280, 2816)
[probe] after mask -> (280, 2816)
[probe] image_embeds=(280, 2816) valid_lens=[266] k2=9 valid_patches=[2394]
```

- 2394 valid patches / 3² = **266** real soft tokens
- 2520 max patches / 3² = **280**, the compiled bucket
- the tower's `pooler_mask` marks **280 of 280** valid, so the strip removes nothing and 14 padding slots survive

What it is **not** (each ruled out by experiment, not by reading):

| hypothesis | test | result |
|---|---|---|
| deploy's layer reduction | run with reduction full / text-only / **absent** | fails identically all three |
| the mask buffer is left unwritten | seed it with the correct mask before the call | unchanged — the runtime overwrites it |

## Fix

Derive the mask from `pixel_position_ids`, where `(-1, -1)` already marks padding. That is the same arithmetic vllm-rbln uses to split the returned features, so producer and consumer agree **by construction** rather than by assumption. On device the two masks match, so behaviour there is unchanged; a disagreement is logged rather than swallowed, so a genuine tower bug stays visible.

## Verification

- **End to end:** the documented `gemma-4-26b-a4b` serve command on the dummy device went from failing that split to **serving and answering**. (Output text from a dummy device is meaningless by construction — this is API-level validation.) The warning fired once, naming the measured numbers.
- **On device:** the same commands already pass on 16× RBLN-CA22 for both models on two stacks, so this touches only the path that was broken.
- **Unit:** `tests/test_gemma4_pooler_mask.py` — the CI case (2394/2520 → 266/280), two images, no padding, all padding, and that valid tokens sit at the front, which the caller's split depends on. 5 passing.

`ruff check` and `ruff format` clean.

## Related

[rbln_deploy#697](https://github.com/rebellions-sw/rbln_deploy/pull/697) stops the suite reporting this as a broken recipe. If this lands, that tolerance becomes unnecessary for gemma-4 — happy to close it in favour of this.