### PR TITLE
other(auto): recover concrete config class for bare PretrainedConfig inputs

### DIFF
--- a/src/optimum/rbln/transformers/models/auto/auto_factory.py
+++ b/src/optimum/rbln/transformers/models/auto/auto_factory.py
@@ -17,6 +17,7 @@ import warnings
 from pathlib import Path
 from typing import Any
 
+import transformers
 from transformers import AutoConfig, PretrainedConfig, PreTrainedModel
 from transformers.dynamic_module_utils import get_class_from_dynamic_module
 from transformers.models.auto.auto_factory import _get_model_class
@@ -29,6 +30,28 @@ from optimum.rbln.utils.model_utils import (
     convert_rbln_to_hf_model_name,
     get_rbln_model_cls,
 )
+
+
+def _upgrade_bare_config(config: PretrainedConfig) -> PretrainedConfig:
+    """Rebuild a bare ``PretrainedConfig`` as its concrete config class.
+
+    Non-HF config parsers (e.g. vLLM's mistral-format loader) hand over an
+    instance of the base ``PretrainedConfig``, whose class carries no model
+    identity and whose ``model_type`` can be a parser artifact ("transformer").
+    Recover the concrete class from ``architectures`` so class-based model
+    resolution and eager model loading work downstream. Returns the config
+    unchanged if the architecture cannot be resolved.
+    """
+    architectures = getattr(config, "architectures", None) or []
+    hf_model_cls = getattr(transformers, architectures[0], None) if architectures else None
+    config_cls = getattr(hf_model_cls, "config_class", None)
+    if config_cls is None:
+        return config
+
+    config_dict = config.to_dict()
+    # Drop the parser's model_type so the concrete class's canonical one wins.
+    config_dict.pop("model_type", None)
+    return config_cls.from_dict(config_dict)
 
 
 class _BaseAutoModelClass:
@@ -128,6 +151,9 @@ class _BaseAutoModelClass:
                 **kwargs,
             )
 
+        if type(config) is PretrainedConfig:
+            config = _upgrade_bare_config(config)
+
         # Get hf_model_class from Config
         has_remote_code = (
             hasattr(config, "auto_map") and convert_rbln_to_hf_model_name(cls.__name__) in config.auto_map
@@ -215,6 +241,11 @@ class _BaseAutoModelClass:
         Returns:
             RBLNBaseModel: An instantiated RBLN model ready for inference on RBLN NPUs.
         """
+        # Upgrade here (not only in infer_hf_model_class) so the concrete
+        # config also reaches the resolved class's from_pretrained.
+        if type(kwargs.get("config")) is PretrainedConfig:
+            kwargs["config"] = _upgrade_bare_config(kwargs["config"])
+
         rbln_cls = cls.get_rbln_cls(model_id, export=export, **kwargs)
         return rbln_cls.from_pretrained(model_id, export=export, rbln_config=rbln_config, **kwargs)
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -23,6 +23,58 @@ def test_version_is_str():
     assert isinstance(__version__, str)
 
 
+def test_bare_pretrained_config_resolves_model_class():
+    # vLLM's mistral-format parser (params.json) yields a base PretrainedConfig
+    # with model_type "transformer"; only `architectures` identifies the model.
+    from transformers import MistralConfig, PretrainedConfig
+
+    from optimum.rbln import RBLNAutoModelForCausalLM, RBLNMistralForCausalLM
+
+    config_dict = MistralConfig(
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        vocab_size=128,
+        architectures=["MistralForCausalLM"],
+    ).to_dict()
+    config_dict["model_type"] = "transformer"
+    bare_config = PretrainedConfig.from_dict(config_dict)
+
+    rbln_cls = RBLNAutoModelForCausalLM.get_rbln_cls("dummy/mistral", export=True, config=bare_config)
+    assert rbln_cls is RBLNMistralForCausalLM
+
+
+def test_upgrade_bare_config_recovers_concrete_class():
+    from transformers import MistralConfig, PretrainedConfig
+
+    from optimum.rbln.transformers.models.auto.auto_factory import _upgrade_bare_config
+
+    reference = MistralConfig(
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        vocab_size=128,
+        architectures=["MistralForCausalLM"],
+    )
+    config_dict = reference.to_dict()
+    config_dict["model_type"] = "transformer"
+    upgraded = _upgrade_bare_config(PretrainedConfig.from_dict(config_dict))
+
+    assert type(upgraded) is MistralConfig
+    assert upgraded.model_type == "mistral"
+    assert upgraded.to_dict() == reference.to_dict()
+
+    # Unresolvable architectures are left untouched.
+    unknown = PretrainedConfig.from_dict({"architectures": ["NoSuchModel"]})
+    assert _upgrade_bare_config(unknown) is unknown
+    no_arch = PretrainedConfig.from_dict({})
+    assert _upgrade_bare_config(no_arch) is no_arch
+
+
 @pytest.mark.parametrize(
     "current_version, expect_raise",
     [


### PR DESCRIPTION
## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Overview
- `auto_factory.py`: add `_upgrade_bare_config`, which rebuilds a bare base-class `PretrainedConfig` as its concrete config class (e.g. `MistralConfig`) by resolving `config.architectures[0]` against the `transformers` namespace and re-instantiating via that class's `from_dict`. The parser-supplied `model_type` is dropped so the concrete class's canonical value wins.
- Hook it in two places: `infer_hf_model_class` (so the exact-config-class model lookup hits) and `_BaseAutoModelClass.from_pretrained` (so the upgraded config — not the bare one — propagates to the resolved class's `from_pretrained` and eager model loading).
- Unit tests covering RBLN class resolution from a bare config, config-class recovery/equivalence, and the leave-unchanged fallback for unresolvable inputs.

## Motivation and Context
`mistralai/Mistral-7B-Instruct-v0.3` fails at vLLM engine startup on the optimum-rbln path. vLLM auto-selects the Mistral config format (`params.json`) for repos shipping `consolidated*.safetensors`, and its parser returns a **base `PretrainedConfig`** instance. The auto factory resolves model classes by exact config class, so `infer_hf_model_class` raises `Unrecognized configuration class ... PreTrainedConfig`.

Two subtleties found while verifying against the real v0.3 repo:
- The parsed config's `model_type` is `"transformer"`, not `"mistral"`, so a `CONFIG_MAPPING[model_type]`-based recovery would also fail. `architectures` (`["MistralForCausalLM"]`) is the reliable identity and is always set by vLLM's adapter.
- Fixing class resolution alone is not enough: the bare config flows through `_export → get_pytorch_model → MistralForCausalLM.from_pretrained(..., config=...)` and crashes there (`AttributeError: 'PreTrainedConfig' object has no attribute 'pad_token_id'`). Hence the propagation hook in `from_pretrained`.

Verified with the real v0.3 config: the upgraded config is field-for-field identical to the `config.json`-loaded `MistralConfig`, resolves to `RBLNMistralForCausalLM`, and constructs the eager model (meta device).

## Related Issues
rebellions-sw/vllm-optimum-executor#76

## Test
- `pytest tests/test_base.py -k "bare or upgrade"` → 2 passed
- `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)