### PR TITLE
fix: keep torch cos/sin for the compile-time decoderonly rotary constants

### DIFF
--- a/src/optimum/rbln/transformers/models/decoderonly/decoderonly_architecture.py
+++ b/src/optimum/rbln/transformers/models/decoderonly/decoderonly_architecture.py
@@ -20,7 +20,7 @@ from torch import nn
 from transformers import PretrainedConfig, PreTrainedModel
 
 from ....utils import logging
-from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, np_cos, np_sin
+from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS
 from .configuration_lora import RBLNLoRAConfig
 from .lora_architecture import LoRALinear
 
@@ -1316,8 +1316,8 @@ class RotaryEmbedding(nn.Module):
 
         emb = torch.cat((freqs, freqs), dim=-1)
 
-        cos = np_cos(emb) * attention_scaling
-        sin = np_sin(emb) * attention_scaling
+        cos = emb.cos() * attention_scaling
+        sin = emb.sin() * attention_scaling
 
         self.register_buffer("_cos_cached", cos, persistent=False)
         self.register_buffer("_sin_cached", sin, persistent=False)


### PR DESCRIPTION
## Summary

Scoped revert of one site from #672 (released in v0.11.2a2), in response to the func-ci B#94 Type1 mismatch analysis (`Qwen3_MOE-30b-256k-B1-KV2k-TP1-CR13`, build 253): the Qwen3-MoE prefill Pearson regression is caused by the 2-line np_cos/np_sin switch in `decoderonly_architecture.py`, not by the compiler (verified: the v0.11.2a1→v0.11.2a2 diff is exactly #672, and for text-only decoderonly models these 2 lines are the only functional change).

## Why revert only this site

- The decoderonly `RotaryEmbedding` cos/sin are **baked into the compiled artifact as constants** — that path was already runtime-deterministic (frozen per artifact). The numpy switch there bought only cross-compile reproducibility.
- In exchange it introduced a **permanent ≤1-ulp rotary difference against the torch-based HF native reference** (~14% of fp32 elements differ by 1 ulp). Dense models absorb it, but **MoE expert routing amplifies near-tie flips into different expert selections**, dropping prefill Pearson below the 0.99 gate — consistent with the failing set being MoE-family only (Qwen3_MOE B1/B8, Qwen3_5) while dense/VL models pass.
- The paths that motivated #672 — cos/sin **computed on host at runtime and fed to compiled graphs as inputs** (qwen-vl visions, qwen3_5/gemma4 tables) — keep numpy; their non-determinism across thread configs was the actual bug (#653/#655).

## Verification

- ruff + import checks pass; the file is back to the pre-#672 form for this site only.
- Expectation: native reference and compiled constants are both torch again → the systematic rotary diff disappears and Qwen3_MOE/Qwen3_5 prefill Pearson returns to the pre-0.11.2a2 level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)